### PR TITLE
Fixed a bug where Basilisp was unable to identify references to Vars in Namespaces whose aliase matches imported Python modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fixed a reader bug where no exception was being thrown splicing reader conditional forms appeared outside of valid splicing contexts (#470)
  * Fixed a bug where fully Namespace-qualified symbols would not resolve if the current Namespace did not alias the referenced Namespace (#479)
+ * Fixed a bug where Basilisp was unable to identify references to Vars in Namespaces whose aliase matches imported Python modules
 
 ## [v0.1.dev12] - 2020-01-26
 ### Added

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -119,6 +119,7 @@ def repl(
         },
     )
     ns_var = runtime.set_current_ns(default_ns)
+    runtime.set_current_compiler_ns(default_ns)
     prompter = get_prompter()
     eof = object()
     while True:

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3499,7 +3499,8 @@
   - :as name, which will alias the imported namespace to the symbol name
   - :refer [& syms], which will refer syms in the local namespace directly"
   [& args]
-  (let [current-ns *ns*
+  (let [current-ns     *ns*
+        current-ns-sym (symbol (name current-ns))
 
         do-require (fn [requires]
                      (when (seq requires)
@@ -3507,12 +3508,12 @@
                          (cond
                            (vector? v) (require-vec current-ns v)
                            (symbol? v) (require-sym v)
-                           :else             (throw
-                                              (ex-info "Invalid libspec for require"
-                                                       {:value v}))))
+                           :else       (throw
+                                        (ex-info "Invalid libspec for require"
+                                                 {:value v})))
+                         (in-ns current-ns-sym))
                        (recur (rest requires))))]
     (do-require args)
-    (set! *ns* current-ns)
     nil))
 
 (defmacro ns

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -219,7 +219,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         return spec.loader_state.filename
 
     def create_module(self, spec: ModuleSpec):
-        logger.debug(f"Creating Basilisp module '{spec.name}''")
+        logger.debug(f"Creating Basilisp module '{spec.name}'")
         mod = BasilispModule(spec.name)
         mod.__file__ = spec.loader_state["filename"]
         mod.__loader__ = spec.loader

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2442,6 +2442,10 @@ def __resolve_namespaced_symbol_in_ns(  # pylint: disable=too-many-branches
             ns = which_ns.import_aliases[ns_sym]
             assert ns is not None
             ns_name = ns.name
+        elif ns_sym in which_ns.aliases:
+            ns = which_ns.aliases[ns_sym]
+            assert ns is not None
+            ns_name = ns.name
         else:
             ns_name = ns_sym.name
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2442,10 +2442,6 @@ def __resolve_namespaced_symbol_in_ns(  # pylint: disable=too-many-branches
             ns = which_ns.import_aliases[ns_sym]
             assert ns is not None
             ns_name = ns.name
-        elif ns_sym in which_ns.aliases:
-            ns = which_ns.aliases[ns_sym]
-            assert ns is not None
-            ns_name = ns.name
         else:
             ns_name = ns_sym.name
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1584,14 +1584,18 @@ def _import_to_py_ast(ctx: GeneratorContext, node: Import) -> GeneratedPyAST:
 
         try:
             module = importlib.import_module(safe_name)
-            if alias.alias is not None:
-                ctx.add_import(sym.symbol(alias.name), module, sym.symbol(alias.alias))
-            else:
-                ctx.add_import(sym.symbol(alias.name), module)
         except ModuleNotFoundError as e:
             raise ImportError(
                 f"Python module '{alias.name}' not found", node.form, node
             ) from e
+        else:
+            if not ctx.has_var_indirection_override:
+                if alias.alias is not None:
+                    ctx.add_import(
+                        sym.symbol(alias.name), module, sym.symbol(alias.alias)
+                    )
+                else:
+                    ctx.add_import(sym.symbol(alias.name), module)
 
         py_import_alias = (
             munge(alias.alias)

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -213,7 +213,7 @@ class GeneratorContext:
 
     @property
     def current_ns(self) -> runtime.Namespace:
-        return runtime.get_current_ns()
+        return runtime.get_current_compiler_ns()
 
     @property
     def filename(self) -> str:
@@ -1588,14 +1588,11 @@ def _import_to_py_ast(ctx: GeneratorContext, node: Import) -> GeneratedPyAST:
             raise ImportError(
                 f"Python module '{alias.name}' not found", node.form, node
             ) from e
+
+        if alias.alias is not None:
+            ctx.add_import(sym.symbol(alias.name), module, sym.symbol(alias.alias))
         else:
-            if not ctx.has_var_indirection_override:
-                if alias.alias is not None:
-                    ctx.add_import(
-                        sym.symbol(alias.name), module, sym.symbol(alias.alias)
-                    )
-                else:
-                    ctx.add_import(sym.symbol(alias.name), module)
+            ctx.add_import(sym.symbol(alias.name), module)
 
         py_import_alias = (
             munge(alias.alias)

--- a/src/basilisp/testrunner.py
+++ b/src/basilisp/testrunner.py
@@ -13,11 +13,14 @@ import basilisp.main as basilisp
 from basilisp.lang.obj import lrepr
 from basilisp.util import Maybe
 
-basilisp.init()
-importlib.import_module("basilisp.test")
-
 _COLLECTED_TESTS_SYM = sym.symbol("collected-tests", ns="basilisp.test")
 _CURRENT_NS_SYM = sym.symbol("current-ns", ns="basilisp.test")
+
+
+# pylint: disable=unused-arg
+def pytest_configure(config):
+    basilisp.init()
+    importlib.import_module("basilisp.test")
 
 
 def pytest_collect_file(parent, path):

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -3116,6 +3116,20 @@ class TestSymbolResolution:
         with pytest.raises(compiler.CompilerException):
             lcompile("basilisp.lang.map.MapEntry.of")
 
+    def test_aliased_namespace_not_hidden_by_python_module(
+        self, lcompile: CompileFn, ns: runtime.Namespace
+    ):
+        import fileinput
+
+        sentinel = object()
+        fileinput_ns = get_or_create_ns(sym.symbol("basilisp.fileinput"))
+        fileinput_ns.add_import(
+            sym.symbol("fileinput"), fileinput, sym.symbol("fileinput")
+        )
+        Var.intern(sym.symbol("basilisp.fileinput"), sym.symbol("some-sym"), sentinel)
+        ns.add_alias(sym.symbol("fileinput"), fileinput_ns)
+        assert sentinel is lcompile("fileinput/some-sym")
+
     def test_aliased_var_does_not_resolve(
         self, lcompile: CompileFn, ns: runtime.Namespace
     ):

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -22,7 +22,7 @@ def test_ns() -> str:
 
 @pytest.fixture
 def ns(test_ns: str) -> runtime.Namespace:
-    runtime.init_ns_var(which_ns=runtime.CORE_NS)
+    runtime.init_ns_var()
     with runtime.ns_bindings(test_ns) as ns:
         yield ns
 

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -379,7 +379,7 @@ def test_trampoline_args():
 
 @pytest.fixture
 def core_ns():
-    ns_var = runtime.init_ns_var(which_ns=runtime.CORE_NS)
+    ns_var = runtime.init_ns_var()
     yield ns_var.value
 
 


### PR DESCRIPTION
Fixes #483 