### PR TITLE
`defonce` no longer throws a SyntaxError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fixed a bug where the Basilisp AST nodes for return values of `deftype` members could be marked as _statements_ rather than _expressions_, resulting in an incorrect `nil` return (#523)
+ * Fixed a bug where `defonce` would throw a Python SyntaxError due to a superfluous `global` statement in the generated Python (#525)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -2826,8 +2826,8 @@
   a `name` is not already defined as a Var in this namespace. `expr` will not be
   evaluated if the Var already exists."
   [name expr]
-  `(let [v (def ~name)]
-     (when-not (.-is-bound v)
+  `(let [v# (def ~name)]
+     (when-not (.-is-bound v#)
        (def ~name ~expr))))
 
 (defmacro for
@@ -3698,7 +3698,7 @@
 
 (import importlib)
 
-(defn- require-libspec
+(defn ^:private require-libspec
   "Convert a user-specified require libspec into a map with well-defined keys.
 
   Required keys:
@@ -3720,7 +3720,7 @@
                    (ex-info "Invalid libspec for require"
                             {:value req}))))
 
-(defn- require-lib
+(defn ^:private require-lib
   "Require the library described by `libspec` into the Namespace `requiring-ns`."
   [requiring-ns libspec]
   (let [required-ns-sym  (:namespace libspec)]
@@ -3737,7 +3737,7 @@
     ;; during the require process
     (set! *ns* requiring-ns)))
 
-(defn- refer-filtered-interns
+(defn ^:private refer-filtered-interns
   "Return a map of symbols to interned Vars in the Namespace `referred-ns` subject
   to the filters described in `libspec`."
   [referred-ns libspec]
@@ -3759,7 +3759,7 @@
                                 m))
                             {}))))
 
