### PR TITLE
Throw a Syntax Error when a splicing reader conditional is outside a valid splice context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Change the default user namespace to `basilisp.user` (#466)
 
+### Fixed
+ * Fixed a reader bug where no exception was being thrown splicing reader conditional forms appeared outside of valid splicing contexts (#470)
+
 ## [v0.1.dev12] - 2020-01-26
 ### Added
  * Added new control structures: `dotimes`, `while`, `dorun`, `doall`, `case`, `for`, `doseq`, `..`, `with`, `doto` (#431)

--- a/docs/reader.rst
+++ b/docs/reader.rst
@@ -360,4 +360,32 @@ Syntax quoting is a facility primarily used for writing macros in Basilisp.
 Reader Conditionals
 -------------------
 
-Reader conditionals are **not** supported at the moment by Basilisp's reader, though support is planned.
+Reader conditionals are a powerful reader feature which allow Basilisp to read code written for other Clojure-like platforms (such as Clojure JVM or ClojureScript) without experiencing catastrophic errors.
+Platform-specific Clojure code can be wrapped in reader conditionals and the reader will match only forms identified by supported reader "features".
+Features are just standard :ref:`keywords`.
+By default, Basilisp supports the ``:lpy`` feature.
+
+Reader conditionals appear as Basilisp lists prefixed with the ``#?`` characters.
+Like maps, reader conditionals should always contain an even number of forms.
+Each pair should consist of the keyword used to identify the platform feature (such as ``:lpy`` for Basilisp) and the intended form for that feature.
+The reader may emit no forms (much like with the :ref:`reader_macros` ``#_``) if there are no supported features in the reader conditional form.
+
+::
+
+    basilisp.user=> #?(:clj 1 :lpy 2)
+    2
+    basilisp.user=> #?(:clj 1)
+    basilisp.user=>
+    basilisp.user=> [#?@(:lpy [1 2 3])]
+    [1 2 3]
+
+For advanced use cases, reader conditionals may also be written to splice their contents into surrounding forms.
+Splicing reader conditionals are subject to the same rules as splicing unquote in a syntax quoting context.
+Splicing reader conditionals may only appear within other collection literal forms (such as lists, maps, sets, and vectors).
+
+::
+
+    basilisp.user=> [#?@(:lpy [1 2 3])]
+    [1 2 3]
+    basilisp.user=> #?@(:lpy [1 2 3])
+    basilisp.lang.reader.SyntaxError: Unexpected reader conditional

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -567,7 +567,7 @@ def __read_map_elems(ctx: ReaderContext) -> Iterable[RawReaderForm]:
         if v is COMMENT or isinstance(v, Comment):
             continue
         elif v is ctx.eof:
-            raise SyntaxError(f"Unexpected EOF in map")
+            raise SyntaxError("Unexpected EOF in map")
         elif _should_splice_reader_conditional(ctx, v):
             assert isinstance(v, ReaderConditional)
             selected_feature = v.select_feature(ctx.reader_features)
@@ -736,7 +736,7 @@ def _read_str(ctx: ReaderContext, allow_arbitrary_escapes: bool = False) -> str:
             if allow_arbitrary_escapes:
                 s.append("\\")
             else:
-                raise SyntaxError("Unknown escape sequence: \\{token}")
+                raise SyntaxError(f"Unknown escape sequence: \\{token}")
         if token == '"':
             reader.next_token()
             return "".join(s)
@@ -1358,10 +1358,11 @@ def read(  # pylint: disable=too-many-arguments
             return
         if expr is COMMENT or isinstance(expr, Comment):
             continue
-        assert (
-            not isinstance(expr, ReaderConditional)
-            or not ctx.should_process_reader_cond
-        ), "Reader conditionals must be processed if specified"
+        if isinstance(expr, ReaderConditional) and ctx.should_process_reader_cond:
+            raise SyntaxError(
+                f"Unexpected reader conditional '{repr(expr)})'; "
+                "reader is configured to process reader conditionals"
+            )
         yield expr
 
 

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -892,6 +892,8 @@ class TestReaderConditional:
     @pytest.mark.parametrize(
         "v",
         [
+            # No splice context
+            "#?@(:clj [1 2 3] :lpy [4 5 6] :default [7 8 9])",
             # Invalid splice collection
             "(#?@(:clj (1 2) :lpy (3 4)))",
             "(#?@(:clj #{1 2} :lpy #{3 4}))",


### PR DESCRIPTION
Fixes #468 