### PR TITLE
Fixed a bug where Basilisp would throw an exception when comparing seqs to non-seqable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fixed a bug where the Basilisp AST nodes for return values of `deftype` members could be marked as _statements_ rather than _expressions_, resulting in an incorrect `nil` return (#523)
  * Fixed a bug where `defonce` would throw a Python SyntaxError due to a superfluous `global` statement in the generated Python (#525)
+ * Fixed a bug where Basilisp would throw an exception when comparing seqs by `=` to non-seqable values (#530)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -321,12 +321,16 @@ class ISeq(ILispObject, ISeqable[T]):
 
     def __eq__(self, other):
         sentinel = object()
-        for e1, e2 in itertools.zip_longest(self, other, fillvalue=sentinel):
-            if bool(e1 is sentinel) or bool(e2 is sentinel):
-                return False
-            if e1 != e2:
-                return False
-        return True
+        try:
+            for e1, e2 in itertools.zip_longest(self, other, fillvalue=sentinel):
+                if bool(e1 is sentinel) or bool(e2 is sentinel):
+                    return False
+                if e1 != e2:
+                    return False
+        except TypeError:
+            return False
+        else:
+            return True
 
     def __hash__(self):
         return hash(tuple(self))

--- a/tests/basilisp/seq_test.py
+++ b/tests/basilisp/seq_test.py
@@ -1,4 +1,6 @@
+import basilisp.lang.keyword as kw
 import basilisp.lang.list as llist
+import basilisp.lang.runtime as runtime
 import basilisp.lang.seq as lseq
 import basilisp.lang.vector as vec
 
@@ -102,3 +104,12 @@ def test_seq_iterator():
 
     s = lseq.sequence(range(10000))
     assert 10000 == len(vec.vector(s))
+
+
+def test_seq_equals():
+    # to_seq should be first to ensure that `ISeq.__eq__` is used
+    assert runtime.to_seq(vec.v(1, 2, 3)) == llist.l(1, 2, 3)
+    assert False is (runtime.to_seq(vec.v(1, 2, 3)) == kw.keyword("abc"))
+
+    assert lseq.sequence(vec.v(1, 2, 3)) == llist.l(1, 2, 3)
+    assert False is (lseq.sequence(vec.v(1, 2, 3)) == kw.keyword("abc"))


### PR DESCRIPTION
Fixes #529 