### PR TITLE
Typed Basilisp module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Change the default user namespace to `basilisp.user` (#466)
  * Changed multi-methods to use a `threading.Lock` internally rather than an Atom (#478)
+ * Changed the Basilisp module type from `types.ModuleType` to a custom subtype with support for custom attributes (#482)
 
 ### Fixed
  * Fixed a reader bug where no exception was being thrown splicing reader conditional forms appeared outside of valid splicing contexts (#470)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -11,6 +11,7 @@ import basilisp.lang.reader as reader
 import basilisp.lang.runtime as runtime
 import basilisp.lang.symbol as sym
 import basilisp.main as basilisp
+from basilisp.lang.typing import BasilispModule
 from basilisp.prompt import get_prompter
 
 CLI_INPUT_FILE_PATH = "<CLI Input>"
@@ -24,7 +25,7 @@ def cli():
     """Basilisp is a Lisp dialect inspired by Clojure targeting Python 3."""
 
 
-def eval_file(filename: str, ctx: compiler.CompilerContext, module: types.ModuleType):
+def eval_file(filename: str, ctx: compiler.CompilerContext, module: BasilispModule):
     """Evaluate a file with the given name into a Python module AST node."""
     last = None
     for form in reader.read_file(filename, resolver=runtime.resolve_alias):
@@ -33,7 +34,7 @@ def eval_file(filename: str, ctx: compiler.CompilerContext, module: types.Module
     return last
 
 
-def eval_stream(stream, ctx: compiler.CompilerContext, module: types.ModuleType):
+def eval_stream(stream, ctx: compiler.CompilerContext, module: BasilispModule):
     """Evaluate the forms in stdin into a Python module AST node."""
     last = None
     for form in reader.read(stream, resolver=runtime.resolve_alias):
@@ -42,7 +43,7 @@ def eval_stream(stream, ctx: compiler.CompilerContext, module: types.ModuleType)
     return last
 
 
-def eval_str(s: str, ctx: compiler.CompilerContext, module: types.ModuleType, eof: Any):
+def eval_str(s: str, ctx: compiler.CompilerContext, module: BasilispModule, eof: Any):
     """Evaluate the forms in a string into a Python module AST node."""
     last = eof
     for form in reader.read_str(s, resolver=runtime.resolve_alias, eof=eof):

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -13,7 +13,7 @@ from typing import Iterable, List, Mapping, MutableMapping, Optional, cast
 import basilisp.lang.compiler as compiler
 import basilisp.lang.reader as reader
 import basilisp.lang.runtime as runtime
-from basilisp.lang.typing import ReaderForm
+from basilisp.lang.typing import BasilispModule, ReaderForm
 from basilisp.lang.util import demunge
 from basilisp.util import timed
 
@@ -219,7 +219,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
 
     def create_module(self, spec: ModuleSpec):
         logger.debug(f"Creating Basilisp module '{spec.name}''")
-        mod = types.ModuleType(spec.name)
+        mod = BasilispModule(spec.name)
         mod.__file__ = spec.loader_state["filename"]
         mod.__loader__ = spec.loader
         mod.__package__ = spec.parent
@@ -232,7 +232,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         fullname: str,
         loader_state: Mapping[str, str],
         path_stats: Mapping[str, int],
-        module: types.ModuleType,
+        module: BasilispModule,
     ):
         """Load and execute a cached Basilisp module."""
         filename = loader_state["filename"]
@@ -260,7 +260,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         fullname: str,
         loader_state: Mapping[str, str],
         path_stats: Mapping[str, int],
-        module: types.ModuleType,
+        module: BasilispModule,
     ):
         """Load and execute a non-cached Basilisp module."""
         filename = loader_state["filename"]
@@ -307,6 +307,8 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         each form in a module may require code compiled from an earlier form, so
         we incrementally compile a Python module by evaluating a single top-level
         form at a time and inserting the resulting AST nodes into the Pyton module."""
+        assert isinstance(module, BasilispModule)
+
         fullname = module.__name__
         cached = self._cache[fullname]
         cached["module"] = module

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -28,7 +28,7 @@ from basilisp.lang.compiler.generator import (  # noqa
     statementize as _statementize,
 )
 from basilisp.lang.compiler.optimizer import PythonASTOptimizer
-from basilisp.lang.typing import ReaderForm
+from basilisp.lang.typing import BasilispModule, ReaderForm
 from basilisp.lang.util import genname
 
 _DEFAULT_FN = "__lisp_expr__"
@@ -89,7 +89,7 @@ def _emit_ast_string(module: ast.AST) -> None:  # pragma: no cover
 def compile_and_exec_form(  # pylint: disable= too-many-arguments
     form: ReaderForm,
     ctx: CompilerContext,
-    module: types.ModuleType,
+    module: BasilispModule,
     wrapped_fn_name: str = _DEFAULT_FN,
     collect_bytecode: Optional[BytecodeCollector] = None,
 ) -> Any:
@@ -101,7 +101,7 @@ def compile_and_exec_form(  # pylint: disable= too-many-arguments
     if form is None:
         return None
 
-    if not module.__basilisp_bootstrapped__:  # type: ignore
+    if not module.__basilisp_bootstrapped__:
         _bootstrap_module(ctx.generator_context, ctx.py_ast_optimizer, module)
 
     final_wrapped_name = genname(wrapped_fn_name)
@@ -134,7 +134,7 @@ def compile_and_exec_form(  # pylint: disable= too-many-arguments
 def _incremental_compile_module(
     optimizer: PythonASTOptimizer,
     py_ast: GeneratedPyAST,
-    mod: types.ModuleType,
+    mod: BasilispModule,
     source_filename: str,
     collect_bytecode: Optional[BytecodeCollector] = None,
 ) -> None:
@@ -163,7 +163,7 @@ def _incremental_compile_module(
 def _bootstrap_module(
     gctx: GeneratorContext,
     optimizer: PythonASTOptimizer,
-    mod: types.ModuleType,
+    mod: BasilispModule,
     collect_bytecode: Optional[BytecodeCollector] = None,
 ) -> None:
     """Bootstrap a new module with imports and other boilerplate."""
@@ -174,13 +174,13 @@ def _bootstrap_module(
         source_filename=gctx.filename,
         collect_bytecode=collect_bytecode,
     )
-    mod.__basilisp_bootstrapped__ = True  # type: ignore
+    mod.__basilisp_bootstrapped__ = True
 
 
 def compile_module(
     forms: Iterable[ReaderForm],
     ctx: CompilerContext,
-    module: types.ModuleType,
+    module: BasilispModule,
     collect_bytecode: Optional[BytecodeCollector] = None,
 ) -> None:
     """Compile an entire Basilisp module into Python bytecode which can be
@@ -209,7 +209,7 @@ def compile_bytecode(
     code: List[types.CodeType],
     gctx: GeneratorContext,
     optimizer: PythonASTOptimizer,
-    module: types.ModuleType,
+    module: BasilispModule,
 ) -> None:
     """Compile cached bytecode into the given module.
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -3,7 +3,6 @@ import contextlib
 import importlib
 import logging
 import re
-import types
 import uuid
 from datetime import datetime
 from decimal import Decimal
@@ -257,11 +256,11 @@ class GeneratorContext:
             yield st
             self._st.pop()
 
-    def add_import(self, imp: sym.Symbol, mod: types.ModuleType, *aliases: sym.Symbol):
+    def add_import(self, imp: sym.Symbol, mod: runtime.Module, *aliases: sym.Symbol):
         self.current_ns.add_import(imp, mod, *aliases)
 
     @property
-    def imports(self) -> lmap.Map[sym.Symbol, types.ModuleType]:
+    def imports(self) -> runtime.ModuleMap:
         return self.current_ns.imports
 
     @property
@@ -2790,8 +2789,8 @@ def _module_imports(ctx: GeneratorContext) -> Iterable[ast.Import]:
     # Yield `import basilisp` so code attempting to call fully qualified
     # `basilisp.lang...` modules don't result in compiler errors
     yield ast.Import(names=[ast.alias(name="basilisp", asname=None)])
-    for imp in ctx.imports:
-        name = imp.key.name
+    for s in sorted(ctx.imports.keys(), key=lambda s: s.name):
+        name = s.name
         alias = _MODULE_ALIASES.get(name, None)
         yield ast.Import(names=[ast.alias(name=name, asname=alias)])
 

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from fractions import Fraction
+from types import ModuleType
 from typing import Pattern, Union
 
 import basilisp.lang.keyword as kw
@@ -36,3 +37,7 @@ LispForm = Union[
 PyCollectionForm = Union[dict, list, set, tuple]
 ReaderForm = Union[LispForm, IRecord, ISeq, IType, PyCollectionForm]
 SpecialForm = Union[llist.List, ISeq]
+
+
+class BasilispModule(ModuleType):
+    __basilisp_bootstrapped__: bool = False


### PR DESCRIPTION
Switch the Basilisp module type to a custom type, which supports the `__basilisp_bootstrapped__` dunder property by default.