### PR TITLE
Allow `deftype*` forms to declare no fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed a bug where Basilisp would throw an exception when comparing seqs by `=` to non-seqable values (#530)
  * Fixed a bug where aliased Python submodule imports referred to the top-level module rather than the submodule (#533)
  * Fixed a bug where static methods and class methods on types created by `deftype` could not be referred to directly (defeating the purpose of the static or class method) (#537)
+ * Fixed a bug where `defftype` forms could not be declared without at least one field (#540)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1554,7 +1554,8 @@ def _deftype_ast(  # pylint: disable=too-many-branches
     nelems = count(form)
     if nelems < 3:
         raise AnalyzerException(
-            "deftype forms must have 3 or more elements, as in: (deftype* name fields [bases+impls])",
+            "deftype forms must have 3 or more elements, as in: "
+            "(deftype* name fields :implements [bases+impls])",
             form=form,
         )
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1334,7 +1334,7 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-branches
                             name=type_name,
                             bases=bases,
                             keywords=[],
-                            body=type_nodes,
+                            body=type_nodes or [ast.Pass()],
                             decorator_list=[decorator],
                         ),
                         ast.Call(

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -605,6 +605,14 @@ class TestDefType:
             """
             )
 
+    @pytest.mark.parametrize(
+        "code", ["(deftype* Shape [])", "(deftype* Shape [] :implements [])"]
+    )
+    def test_deftype_interface_may_have_no_fields_or_methods(
+        self, lcompile: CompileFn, code: str,
+    ):
+        lcompile(code)
+
     def test_deftype_interface_may_implement_only_some_object_methods(
         self, lcompile: CompileFn
     ):


### PR DESCRIPTION
Fixes #540 