### PR TITLE
Start running CircleCI builds with Python 3.8 dev builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             TOX_NUM_CORES: 2
             TOX_SHOW_OUTPUT: "True"
           command: |
-            tox -p $TOX_NUM_CORES -e py36,py37,coverage,mypy,format,lint,safety
+            tox -p $TOX_NUM_CORES -e py36,py37,py38,coverage,mypy,format,lint,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test-cpython:
     docker:
-      - image: chrisrink10/pyenv:3.6-3.7-3.8dev-0.0.4
+      - image: chrisrink10/pyenv:3.6-3.7-3.8dev-0.0.5
         user: pyenv
     steps:
       - checkout
@@ -32,7 +32,7 @@ jobs:
 
   test-pypy:
     docker:
-      - image: pypy:3.6-7.0-slim-jessie
+      - image: pypy:3.6-7.1-slim-stretch
     steps:
       - checkout
       - restore_cache:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,mypy,format,lint
+envlist = py36,py37,py38,mypy,format,lint
 
 [testenv]
 parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
@@ -15,6 +15,9 @@ commands =
              -m pytest \
              --junitxml={toxinidir}/junit/pytest/{envname}.xml \
              {posargs}
+
+[testenv:py38]
+ignore_outcome = true
 
 [testenv:coverage]
 parallel_show_output = {env:TOX_SHOW_OUTPUT:false}


### PR DESCRIPTION
Start running CircleCI builds with Python 3.8 and allow it to fail until I have time to address changes.