### PR TITLE
Change `builtins` name to `python` in Basilisp code

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,11 +18,11 @@
     "default": {
         "astor": {
             "hashes": [
-                "sha256:95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d",
-                "sha256:fb503b9e2fdd05609fbf557b916b4a7824171203701660f0c55bbf5a7a68713e"
+                "sha256:0e41295809baf43ae8303350e031aff81ae52189b6f881f36d623fa8b2f1960e",
+                "sha256:37a6eed8b371f1228db08234ed7f6cfdc7817a3ed3824797e20cbb11dc2a7862"
             ],
             "index": "pypi",
-            "version": "==0.7.1"
+            "version": "==0.8.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -67,16 +67,23 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633",
-                "sha256:d610c1bb404daf85976d7a82eb2ada120f04671007266b708606565dd03b5be6"
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
             ],
-            "version": "==3.0.10"
+            "version": "==3.0.12"
         },
         "future": {
             "hashes": [
                 "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
             ],
             "version": "==0.17.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f",
+                "sha256:df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"
+            ],
+            "version": "==0.17"
         },
         "more-itertools": {
             "hashes": [
@@ -86,12 +93,19 @@
             "markers": "python_version > '2.7'",
             "version": "==7.0.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -109,20 +123,27 @@
             "index": "pypi",
             "version": "==1.2.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
         "pyrsistent": {
             "hashes": [
-                "sha256:5403d37f4d55ff4572b5b5676890589f367a9569529c6f728c11046c4ea4272b"
+                "sha256:16692ee739d42cf5e39cef8d27649a8c1fdb7aa99887098f1460057c5eb75c3a"
             ],
             "index": "pypi",
-            "version": "==0.15.1"
+            "version": "==0.15.2"
         },
         "pytest": {
             "hashes": [
-                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
-                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
+                "sha256:6032845e68a17a96e8da3088037f899b56357769a724122056265ca2ea1890ee",
+                "sha256:bea27a646a3d74cbbcf8d3d4a06b2dfc336baf3dc2cc85cf70ad0157e73e8322"
             ],
             "index": "pypi",
-            "version": "==4.4.1"
+            "version": "==4.6.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -154,17 +175,31 @@
         },
         "tox": {
             "hashes": [
-                "sha256:1b166b93d2ce66bb7b253ba944d2be89e0c9d432d49eeb9da2988b4902a4684e",
-                "sha256:665cbdd99f5c196dd80d1d8db8c8cf5d48b1ae1f778bccd1bdf14d5aaf4ca0fc"
+                "sha256:f5c8e446b51edd2ea97df31d4ded8c8b72e7d6c619519da6bb6084b9dd5770f9",
+                "sha256:f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f"
             ],
-            "version": "==3.9.0"
+            "version": "==3.12.1"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
-                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
+                "sha256:99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0",
+                "sha256:fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"
             ],
-            "version": "==16.5.0"
+            "version": "==16.6.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     },
     "develop": {
@@ -199,10 +234,10 @@
         },
         "babel": {
             "hashes": [
-                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
-                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
             ],
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "black": {
             "hashes": [
@@ -251,10 +286,10 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:b8d5ca5ca1c815e1574aee746650ea7301de63d87935b3463d26368b76e31633",
-                "sha256:d610c1bb404daf85976d7a82eb2ada120f04671007266b708606565dd03b5be6"
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
             ],
-            "version": "==3.0.10"
+            "version": "==3.0.12"
         },
         "idna": {
             "hashes": [
@@ -269,6 +304,13 @@
                 "sha256:f3832918bc3c66617f92e35f5d70729187676313caa60c187eb0f28b8fe5e3b5"
             ],
             "version": "==1.1.0"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:a9f185022cfa69e9ca5f7eabfd5a58b689894cb78a11e3c8c89398a8ccbb8e7f",
+                "sha256:df1403cd3aebeb2b1dcd3515ca062eecb5bd3ea7611f18cba81130c68707e879"
+            ],
+            "version": "==0.17"
         },
         "jinja2": {
             "hashes": [
@@ -334,10 +376,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "py": {
             "hashes": [
@@ -348,10 +390,10 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
+                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
             ],
-            "version": "==2.3.1"
+            "version": "==2.4.2"
         },
         "pyparsing": {
             "hashes": [
@@ -362,11 +404,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:3773f4c235918987d51daf1db66d51c99fac654c81d6f2f709a046ab446d5e5d",
-                "sha256:b7802283b70ca24d7119b32915efa7c409982f59913c1a6c0640aacf118b95f5"
+                "sha256:6032845e68a17a96e8da3088037f899b56357769a724122056265ca2ea1890ee",
+                "sha256:bea27a646a3d74cbbcf8d3d4a06b2dfc336baf3dc2cc85cf70ad0157e73e8322"
             ],
             "index": "pypi",
-            "version": "==4.4.1"
+            "version": "==4.6.2"
         },
         "pytest-pycharm": {
             "hashes": [
@@ -393,10 +435,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -421,11 +463,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:423280646fb37944dd3c85c58fb92a20d745793a9f6c511f59da82fa97cd404b",
-                "sha256:de930f42600a4fef993587633984cc5027dedba2464bcf00ddace26b40f8d9ce"
+                "sha256:2c5becc0fd6706dc0aeb4703f9f1f8a1d1eecacf02e9ac5943cbae48b11e5e42",
+                "sha256:7a359a91fb04054ec77d68ff97cb8728f8cc322e25f22dc94299d67e0e6a7123"
             ],
             "index": "pypi",
-            "version": "==2.0.1"
+            "version": "==2.1.0"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -486,10 +528,10 @@
         },
         "tox": {
             "hashes": [
-                "sha256:1b166b93d2ce66bb7b253ba944d2be89e0c9d432d49eeb9da2988b4902a4684e",
-                "sha256:665cbdd99f5c196dd80d1d8db8c8cf5d48b1ae1f778bccd1bdf14d5aaf4ca0fc"
+                "sha256:f5c8e446b51edd2ea97df31d4ded8c8b72e7d6c619519da6bb6084b9dd5770f9",
+                "sha256:f87fd33892a2df0950e5e034def9468988b8d008c7e9416be665fcc0dd45b14f"
             ],
-            "version": "==3.9.0"
+            "version": "==3.12.1"
         },
         "tox-pyenv": {
             "hashes": [
@@ -501,10 +543,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:d385c95361699e5cf7622485d9b9eae2d4864b21cd5a2374a9c381ffed701021",
-                "sha256:e22977e3ebe961f72362f6ddfb9197cc531c9737aaf5f607ef09740c849ecd05"
+                "sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab",
+                "sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b"
             ],
-            "version": "==4.31.1"
+            "version": "==4.32.1"
         },
         "twine": {
             "hashes": [
@@ -516,22 +558,36 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4",
-                "sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "version": "==1.24.3"
+            "version": "==1.25.3"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
-                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
+                "sha256:99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0",
+                "sha256:fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"
             ],
-            "version": "==16.5.0"
+            "version": "==16.6.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         },
         "webencodings": {
             "hashes": [
                 "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
                 "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
             ],
             "version": "==0.5.1"
         }

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -50,7 +50,7 @@
        :arglists '([o])}
   meta
   (fn* meta [o]
-       (if (builtins/hasattr o "meta")
+       (if (python/hasattr o "meta")
          (.-meta o)
          nil)))
 
@@ -86,35 +86,35 @@
     :arglists '([class obj])}
   instance?
   (fn instance? [class obj]
-    (builtins/isinstance obj class)))
+    (python/isinstance obj class)))
 
 (def
   ^{:doc      "Return true if obj is a boolean."
     :arglists '([o])}
   boolean?
   (fn boolean? [o]
-    (instance? builtins/bool o)))
+    (instance? python/bool o)))
 
 (def
   ^{:doc      "Return true if obj is a float."
     :arglists '([o])}
   float?
   (fn float? [o]
-    (instance? builtins/float o)))
+    (instance? python/float o)))
 
 (def
   ^{:doc      "Return true if obj is an integer."
     :arglists '([o])}
   integer?
   (fn integer? [o]
-    (instance? builtins/int o)))
+    (instance? python/int o)))
 
 (def
   ^{:doc      "Return true if obj is a string."
     :arglists '([o])}
   string?
   (fn string? [o]
-    (instance? builtins/str o)))
+    (instance? python/str o)))
 
 (def
   ^{:doc      "Return true if obj is a symbol."
@@ -232,7 +232,7 @@
   count
   (fn count [coll]
     (try
-      (builtins/len coll)
+      (python/len coll)
       (catch TypeError _
         (count (apply vector coll))))))
 
@@ -270,7 +270,7 @@
     (if (symbol? name)
       nil  ;; Do nothing!
       (throw (ex-info "First argument to defn must be a symbol"
-                      {:found name :type (builtins/type name)})))
+                      {:found name :type (python/type name)})))
     (let [body   (concat body)
           doc    (if (string? (first body))
                    (first body)
@@ -615,7 +615,7 @@
 (defn hash
   "Return the hash code for its argument."
   [x]
-  (builtins/hash x))
+  (python/hash x))
 
 (defn identical?
   "Return true if x and y are the same object, otherwise false."
@@ -840,12 +840,12 @@
 (defn min
   "Return the minimum of the arguments."
   [& args]
-  (builtins/min args))
+  (python/min args))
 
 (defn max
   "Return the maximum of the arguments."
   [& args]
-  (builtins/max args))
+  (python/max args))
 
 (defn numerator
   "Return the numerator of a Fraction."
@@ -888,7 +888,7 @@
   true iff x is a Python bytearray. To check if an object is a Python `bytes`,
   use `byte-string?`."
   [x]
-  (instance? builtins/bytearray x))
+  (instance? python/bytearray x))
 
 (defn byte-string?
   "Return true if x is a byte string (the Python `bytes` type).
@@ -896,12 +896,12 @@
   Note that Python supplies byte string and byte array objects in its standard
   library. To check if an object is a Python `bytearray`, use `bytes?`."
   [x]
-  (instance? builtins/bytes x))
+  (instance? python/bytes x))
 
 (defn class?
   "Return true if x names a type."
   [x]
-  (instance? builtins/type x))
+  (instance? python/type x))
 
 (defn coll?
   "Return true if x implements IAssociative."
@@ -911,7 +911,7 @@
 (defn complex?
   "Return true if x is a complex number."
   [x]
-  (instance? builtins/complex x))
+  (instance? python/complex x))
 
 (defn decimal?
   "Return true if x is a Decimal."
@@ -933,9 +933,9 @@
 (defn fn?
   "Return true if x is a function created by `fn` or `fn*`."
   [x]
-  (and (builtins/callable x)
-       (builtins/hasattr x "_basilisp_fn")
-       (builtins/getattr x "_basilisp_fn")))
+  (and (python/callable x)
+       (python/hasattr x "_basilisp_fn")
+       (python/getattr x "_basilisp_fn")))
 
 (defn ident?
   "Return true if x is either a keyword or symbol."
@@ -948,7 +948,7 @@
   Many Basilisp data structures are callable as functions though
   they are not proper function types."
   [x]
-  (builtins/callable x))
+  (python/callable x))
 
 (def ^{:doc "Return true if x is an integer.
 
@@ -1016,27 +1016,27 @@
 (defn py-dict?
   "Return true if x is a Python `dict`."
   [x]
-  (instance? builtins/dict x))
+  (instance? python/dict x))
 
 (defn py-frozenset?
   "Return true if x is a Python `frozenset`."
   [x]
-  (instance? builtins/frozenset x))
+  (instance? python/frozenset x))
 
 (defn py-list?
   "Return true if x is a Python `list`."
   [x]
-  (instance? builtins/list x))
+  (instance? python/list x))
 
 (defn py-set?
   "Return true if x is a Python `set`."
   [x]
-  (instance? builtins/set x))
+  (instance? python/set x))
 
 (defn py-tuple?
   "Return true if x is a Python `tuple`."
   [x]
-  (instance? builtins/tuple x))
+  (instance? python/tuple x))
 
 (defn qualified-ident?
   "Return true if x is either a keyword or symbol with a namespace."
@@ -1113,9 +1113,9 @@
       (or (py-tuple? x)
           (vector? x))  (do (apply-kw uuid/UUID {:fields x}) true)
       :else             false)
