### PR TITLE
A few tiny changes to slightly improve performance

### DIFF
--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -655,7 +655,7 @@ def _def_ast(  # pylint: disable=too-many-branches,too-many-locals
     def_loc = _loc(form) or (None, None)
     def_node_env = ctx.get_node_env()
     def_meta = _clean_meta(
-        name.meta.update(  # type: ignore [union-attr]
+        name.meta.update(
             lmap.map(
                 {
                     COL_KW: def_loc[1],

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -593,10 +593,12 @@ def __should_warn_on_redef(
     no_warn_on_redef = def_meta.val_at(SYM_NO_WARN_ON_REDEF_META_KEY, False)
     if no_warn_on_redef:
         return False
-    elif safe_name in ctx.current_ns.module.__dict__:
+
+    current_ns = ctx.current_ns
+    if safe_name in current_ns.module.__dict__:
         return True
-    elif defsym in ctx.current_ns.interns:
-        var = ctx.current_ns.find(defsym)
+    elif defsym in current_ns.interns:
+        var = current_ns.find(defsym)
         assert var is not None, f"Var {defsym} cannot be none here"
 
         if var.meta is not None and var.meta.val_at(SYM_REDEF_META_KEY):

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -197,7 +197,7 @@ class Node(ABC, Generic[T]):
             loc = (self.env.line, self.env.col)
 
         assert loc is not None and all(
-            [e is not None for e in loc]
+            e is not None for e in loc
         ), "Must specify location information"
 
         new_attrs: MutableMapping[str, Union[NodeEnv, Node, Iterable[Node]]] = {
@@ -210,10 +210,9 @@ class Node(ABC, Generic[T]):
             if child_attr.endswith("s"):
                 iter_child: Iterable[Node] = getattr(self, child_attr)
                 assert iter_child is not None, "Listed child must not be none"
-                new_children = []
-                for item in iter_child:
-                    new_children.append(item.fix_missing_locations(start_loc))
-                new_attrs[child_attr] = vec.vector(new_children)
+                new_attrs[child_attr] = vec.vector(
+                    item.fix_missing_locations(start_loc) for item in iter_child
+                )
             else:
                 child: Node = getattr(self, child_attr)
                 assert child is not None, "Listed child must not be none"

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -25,20 +25,17 @@ _MUNGE_REPLACEMENTS = {
     "&": "__AMP__",
     "$": "__DOLLAR__",
 }
+_MUNGE_TRANSLATE_TABLE = str.maketrans(_MUNGE_REPLACEMENTS)
 
 
 def count(seq: Iterable) -> int:
-    return sum([1 for _ in seq])
+    return sum(1 for _ in seq)
 
 
 def munge(s: str, allow_builtins: bool = False) -> str:
     """Replace characters which are not valid in Python symbols
     with valid replacement strings."""
-    new_str = []
-    for c in s:
-        new_str.append(_MUNGE_REPLACEMENTS.get(c, c))
-
-    new_s = "".join(new_str)
+    new_s = s.translate(_MUNGE_TRANSLATE_TABLE)
 
     if keyword.iskeyword(new_s):
         return f"{new_s}_"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py36,py37,py38,pypy3,coverage,mypy,format,lint,safety
 
 [testenv]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
+parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
 setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true
 deps =
@@ -17,7 +17,6 @@ commands =
              {posargs}
 
 [testenv:coverage]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 depends = py36, py37, py38
 deps =
     coveralls
@@ -54,25 +53,21 @@ exclude_lines =
     if __name__ == .__main__.:
 
 [testenv:format]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 deps = black
 commands =
     black --check .
 
 [testenv:mypy]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 deps = mypy
 commands =
     mypy --config-file={toxinidir}/mypy.ini src/basilisp
 
 [testenv:lint]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 deps = prospector==1.1.6.2
 commands =
     prospector --profile-path={toxinidir}
 
 [testenv:safety]
-parallel_show_output = {env:TOX_SHOW_OUTPUT:false}
 deps = safety
 commands =
     safety check


### PR DESCRIPTION
 * Cache `ctx.current_ns` in the Analyzer and Generator whenever possible
 * Do not collect comprehensions into intermediate lists when they will just be put into some other iterable later
 * Use `str.translate` for munging, rather than manual translation

Nothing here moves the needle dramatically, but every little bit that shaves a few milliseconds off of the startup time helps.