### PR TITLE
Dump generated `basilisp.core` Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,6 @@ ENV/
 # Misc
 TODO
 lintout.txt
+lispcore.py
 .idea/
 .envrc

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -11,6 +11,7 @@ ignore-paths:
   - .tox
   - build
   - dist
+  - lispcore.py
   - tests
 
 pep8:

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ format:
 	@pipenv run black .
 
 
+.PHONY: dump-core-lpy
+dump-core-lpy:
+	@BASILISP_DO_NOT_CACHE_NAMESPACES=true pipenv run basilisp run -c '(with [f (python/open "lispcore.py" "w")] (.write f basilisp.core/*generated-python*))'
+	@pipenv run black lispcore.py
+
+
 .PHONY: repl
 repl:
 	@BASILISP_USE_DEV_LOGGER=true pipenv run basilisp repl

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,16 @@ format:
 	@pipenv run black .
 
 
-.PHONY: dump-core-lpy
-dump-core-lpy:
-	@BASILISP_DO_NOT_CACHE_NAMESPACES=true pipenv run basilisp run -c '(with [f (python/open "lispcore.py" "w")] (.write f basilisp.core/*generated-python*))'
+lispcore.py:
+	@BASILISP_DO_NOT_CACHE_NAMESPACES=true \
+		pipenv run basilisp run -c \
+		'(with [f (python/open "lispcore.py" "w")] (.write f basilisp.core/*generated-python*))'
 	@pipenv run black lispcore.py
+
+
+.PHONY: clean
+clean:
+	@rm -rf ./lispcore.py
 
 
 .PHONY: repl

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -61,7 +61,7 @@ def _get_basilisp_bytecode(
             f"expected {MAGIC_NUMBER!r}"
         )
         logger.debug(message)
-        raise ImportError(message, **exc_details)  # type: ignore
+        raise ImportError(message, **exc_details)
     elif len(raw_timestamp) != 4:
         message = f"Reached EOF while reading timestamp in {fullname}"
         logger.debug(message)
@@ -69,7 +69,7 @@ def _get_basilisp_bytecode(
     elif _r_long(raw_timestamp) != mtime:
         message = f"Non-matching timestamp ({_r_long(raw_timestamp)}) in {fullname} bytecode cache; expected {mtime}"
         logger.debug(message)
-        raise ImportError(message, **exc_details)  # type: ignore
+        raise ImportError(message, **exc_details)
     elif len(raw_size) != 4:
         message = f"Reached EOF while reading size of source in {fullname}"
         logger.debug(message)
@@ -77,7 +77,7 @@ def _get_basilisp_bytecode(
     elif _r_long(raw_size) != source_size:
         message = f"Non-matching filesize ({_r_long(raw_size)}) in {fullname} bytecode cache; expected {source_size}"
         logger.debug(message)
-        raise ImportError(message, **exc_details)  # type: ignore
+        raise ImportError(message, **exc_details)
 
     return marshal.loads(cache_data[12:])
 

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -11,6 +11,9 @@ import dateutil.parser as dateparser
 
 import basilisp.lang.atom as atom
 
+_DOUBLE_DOT = ".."
+_DOUBLE_DOT_REPLACEMENT = "__DOT_DOT__"
+
 _MUNGE_REPLACEMENTS = {
     "+": "__PLUS__",
     "-": "_",
@@ -24,6 +27,7 @@ _MUNGE_REPLACEMENTS = {
     "\\": "__IDIV__",
     "&": "__AMP__",
     "$": "__DOLLAR__",
+    "%": "__PCT__",
 }
 _MUNGE_TRANSLATE_TABLE = str.maketrans(_MUNGE_REPLACEMENTS)
 
@@ -36,6 +40,9 @@ def munge(s: str, allow_builtins: bool = False) -> str:
     """Replace characters which are not valid in Python symbols
     with valid replacement strings."""
     new_s = s.translate(_MUNGE_TRANSLATE_TABLE)
+
+    if new_s == _DOUBLE_DOT:
+        return _DOUBLE_DOT_REPLACEMENT
 
     if keyword.iskeyword(new_s):
         return f"{new_s}_"


### PR DESCRIPTION
Easy `make` target to dump generated Python for `basilisp.core`.

Also, munge `..` macro name using a kind-of-dirty change to `basilisp.lang.util.munge` 🤷‍♂ 