### PR TITLE
`quote` special form accepts exactly 1 argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fixed a reader bug where no exception was being thrown splicing reader conditional forms appeared outside of valid splicing contexts (#470)
  * Fixed a bug where fully Namespace-qualified symbols would not resolve if the current Namespace did not alias the referenced Namespace (#479)
+ * Fixed a bug where the `quote` special form allowed more than one argument and raised an unintended exception when no argument was provided (#497)
 
 ## [v0.1.dev12] - 2020-01-26
 ### Added

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2034,6 +2034,12 @@ def _loop_ast(ctx: AnalyzerContext, form: ISeq) -> Loop:
 
 def _quote_ast(ctx: AnalyzerContext, form: ISeq) -> Quote:
     assert form.first == SpecialForm.QUOTE
+    nelems = count(form)
+
+    if nelems != 2:
+        raise AnalyzerException(
+            "quote forms must have exactly two elements: (quote form)", form=form
+        )
 
     with ctx.quoted():
         with ctx.expr_pos():

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -2562,6 +2562,11 @@ class TestLoop:
 
 
 class TestQuote:
+    @pytest.mark.parametrize("code", ["(quote)", "(quote form other-form)"])
+    def test_quote_num_elems(self, lcompile: CompileFn, code: str):
+        with pytest.raises(compiler.CompilerException):
+            lcompile(code)
+
     def test_quoted_list(self, lcompile: CompileFn):
         assert lcompile("'()") == llist.l()
         assert lcompile("'(str)") == llist.l(sym.symbol("str"))


### PR DESCRIPTION
Fixes #496 