-(defn- refer-lib
+(defn ^:private refer-lib
   "Refer Vars into `requiring-ns` as described by `libspec`.
 
   This function assumes the referred-to Namespace has already been loaded by
@@ -3985,6 +3985,9 @@
   [name & body]
   (let [doc         (when (string? (first body))
                       (first body))
+        name        (if doc
+                      (vary-meta name assoc :doc doc)
+                      name)
         body        (if doc
                       (rest body)
                       body)
@@ -4414,9 +4417,9 @@
   ([o & {:keys [keywordize-keys] :or {keywordize-keys true}}]
    (basilisp.lang.runtime/to-lisp o keywordize-keys)))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Data Types & Protocols ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;
+;; Interfaces ;;
+;;;;;;;;;;;;;;;;
 
 (import* abc)
 
@@ -4492,6 +4495,10 @@
     `(def ~interface-name
        (gen-interface ~name-str [~@method-sigs]))))
 
+;;;;;;;;;;;;;;;;
+;; Data Types ;;
+;;;;;;;;;;;;;;;;
+
 (defn ^:private collect-methods
   "Collect method and interface declarations for `deftype` and `defrecord`
   into a map containing `:interfaces` and `:methods` keys."
@@ -4560,6 +4567,10 @@
          ~@methods)
        (def ~ctor-name ~type-name)
        ~type-name)))
+
+;;;;;;;;;;;;;
+;; Records ;;
+;;;;;;;;;;;;;
 
 (import* attr)
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -394,10 +394,14 @@ class AnalyzerContext:
 
     @property
     def should_macroexpand(self) -> bool:
+        """Return True if macros should be expanded."""
         return self._should_macroexpand
 
     @property
     def is_async_ctx(self) -> bool:
+        """If True, the current node appears inside of an async function definition.
+        It is possible that the current function is defined inside other functions,
+        so this does not imply anything about the nesting level of the current node."""
         try:
             return self._func_ctx[-1] is True
         except IndexError:
@@ -405,6 +409,9 @@ class AnalyzerContext:
 
     @property
     def in_func_ctx(self) -> bool:
+        """If True, the current node appears inside of a function definition.
+        It is possible that the current function is defined inside other functions,
+        so this does not imply anything about the nesting level of the current node."""
         try:
             self._func_ctx[-1]
         except IndexError:
@@ -414,12 +421,18 @@ class AnalyzerContext:
 
     @contextlib.contextmanager
     def new_func_ctx(self, is_async: bool = False):
+        """Context manager which can be used to set a function context for child
+        nodes to examine. A new function context is pushed onto the stack each time
+        the Analyzer finds a new function definition, so there may be many nested
+        function contexts."""
         self._func_ctx.append(is_async)
         yield
         self._func_ctx.pop()
 
     @property
     def recur_point(self) -> Optional[RecurPoint]:
+        """Return the current recur point which applies to the current node, if there
+        is one."""
         try:
             return self._recur_points[-1]
         except IndexError:
@@ -427,6 +440,11 @@ class AnalyzerContext:
 
     @contextlib.contextmanager
     def new_recur_point(self, loop_id: str, args: Collection[Any] = ()):
+        """Context manager which can be used to set a recur point for child nodes.
+        A new recur point is pushed onto the stack each time the Analyzer finds a
+        form which supports recursion (such as `fn*` or `loop*`), so there may be
+        many recur points, though only one may be active at any given time for a
+        node."""
         self._recur_points.append(RecurPoint(loop_id, args=args))
         yield
         self._recur_points.pop()

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -403,6 +403,15 @@ class AnalyzerContext:
         except IndexError:
             return False
 
+    @property
+    def in_func_ctx(self) -> bool:
+        try:
+            self._func_ctx[-1]
+        except IndexError:
+            return False
+        else:
+            return True
+
     @contextlib.contextmanager
     def new_func_ctx(self, is_async: bool = False):
         self._func_ctx.append(is_async)
@@ -801,6 +810,7 @@ def _def_ast(  # pylint: disable=too-many-branches,too-many-locals
         var=var,
         init=init,
         doc=doc,
+        in_func_ctx=ctx.in_func_ctx,
         children=children,
         env=def_node_env,
     )

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -721,11 +721,12 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
     # global declaration prior to emitting the Python `def` otherwise the
     # Python compiler will throw an exception during compilation
     # complaining that we assign the value prior to global declaration.
+    should_emit_global_decl = bool(node.top_level and not node.in_func_ctx)
     if is_defn:
         assert def_ast is not None, "def_ast must be defined at this point"
         def_dependencies = list(
             chain(
-                [] if node.top_level else [ast.Global(names=[safe_name])],
+                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
                 def_ast.dependencies,
                 [] if meta_ast is None else meta_ast.dependencies,
             )
@@ -736,7 +737,7 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
         assert def_ast is None, "def_ast is not defined at this point"
         def_dependencies = list(
             chain(
-                [] if node.top_level else [ast.Global(names=[safe_name])],
+                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
                 [] if meta_ast is None else meta_ast.dependencies,
             )
         )
@@ -745,7 +746,7 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
         def_dependencies = list(
             chain(
                 def_ast.dependencies,
-                [] if node.top_level else [ast.Global(names=[safe_name])],
+                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
                 [
                     ast.Assign(
                         targets=[ast.Name(id=safe_name, ctx=ast.Store())],

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -659,9 +659,9 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
     defsym = node.name
     is_defn = False
     is_var_bound = node.var.is_bound
-    is_noop_redef_of_bound_var = is_var_bound and node.init is None
+    is_binding_def = node.init is not None
 
-    if node.init is not None:
+    if is_binding_def:
         # Since Python function definitions always take the form `def name(...):`,
         # it is redundant to assign them to the their final name after they have
         # been defined under a private alias. This codepath generates `defn`
@@ -683,10 +683,8 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
             is_defn = True
         else:
             def_ast = gen_py_ast(ctx, node.init)
-    elif is_noop_redef_of_bound_var:
-        def_ast = None
     else:
-        def_ast = GeneratedPyAST(node=ast.Constant(None))
+        def_ast = None
 
     ns_name = _load_attr(_NS_VAR_VALUE)
     def_name = ast.Call(
@@ -717,67 +715,47 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
 
     meta_ast = gen_py_ast(ctx, node.meta)
 
-    # For defn style def generation, we specifically need to generate the
-    # global declaration prior to emitting the Python `def` otherwise the
-    # Python compiler will throw an exception during compilation
-    # complaining that we assign the value prior to global declaration.
-    should_emit_global_decl = bool(node.top_level and not node.in_func_ctx)
-    if is_defn:
+    if is_binding_def:
         assert def_ast is not None, "def_ast must be defined at this point"
-        def_dependencies = list(
-            chain(
-                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
-                def_ast.dependencies,
-                [] if meta_ast is None else meta_ast.dependencies,
+        func = _INTERN_VAR_FN_NAME
+        extra_args = [ast.Name(id=safe_name, ctx=ast.Load())]
+        if is_defn:
+            # For defn style def generation, we specifically need to generate
+            # the global declaration prior to emitting the Python `def` otherwise
+            # the Python compiler will throw an exception during compilation
+            # complaining that we assign the value prior to global declaration.
+            def_dependencies = list(
+                chain(
+                    [ast.Global(names=[safe_name])] if node.in_func_ctx else [],
+                    def_ast.dependencies,
+                )
             )
-        )
-    elif is_noop_redef_of_bound_var:
+        else:
+            def_dependencies = list(
+                chain(
+                    def_ast.dependencies,
+                    [ast.Global(names=[safe_name])] if node.in_func_ctx else [],
+                    [
+                        ast.Assign(
+                            targets=[ast.Name(id=safe_name, ctx=ast.Store())],
+                            value=def_ast.node,
+                        )
+                    ],
+                )
+            )
+    else:
+        assert def_ast is None, "def_ast is not defined at this point"
+        assert not is_defn, "defn defs must be binding defs"
         # Re-def-ing previously bound Vars without providing a value is
         # essentially a no-op, which should not modify the Var root.
-        assert def_ast is None, "def_ast is not defined at this point"
-        def_dependencies = list(
-            chain(
-                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
-                [] if meta_ast is None else meta_ast.dependencies,
-            )
-        )
-    else:
-        assert def_ast is not None, "def_ast must be defined at this point"
-        def_dependencies = list(
-            chain(
-                def_ast.dependencies,
-                [ast.Global(names=[safe_name])] if should_emit_global_decl else [],
-                [
-                    ast.Assign(
-                        targets=[ast.Name(id=safe_name, ctx=ast.Store())],
-                        value=def_ast.node,
-                    )
-                ],
-                [] if meta_ast is None else meta_ast.dependencies,
-            )
-        )
-
-    if is_noop_redef_of_bound_var:
-        return GeneratedPyAST(
-            node=ast.Call(
-                func=_INTERN_UNBOUND_VAR_FN_NAME,
-                args=[ns_name, def_name],
-                keywords=list(
-                    chain(
-                        dynamic_kwarg,
-                        []
-                        if meta_ast is None
-                        else [ast.keyword(arg="meta", value=meta_ast.node)],
-                    )
-                ),
-            ),
-            dependencies=def_dependencies,
-        )
+        func = _INTERN_UNBOUND_VAR_FN_NAME
+        extra_args = []
+        def_dependencies = [ast.Global(names=[safe_name])] if node.in_func_ctx else []
 
     return GeneratedPyAST(
         node=ast.Call(
-            func=_INTERN_VAR_FN_NAME,
-            args=[ns_name, def_name, ast.Name(id=safe_name, ctx=ast.Load())],
+            func=func,
+            args=list(chain([ns_name, def_name], extra_args)),
             keywords=list(
                 chain(
                     dynamic_kwarg,
@@ -787,7 +765,9 @@ def _def_to_py_ast(  # pylint: disable=too-many-branches
                 )
             ),
         ),
-        dependencies=def_dependencies,
+        dependencies=list(
+            chain(def_dependencies, [] if meta_ast is None else meta_ast.dependencies,)
+        ),
     )
 
 

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -351,6 +351,7 @@ class Def(Node[SpecialForm]):
     var: Var
     init: Optional[Node]
     doc: Optional[str]
+    in_func_ctx: bool
     env: NodeEnv
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.Vector.empty()

--- a/src/basilisp/lang/compiler/optimizer.py
+++ b/src/basilisp/lang/compiler/optimizer.py
@@ -1,4 +1,6 @@
-from typing import Iterable, List, Optional
+from collections import deque
+from contextlib import contextmanager
+from typing import Iterable, List, Optional, Set
 
 import basilisp._pyast as ast
 
@@ -17,6 +19,23 @@ def _filter_dead_code(nodes: Iterable[ast.AST]) -> List[ast.AST]:
 
 
 class PythonASTOptimizer(ast.NodeTransformer):
+    __slots__ = ("_global_ctx",)
+
+    def __init__(self):
+        self._global_ctx = deque([set()])
+
+    @contextmanager
+    def _new_global_context(self):
+        self._global_ctx.append(set())
+        try:
+            yield
+        finally:
+            self._global_ctx.pop()
+
+    @property
+    def _global_context(self) -> Set[str]:
+        return self._global_ctx[-1]
+
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Optional[ast.AST]:
         """Eliminate dead code from except handler bodies."""
         new_node = self.generic_visit(node)
@@ -39,7 +58,8 @@ class PythonASTOptimizer(ast.NodeTransformer):
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> Optional[ast.AST]:
         """Eliminate dead code from function bodies."""
-        new_node = self.generic_visit(node)
+        with self._new_global_context():
+            new_node = self.generic_visit(node)
         assert isinstance(new_node, ast.FunctionDef)
         return ast.copy_location(
             ast.FunctionDef(
@@ -50,6 +70,16 @@ class PythonASTOptimizer(ast.NodeTransformer):
                 returns=new_node.returns,
             ),
             new_node,
+        )
+
+    def visit_Global(self, node: ast.Global) -> Optional[ast.Global]:
+        """"""
+        new_names = set(node.names) - self._global_context
+        self._global_context.update(new_names)
+        return (
+            ast.copy_location(ast.Global(names=list(new_names)), node)
+            if new_names
+            else None
         )
 
     def visit_If(self, node: ast.If) -> Optional[ast.AST]:

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -155,6 +155,19 @@ class _VarBindings(threading.local):
         self.bindings: List = []
 
 
+class Unbound:
+    __slots__ = ("var",)
+
+    def __init__(self, v: "Var"):
+        self.var = v
+
+    def __repr__(self):  # pragma: no cover
+        return f"Unbound(var={self.var})"
+
+    def __eq__(self, other):
+        return isinstance(other, Unbound) and self.var == other.var
+
+
 class Var(IDeref, ReferenceBase):
     __slots__ = (
         "_name",
@@ -176,7 +189,7 @@ class Var(IDeref, ReferenceBase):
     ) -> None:
         self._ns = ns
         self._name = name
-        self._root = None
+        self._root = Unbound(self)
         self._dynamic = dynamic
         self._is_bound = False
         self._tl = None

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -284,7 +284,7 @@ class TestDef:
     def test_def_unbound(self, lcompile: CompileFn, ns: runtime.Namespace):
         lcompile("(def a)")
         var = Var.find_in_ns(sym.symbol(ns.name), sym.symbol("a"))
-        assert var.root is None
+        assert var.root == runtime.Unbound(var)
         assert not var.is_bound
 
     def test_def_number_of_elems(self, lcompile: CompileFn, ns: runtime.Namespace):
@@ -386,11 +386,13 @@ class TestDef:
 
     def test_redef_unbound_var(self, lcompile: CompileFn):
         v1: Var = lcompile("(def unbound-var)")
-        assert None is v1.root
+        assert runtime.Unbound(v1) == v1.root
 
         v2: Var = lcompile("(def unbound-var :a)")
         assert kw.keyword("a") == v2.root
         assert v2.is_bound
+
+        assert v1 is v2
 
     def test_def_unbound_does_not_clear_var_root(self, lcompile: CompileFn):
         v1: Var = lcompile("(def bound-var :a)")
@@ -401,7 +403,7 @@ class TestDef:
         assert kw.keyword("a") == v2.root
         assert v2.is_bound
 
-        assert v1 == v2
+        assert v1 is v2
 
 
 class TestDefType:

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -285,8 +285,7 @@ class TestDef:
         lcompile("(def a)")
         var = Var.find_in_ns(sym.symbol(ns.name), sym.symbol("a"))
         assert var.root is None
-        # TODO: fix this
-        # assert not var.is_bound
+        assert not var.is_bound
 
     def test_def_number_of_elems(self, lcompile: CompileFn, ns: runtime.Namespace):
         with pytest.raises(compiler.CompilerException):

--- a/tests/basilisp/core_macros_test.lpy
+++ b/tests/basilisp/core_macros_test.lpy
@@ -267,7 +267,7 @@
 
   (testing "defonce can bind an unbound Var"
     (def defonce-unbound)
-    (is (nil? defonce-unbound))
+    (is (not (.-is-bound (var defonce-unbound))))
     (defonce defonce-unbound :defonce-bound-now)
     (is (= :defonce-bound-now defonce-unbound)))
 

--- a/tests/basilisp/core_macros_test.lpy
+++ b/tests/basilisp/core_macros_test.lpy
@@ -258,6 +258,25 @@
         (is (= "0.1" (:added vmeta)))
         (is (= "another multi-arity docstring" (:doc vmeta)))))))
 
+(deftest defonce-test
+  (testing "defonce will not rebind bound Var"
+    (defonce defonce-value :defonce-value-1)
+    (is (= :defonce-value-1 defonce-value))
+    (defonce defonce-value :defonce-value-2)
+    (is (= :defonce-value-1 defonce-value)))
+
+  (testing "defonce can bind an unbound Var"
+    (def defonce-unbound)
+    (is (nil? defonce-unbound))
+    (defonce defonce-unbound :defonce-bound-now)
+    (is (= :defonce-bound-now defonce-unbound)))
+
+  (testing "defonce will not rebind bound Var by regular def"
+    (def defonce-bound :defonce-bound-first)
+    (is (= :defonce-bound-first defonce-bound))
+    (defonce defonce-bound :defounce-rebinding)
+    (is (= :defonce-bound-first defonce-bound))))
+
 (deftest fn-meta-test
   (testing "fn has no meta to start"
     (is (nil? (meta (fn* []))))

--- a/tests/basilisp/var_test.py
+++ b/tests/basilisp/var_test.py
@@ -7,7 +7,14 @@ import basilisp.lang.keyword as kw
 import basilisp.lang.map as lmap
 import basilisp.lang.symbol as sym
 import basilisp.lang.vector as vec
-from basilisp.lang.runtime import Namespace, NamespaceMap, RuntimeException, Var, assoc
+from basilisp.lang.runtime import (
+    Namespace,
+    NamespaceMap,
+    RuntimeException,
+    Unbound,
+    Var,
+    assoc,
+)
 from tests.basilisp.helpers import get_or_create_ns
 
 
@@ -210,9 +217,9 @@ def test_intern_unbound(
     assert not v.is_bound
     assert not v.dynamic
     assert not v.is_thread_bound
-    assert None is v.root
-    assert None is v.value
-    assert None is v.deref()
+    assert Unbound(v) == v.root
+    assert Unbound(v) == v.value
+    assert Unbound(v) == v.deref()
 
     ns = get_or_create_ns(ns_sym)
     assert None is not ns
@@ -229,9 +236,9 @@ def test_dynamic_unbound(
     assert not v.is_bound
     assert v.dynamic
     assert not v.is_thread_bound
-    assert None is v.root
-    assert None is v.value
-    assert None is v.deref()
+    assert Unbound(v) == v.root
+    assert Unbound(v) == v.value
+    assert Unbound(v) == v.deref()
 
     new_val = kw.keyword("new-val")
     try:
@@ -239,7 +246,7 @@ def test_dynamic_unbound(
         assert v.is_bound
         assert v.dynamic
         assert v.is_thread_bound
-        assert None is v.root
+        assert Unbound(v) == v.root
         assert new_val == v.value
         assert new_val == v.deref()
     finally:


### PR DESCRIPTION
Fixes #524 