-    (catch builtins/AttributeError _ false)
-    (catch builtins/TypeError _ false)
-    (catch builtins/ValueError _ false)))
+    (catch python/AttributeError _ false)
+    (catch python/TypeError _ false)
+    (catch python/ValueError _ false)))
 
 (defn var?
   "Return true if x is a Var."
@@ -1152,7 +1152,7 @@
   "Return the cause (another Exception) of ex if it derives from Exception,
   otherwise it returns nil."
   [ex]
-  (when (instance? builtins/Exception ex)
+  (when (instance? python/Exception ex)
     (or (.- ex __cause__) (.- ex __context__))))
 
 (defn ex-data
@@ -1166,8 +1166,8 @@
   "Return the message of ex if is an Exception, otherwise
   it returns nil."
   [ex]
-  (when (instance? builtins/Exception ex)
-    (builtins/getattr ex "message" (builtins/str ex))))
+  (when (instance? python/Exception ex)
+    (python/getattr ex "message" (python/str ex))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Bit Manipulation Functions ;;
@@ -1702,9 +1702,9 @@
   "Create a new instance of class with args.
 
   New objects may be created as any of:
-    (new builtins/str *args)
-    (new builtins.str *args)
-    (new builtins.str. *args)
+    (new python/str *args)
+    (new python.str *args)
+    (new python.str. *args)
 
   This is compatibility syntax for Clojure, since Python (and therefore
   Basilisp) do not require the new keyword for object instantiation."
@@ -2095,7 +2095,7 @@
     (throw
      (ex-info "Expected a Symbol or a Namespace"
               {:value v
-               :type  (builtins/type v)}))))
+               :type  (python/type v)}))))
 
 (defn create-ns
   "Create a Namespace with the name ns-sym or return the existing one
@@ -2555,7 +2555,7 @@
   [arg]
   (throw
    (ex-info "Invalid destructuring argument type"
-            {:type (builtins/type arg)})))
+            {:type (python/type arg)})))
 
 (defmulti ^:private destructure-binding
   (fn [ddef]
@@ -2808,7 +2808,7 @@
 (defmulti ^:private munge
   "Munge the input value into a Python-safe string. Converts keywords and
   symbols into strings as by `name` prior to munging. Returns a string."
-  builtins/type)
+  python/type)
 
 (defmethod munge basilisp.lang.keyword/Keyword
   [kw]
@@ -2818,7 +2818,7 @@
   [s]
   (basilisp.lang.util/munge (name s)))
 
-(defmethod munge builtins/str
+(defmethod munge python/str
   [s]
   (basilisp.lang.util/munge s))
 
@@ -2838,7 +2838,7 @@
                             (assoc m (munge method-name) method)))
                         {}
                         methods)]
