### PR TITLE
Add exception details functions

### DIFF
--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -1102,6 +1102,48 @@
   [x]
   (= 0 x))
 
+;;;;;;;;;;;;;;;;
+;; Exceptions ;;
+;;;;;;;;;;;;;;;;
+
+(def ^{:doc     "During a REPL session, bound to the most recent value evaluated."
+       :dynamic true}
+  *1
+  nil)
+(def ^{:doc     "During a REPL session, bound to the second most recent value evaluated."
+       :dynamic true}
+  *2
+  nil)
+(def ^{:doc     "During a REPL session, bound to the third most recent value evaluated."
+       :dynamic true}
+  *3
+  nil)
+(def ^{:doc     "During a REPL session, bound to the most recently thrown exception."
+       :dynamic true}
+  *e
+  nil)
+
+(defn ex-cause
+  "Return the cause (another Exception) of ex if it derives from Exception,
+  otherwise it returns nil."
+  [ex]
+  (when (instance? builtins/Exception ex)
+    (or (.- ex __cause__) (.- ex __context__))))
+
+(defn ex-data
+  "Return the data map of ex if is an instance of IExceptionInfo, otherwise
+  it returns nil."
+  [ex]
+  (when (instance? basilisp.lang.interfaces/IExceptionInfo ex)
+    (.-data ex)))
+
+(defn ex-message
+  "Return the message of ex if is an Exception, otherwise
+  it returns nil."
+  [ex]
+  (when (instance? builtins/Exception ex)
+    (builtins/getattr ex "message" (builtins/str ex))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Bit Manipulation Functions ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -26,7 +26,7 @@ class IBlockingDeref(IDeref[T]):
 
 
 # Making this interface Generic causes the __repr__ to differ between
-# Python 3.6 and 3.6, which affects a few simple test assertions.
+# Python 3.6 and 3.7, which affects a few simple test assertions.
 # Since there is little benefit to this type being Generic, I'm leaving
 # it as is for now.
 class IExceptionInfo(Exception):

--- a/src/basilisp/repl.lpy
+++ b/src/basilisp/repl.lpy
@@ -1,11 +1,6 @@
 (ns basilisp.repl
   (:import inspect))
 
-(def ^:dynamic *1 nil)
-(def ^:dynamic *2 nil)
-(def ^:dynamic *3 nil)
-(def ^:dynamic *e nil)
-
 (defn mark-repl-result
   "Mark the REPL result and move each result to the next slot
   down."

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -983,7 +983,7 @@ class TestExceptionData:
         try:
             raise Exception("Exception Message")
         except Exception as e:
-            assert None is core.ex_message(e)
+            assert "Exception Message" is core.ex_message(e)
 
 
 class TestBitManipulation:


### PR DESCRIPTION
Add `ex-cause`, `ex-data`, and `ex-message` for fetching data from exceptions. Move `*1`, `*2`, `*3`, `*e` from `basilisp.repl` to match their definitions in Clojure.