-    (builtins/type interface-name
+    (python/type interface-name
                    #py (abc/ABC)
                    (lisp->py methods))))
 
@@ -2937,7 +2937,7 @@
        (deftype* ~type-name ~fields
          :implements [~@interfaces
                       ~'basilisp.lang.interfaces/IType
-                      ~'builtins/object]
+                      ~'python/object]
          ~@methods)
        (def ~ctor-name ~type-name)
        ~type-name)))
@@ -3043,7 +3043,7 @@
                            '[basilisp.lang.interfaces/IPersistentMap
                              basilisp.lang.interfaces/IMeta
                              basilisp.lang.interfaces/IRecord
-                             builtins/object])
+                             python/object])
 
         ;; We can use these gensyms repeatedly and interpolate them in
         ;; multiple layers of syntax quoting, unlike gensyms using # syntax.
@@ -3106,10 +3106,10 @@
               (throw
                (ex-info "Argument to record conj must be another Map or castable to MapEntry"
                         {:value f#
-                         :type  (builtins/type f#)})))))
+                         :type  (python/type f#)})))))
          (~'empty [~this-gs]
           (throw
-           (builtins/TypeError
+           (python/TypeError
             ~(str "Cannot create empty " type-name))))
          (~'seq [~this-gs]
           (concat
@@ -3146,7 +3146,7 @@
           (let [[default#] args#]
             (cond
               (contains? ~field-kw-set ~key-gs)
-              (builtins/getattr ~this-gs (munge ~key-gs))
+              (python/getattr ~this-gs (munge ~key-gs))
 
               (contains? ~'_recmap ~key-gs)
               (get ~'_recmap ~key-gs default#))))
@@ -3185,7 +3185,7 @@
          ;; object
          (~'__eq__ [~this-gs ~other-gs]
           (or (identical? ~this-gs ~other-gs)
-              (and (instance? (builtins/type ~this-gs) ~other-gs)
+              (and (instance? (python/type ~this-gs) ~other-gs)
                    (= [~@fields
                        ~'_recmap]
                       [~@(map (fn [field]

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -138,7 +138,7 @@ FINALLY = kw.keyword("finally")
 # Constants used in analyzing
 AS = kw.keyword("as")
 IMPLEMENTS = kw.keyword("implements")
-_BUILTINS_NS = "builtins"
+_BUILTINS_NS = "python"
 
 # Symbols to be ignored for unused symbol warnings
 _IGNORED_SYM = sym.symbol("_")

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -444,7 +444,6 @@ _VAR_ALIAS = genname("Var")
 _UTIL_ALIAS = genname("langutil")
 
 _MODULE_ALIASES = {
-    "builtins": None,
     "basilisp.lang.atom": _ATOM_ALIAS,
     "basilisp.lang.compiler": _COMPILER_ALIAS,
     "basilisp.core": _CORE_ALIAS,

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -105,7 +105,6 @@ USE_VAR_INDIRECTION = "use_var_indirection"
 WARN_ON_VAR_INDIRECTION = "warn_on_var_indirection"
 
 # String constants used in generating code
-_BUILTINS_NS = "builtins"
 _DEFAULT_FN = "__lisp_expr__"
 _DO_PREFIX = "lisp_do"
 _FN_PREFIX = "lisp_fn"

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -819,8 +819,8 @@ def apply_kw(f, args):
     The last argument must always be coercible to a Mapping. Intermediate
     arguments are not modified.
     For example:
-        (apply builtins/dict {:a 1} {:b 2})   ;=> #py {:a 1 :b 2}
-        (apply builtins/dict {:a 1} {:a 2})   ;=> #py {:a 2}"""
+        (apply python/dict {:a 1} {:b 2})   ;=> #py {:a 1 :b 2}
+        (apply python/dict {:a 1} {:a 2})   ;=> #py {:a 2}"""
     final = list(args[:-1])
 
     try:

--- a/src/basilisp/repl.lpy
+++ b/src/basilisp/repl.lpy
@@ -35,7 +35,7 @@
 (defn print-source
   "Print the source forms for a function."
   [_]
-  (throw (builtins/NotImplementedError)))
+  (throw (python/NotImplementedError)))
 
 (defmacro source
   "Print the source code for a form if found."

--- a/src/basilisp/string.lpy
+++ b/src/basilisp/string.lpy
@@ -31,7 +31,7 @@
   "Returns true if s is nil, empty, or contains only whitespace."
   [s]
   (when s
-    (not (builtins/bool (.strip s)))))
+    (not (python/bool (.strip s)))))
 
 (defn capitalize
   "Return a copy of the string with the first character capitalized
@@ -88,7 +88,7 @@
   "Return the last index of value in s, optionally searching backwards
   from from-index. Returns nil if value is not found in s."
   ([s value]
-   (last-index-of s value (builtins/len s)))
+   (last-index-of s value (python/len s)))
   ([s value from-index]
    (let [idx (.rfind s value 0 from-index)]
      (if (= idx -1)
@@ -110,7 +110,7 @@
 (defn reverse
   "Returns a string which is the reverse of s."
   [s]
-  (operator/getitem s (builtins/slice nil nil -1)))
+  (operator/getitem s (python/slice nil nil -1)))
 
 (defn split
   "Split a string on a regular expression or another string. Caller may
@@ -135,7 +135,7 @@
      (throw
       (ex-info "String split pattern must be a re.Pattern or str"
                {:pattern pattern
-                :type    (builtins/type pattern)})))))
+                :type    (python/type pattern)})))))
 
 (defn split-lines
   "Split s on universal newlines as by Python's str.splitlines."
@@ -182,9 +182,9 @@
   [s match replacement]
   (cond
     (and (instance? typing/Pattern match)
-         (or (string? replacement) (builtins/callable replacement)))
+         (or (string? replacement) (python/callable replacement)))
     (re/sub match
-            (if (builtins/callable replacement)
+            (if (python/callable replacement)
               #(replacement (.group % 0))
               replacement)
             s)
@@ -196,9 +196,9 @@
     (throw
      (ex-info "String replace match/replacement must be: (str and str) or (re.Pattern and (str or function))"
               {:match            match
-               :match-type       (builtins/type match)
+               :match-type       (python/type match)
                :replacement      replacement
-               :replacement-type (builtins/type replacement)}))))
+               :replacement-type (python/type replacement)}))))
 
 (defn replace-first
   "Replace the first instance of match in s with replacement.
@@ -214,9 +214,9 @@
   [s match replacement]
   (cond
     (and (instance? typing/Pattern match)
-         (or (string? replacement) (builtins/callable replacement)))
+         (or (string? replacement) (python/callable replacement)))
     (re/sub match
-            (if (builtins/callable replacement)
+            (if (python/callable replacement)
               #(replacement (.group % 0))
               replacement)
             s
@@ -229,9 +229,9 @@
     (throw
      (ex-info "String replace match/replacement must be: (str and str) or (re.Pattern and (str or function))"
               {:match            match
-               :match-type       (builtins/type match)
+               :match-type       (python/type match)
                :replacement      replacement
-               :replacement-type (builtins/type replacement)}))))
+               :replacement-type (python/type replacement)}))))
 
 (defn trim
   "Trim whitespace off the ends of s."

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -64,12 +64,12 @@
                  :line         (line-no 1)
                  :type         :failure}))
        (catch ~exc-type _ nil)
-       (catch builtins/Exception e#
+       (catch python/Exception e#
          (swap! *test-failures*
                 conj
                 {:test-name    *test-name*
                  :test-section *test-section*
-                 :message      (str "Expected " ~exc-type "; got " (builtins/type e#) " instead")
+                 :message      (str "Expected " ~exc-type "; got " (python/type e#) " instead")
                  :expr         (quote ~expr)
                  :actual       e#
                  :expected     ~exc-type
@@ -98,12 +98,12 @@
   ([expr msg]
    `(try
       ~(gen-assert expr msg)
-      (catch builtins/Exception e#
+      (catch python/Exception e#
         (swap! *test-failures*
                conj
                {:test-name    *test-name*
                 :test-section *test-section*
-                :message      (str "Unexpected exception thrown during test run: " (builtins/repr e#))
+                :message      (str "Unexpected exception thrown during test run: " (python/repr e#))
                 :expr         (quote ~expr)
                 :actual       e#
                 :expected     (quote ~expr)

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -46,7 +46,7 @@ class TestREPL:
     def test_other_exception(self):
         runner = CliRunner()
         result = runner.invoke(
-            cli, ["repl"], input='(throw (builtins/Exception "CLI test"))'
+            cli, ["repl"], input='(throw (python/Exception "CLI test"))'
         )
         assert "Exception: CLI test\nuser=> " in result.stdout
 

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1956,9 +1956,18 @@ class TestPythonInterop:
             lcompile("(. :kw 1)")
 
     def test_interop_new(self, ns: runtime.Namespace):
+        assert "hi" == lcompile('(python.str. "hi")')
+        assert "1" == lcompile("(python.str. 1)")
+        assert sym.symbol("hi") == lcompile('(basilisp.lang.symbol.Symbol. "hi")')
+
+        with pytest.raises(compiler.CompilerException):
+            lcompile('(python.str "hi")')
+
+    def test_interop_new_with_import(self, ns: runtime.Namespace):
+        import builtins
+        ns.add_import(sym.symbol("builtins"), builtins)
         assert "hi" == lcompile('(builtins.str. "hi")')
         assert "1" == lcompile("(builtins.str. 1)")
-        assert sym.symbol("hi") == lcompile('(basilisp.lang.symbol.Symbol. "hi")')
 
         with pytest.raises(compiler.CompilerException):
             lcompile('(builtins.str "hi")')

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -577,9 +577,9 @@ class TestDefType:
         Point = lcompile(
             """
         (deftype* Point [x y z]
-          :implements [builtins/object]
+          :implements [python/object]
           (__str__ [this]
-            (builtins/repr #py ("Point" x y z))))
+            (python/repr #py ("Point" x y z))))
         """
         )
         pt = Point(1, 2, 3)
@@ -712,10 +712,10 @@ class TestDefType:
                 """
             (import* abc)
             (def WithCls
-              (builtins/type "WithCls"
+              (python/type "WithCls"
                              #py (abc/ABC)
                              #py {"create"
-                                  (builtins/classmethod
+                                  (python/classmethod
                                    (abc/abstractmethod
                                     (fn [cls])))}))
             """
@@ -812,7 +812,7 @@ class TestDefType:
               (^:classmethod create [cls x y z]
                 (cls x y z))
               (__str__ [this]
-                (builtins/str [x y z])))"""
+                (python/str [x y z])))"""
             )
             pt = Point.create(1, 2, 3)
             assert "[1 2 3]" == str(pt)
@@ -974,10 +974,10 @@ class TestDefType:
                 """
             (import* abc)
             (def WithProp
-              (builtins/type "WithProp"
+              (python/type "WithProp"
                              #py (abc/ABC)
                              #py {"prop"
-                                  (builtins/property
+                                  (python/property
                                    (abc/abstractmethod
                                     (fn [self])))}))
             """
@@ -1064,10 +1064,10 @@ class TestDefType:
                 """
             (import* abc)
             (def WithStatic
-              (builtins/type "WithStatic"
+              (python/type "WithStatic"
                              #py (abc/ABC)
                              #py {"dostatic"
-                                  (builtins/staticmethod
+                                  (python/staticmethod
                                    (abc/abstractmethod
                                     (fn [])))}))
             """
@@ -1160,7 +1160,7 @@ class TestDefType:
               (^:staticmethod dostatic [x y z]
                 [x y z])
               (__str__ [this]
-                (builtins/str [x y z])))"""
+                (python/str [x y z])))"""
             )
             assert vec.v(1, 2, 3) == Point.dostatic(1, 2, 3)
             assert "[1 2 3]" == str(Point(1, 2, 3))
@@ -2373,8 +2373,8 @@ class TestRecur:
           (fn rev-str [s & args]
             (let [coerce (fn [in out]
                            (if (seq (rest in))
-                             (recur (rest in) (cons (builtins/str (first in)) out))
-                             (cons (builtins/str (first in)) out)))]
+                             (recur (rest in) (cons (python/str (first in)) out))
+                             (cons (python/str (first in)) out)))]
              (.join \"\" (coerce (cons s args) '())))))
          """
 
@@ -2636,13 +2636,13 @@ def test_syntax_quoting(test_ns: str, ns: runtime.Namespace, resolver: reader.Re
 
 def test_throw(ns: runtime.Namespace):
     with pytest.raises(AttributeError):
-        lcompile("(throw (builtins/AttributeError))")
+        lcompile("(throw (python/AttributeError))")
 
     with pytest.raises(TypeError):
-        lcompile("(throw (builtins/TypeError))")
+        lcompile("(throw (python/TypeError))")
 
     with pytest.raises(ValueError):
-        lcompile("(throw (builtins/ValueError))")
+        lcompile("(throw (python/ValueError))")
 
 
 class TestTryCatch:
@@ -2658,7 +2658,7 @@ class TestTryCatch:
         code = """
           (try
             (.fake-lower "UPPER")
-            (catch builtins/AttributeError e (.-args e)))
+            (catch python/AttributeError e (.-args e)))
         """
         assert ("'str' object has no attribute 'fake_lower'",) == lcompile(code)
 
@@ -2680,7 +2680,7 @@ class TestTryCatch:
             (.fake-lower "UPPER")
             (catch TypeError _ "lower")
             (catch AttributeError _ "mIxEd")
-            (finally (builtins/print "neither")))
+            (finally (python/print "neither")))
         """
         assert "mIxEd" == lcompile(code)
         captured = capsys.readouterr()
@@ -2751,7 +2751,7 @@ class TestTryCatch:
                 """
               (try
                 (.lower "UPPER")
-                (finally (builtins/print "mIxEd"))
+                (finally (python/print "mIxEd"))
                 "neither")
             """
             )
@@ -2762,7 +2762,7 @@ class TestTryCatch:
                 """
               (try
                 (.fake-lower "UPPER")
-                (finally (builtins/print "this is bad!"))
+                (finally (python/print "this is bad!"))
                 (catch AttributeError _ "mIxEd"))
             """
             )
@@ -2774,8 +2774,8 @@ class TestTryCatch:
               (try
                 (.fake-lower "UPPER")
                 (catch AttributeError _ "mIxEd")
-                (finally (builtins/print "this is bad!"))
-                (finally (builtins/print "but this is worse")))
+                (finally (python/print "this is bad!"))
+                (finally (python/print "but this is worse")))
             """
             )
 
@@ -2808,11 +2808,11 @@ class TestSymbolResolution:
         assert object is lcompile("object")
 
     def test_builtin_resolves_builtins(self, ns: runtime.Namespace):
-        assert object is lcompile("builtins/object")
+        assert object is lcompile("python/object")
 
     def test_builtins_fails_to_resolve_correctly(self, ns: runtime.Namespace):
         with pytest.raises(compiler.CompilerException):
-            lcompile("builtins/fake")
+            lcompile("python/fake")
 
     def test_namespaced_sym_may_not_contain_period(self, ns: runtime.Namespace):
         with pytest.raises(compiler.CompilerException):

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1965,6 +1965,7 @@ class TestPythonInterop:
 
     def test_interop_new_with_import(self, ns: runtime.Namespace):
         import builtins
+
         ns.add_import(sym.symbol("builtins"), builtins)
         assert "hi" == lcompile('(builtins.str. "hi")')
         assert "1" == lcompile("(builtins.str. 1)")

--- a/tests/basilisp/defrecord_test.lpy
+++ b/tests/basilisp/defrecord_test.lpy
@@ -110,7 +110,7 @@
       (is (= 2 (count p3))))
 
     (testing "empty record not supported"
-      (is (thrown? builtins/TypeError
+      (is (thrown? python/TypeError
                    (empty (->Point 1 2 3)))))
 
     (testing "seq"
@@ -232,23 +232,23 @@
                  (eval '(defrecord NewType [a ^{:default "b"} b]))))))
 
 (def ^:private WithCls
-  (builtins/type "WithCls"
+  (python/type "WithCls"
                  #py (abc/ABC)
-                 #py {"create" (builtins/classmethod
+                 #py {"create" (python/classmethod
                                 (abc/abstractmethod
                                  (fn [cls])))}))
 
 (def ^:private WithProp
-  (builtins/type "WithProp"
+  (python/type "WithProp"
                  #py (abc/ABC)
-                 #py { "prop" (builtins/property
+                 #py { "prop" (python/property
                                (abc/abstractmethod
                                 (fn [self])))}))
 
 (def ^:private WithStatic
-  (builtins/type "WithStatic"
+  (python/type "WithStatic"
                  #py (abc/ABC)
-                 #py {"dostatic" (builtins/staticmethod
+                 #py {"dostatic" (python/staticmethod
                                   (abc/abstractmethod
                                    (fn [])))}))
 

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -14,7 +14,7 @@ def test_testrunner(testdir: pytester.Testdir, capsys):
       (is false)
       (is (= "true" false))
       (is (thrown? basilisp.lang.exception/ExceptionInfo (throw (ex-info "Exception" {}))))
-      (is (thrown? basilisp.lang.exception/ExceptionInfo (throw (builtins/Exception))))
+      (is (thrown? basilisp.lang.exception/ExceptionInfo (throw (python/Exception))))
       (is (= 4.6 4.6))
       (is (throw (ex-info "Uncaught exception" {}))))
     """


### PR DESCRIPTION
In Basilisp code, we use the namespace `builtins` (which is actually the Python module `builtins`) to refer unambiguously to builtin Python functions and classes. However, this is not very clear to end users what is being called. This PR changes that value to be `python` so it is clearer that callers are using the native Python builtins.

Fixes #398 