### PR TITLE
More flexible resolution of import and require symbols 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed a bug where `deftype` forms could not be declared without at least one field (#540)
  * Fixed a bug where not all builtin Basilisp types could be pickled (#518)
  * Fixed a bug where `deftype` forms could not be created interfaces declared not at the top-level of a code block in a namespace (#376)
- * Fixed multiple bugs relating to symbol resolution of `import`ed and `require`ed symbols in various contexts (#544, #545)
+ * Fixed multiple bugs relating to symbol resolution of `import`ed symbols in various contexts (#544)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed a bug where `deftype` forms could not be declared without at least one field (#540)
  * Fixed a bug where not all builtin Basilisp types could be pickled (#518)
  * Fixed a bug where `deftype` forms could not be created interfaces declared not at the top-level of a code block in a namespace (#376)
+ * Fixed multiple bugs relating to symbol resolution of `import`ed and `require`ed symbols in various contexts (#544, #545)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3712,9 +3712,19 @@
   (ns-resolve *ns* sym))
 
 (defmacro import
-  "Import a Python module by name."
-  [module]
-  `(import* ~module))
+  "Import Python modules by name.
+
+  Modules may be specified either as symbols naming the full module path or as a
+  vector taking the form `[full.module.path :as alias]`.
+
+  Note that unlike in Python, `import`ed Python module names are always hoisted to
+  the current Namespace, so imported names will be available within a Namespace even
+  if the `import` itself occurs within a function or method.
+
+  Use of `import` directly is discouraged in favor of the `:import` directive in
+  the `ns` macro."
+  [& modules]
+  `(import* ~@modules))
 
 (import importlib)
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -87,6 +87,7 @@ from basilisp.lang.compiler.nodes import (
     Do,
     Fn,
     FnArity,
+    FunctionContext,
     HostCall,
     HostField,
     If,
@@ -309,7 +310,7 @@ class AnalyzerContext:
     ) -> None:
         self._allow_unresolved_symbols = allow_unresolved_symbols
         self._filename = Maybe(filename).or_else_get(DEFAULT_COMPILER_FILE_PATH)
-        self._func_ctx: Deque[bool] = collections.deque([])
+        self._func_ctx: Deque[FunctionContext] = collections.deque([])
         self._is_quoted: Deque[bool] = collections.deque([])
         self._macro_ns: Deque[Optional[runtime.Namespace]] = collections.deque([])
         self._opts = (
@@ -411,13 +412,13 @@ class AnalyzerContext:
         It is possible that the current function is defined inside other functions,
         so this does not imply anything about the nesting level of the current node."""
         try:
-            return self._func_ctx[-1] is True
+            return self._func_ctx[-1] == FunctionContext.ASYNC_FUNCTION
         except IndexError:
             return False
 
     @property
-    def in_func_ctx(self) -> bool:
-        """If True, the current node appears inside of a function definition.
+    def in_func_or_method_ctx(self) -> bool:
+        """If True, the current node appears inside of a function or method definition.
         It is possible that the current function is defined inside other functions,
         so this does not imply anything about the nesting level of the current node."""
         try:
@@ -428,12 +429,12 @@ class AnalyzerContext:
             return True
 
     @contextlib.contextmanager
-    def new_func_ctx(self, is_async: bool = False):
-        """Context manager which can be used to set a function context for child
-        nodes to examine. A new function context is pushed onto the stack each time
-        the Analyzer finds a new function definition, so there may be many nested
-        function contexts."""
-        self._func_ctx.append(is_async)
+    def new_func_ctx(self, context_type: FunctionContext):
+        """Context manager which can be used to set a function or method context for
+        child nodes to examine. A new function context is pushed onto the stack each
+        time the Analyzer finds a new function or method definition, so there may be
+        many nested function contexts."""
+        self._func_ctx.append(context_type)
         yield
         self._func_ctx.pop()
 
@@ -895,7 +896,7 @@ def _def_ast(  # pylint: disable=too-many-branches,too-many-locals
         var=var,
         init=init,
         doc=doc,
-        in_func_ctx=ctx.in_func_ctx,
+        in_func_ctx=ctx.in_func_or_method_ctx,
         children=children,
         env=def_node_env,
     )
@@ -1037,29 +1038,30 @@ def __deftype_classmethod(
         has_vargs, fixed_arity, param_nodes = __deftype_method_param_bindings(
             ctx, params
         )
-        with ctx.expr_pos():
-            stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
-        method = DefTypeClassMethodArity(
-            form=form,
-            name=method_name,
-            params=vec.vector(param_nodes),
-            fixed_arity=fixed_arity,
-            is_variadic=has_vargs,
-            kwarg_support=kwarg_support,
-            body=Do(
-                form=form.rest,
-                statements=vec.vector(stmts),
-                ret=ret,
-                is_body=True,
-                # Use the argument vector or first body statement, whichever
-                # exists, for metadata.
+        with ctx.new_func_ctx(FunctionContext.CLASSMETHOD):
+            with ctx.expr_pos():
+                stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
+            method = DefTypeClassMethodArity(
+                form=form,
+                name=method_name,
+                params=vec.vector(param_nodes),
+                fixed_arity=fixed_arity,
+                is_variadic=has_vargs,
+                kwarg_support=kwarg_support,
+                body=Do(
+                    form=form.rest,
+                    statements=vec.vector(stmts),
+                    ret=ret,
+                    is_body=True,
+                    # Use the argument vector or first body statement, whichever
+                    # exists, for metadata.
+                    env=ctx.get_node_env(),
+                ),
+                class_local=cls_binding,
                 env=ctx.get_node_env(),
-            ),
-            class_local=cls_binding,
-            env=ctx.get_node_env(),
-        )
-        method.visit(_assert_no_recur)
-        return method
+            )
+            method.visit(_assert_no_recur)
+            return method
 
 
 def __deftype_method(
@@ -1096,7 +1098,9 @@ def __deftype_method(
         )
 
         loop_id = genname(method_name)
-        with ctx.new_recur_point(loop_id, param_nodes):
+        with ctx.new_func_ctx(FunctionContext.METHOD), ctx.new_recur_point(
+            loop_id, param_nodes
+        ):
             with ctx.expr_pos():
                 stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
             method = DefTypeMethodArity(
@@ -1160,26 +1164,27 @@ def __deftype_property(
 
         assert not has_vargs, "deftype* properties may not have arguments"
 
-        with ctx.expr_pos():
-            stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
-        prop = DefTypeProperty(
-            form=form,
-            name=method_name,
-            this_local=this_binding,
-            params=vec.vector(param_nodes),
-            body=Do(
-                form=form.rest,
-                statements=vec.vector(stmts),
-                ret=ret,
-                is_body=True,
-                # Use the argument vector or first body statement, whichever
-                # exists, for metadata.
+        with ctx.new_func_ctx(FunctionContext.PROPERTY):
+            with ctx.expr_pos():
+                stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
+            prop = DefTypeProperty(
+                form=form,
+                name=method_name,
+                this_local=this_binding,
+                params=vec.vector(param_nodes),
+                body=Do(
+                    form=form.rest,
+                    statements=vec.vector(stmts),
+                    ret=ret,
+                    is_body=True,
+                    # Use the argument vector or first body statement, whichever
+                    # exists, for metadata.
+                    env=ctx.get_node_env(),
+                ),
                 env=ctx.get_node_env(),
-            ),
-            env=ctx.get_node_env(),
-        )
-        prop.visit(_assert_no_recur)
-        return prop
+            )
+            prop.visit(_assert_no_recur)
+            return prop
 
 
 def __deftype_staticmethod(
@@ -1192,28 +1197,29 @@ def __deftype_staticmethod(
     """Emit a node for a :staticmethod member of a deftype* form."""
     with ctx.hide_parent_symbol_table(), ctx.new_symbol_table(method_name):
         has_vargs, fixed_arity, param_nodes = __deftype_method_param_bindings(ctx, args)
-        with ctx.expr_pos():
-            stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
-        method = DefTypeStaticMethodArity(
-            form=form,
-            name=method_name,
-            params=vec.vector(param_nodes),
-            fixed_arity=fixed_arity,
-            is_variadic=has_vargs,
-            kwarg_support=kwarg_support,
-            body=Do(
-                form=form.rest,
-                statements=vec.vector(stmts),
-                ret=ret,
-                is_body=True,
-                # Use the argument vector or first body statement, whichever
-                # exists, for metadata.
+        with ctx.new_func_ctx(FunctionContext.STATICMETHOD):
+            with ctx.expr_pos():
+                stmts, ret = _body_ast(ctx, runtime.nthrest(form, 2))
+            method = DefTypeStaticMethodArity(
+                form=form,
+                name=method_name,
+                params=vec.vector(param_nodes),
+                fixed_arity=fixed_arity,
+                is_variadic=has_vargs,
+                kwarg_support=kwarg_support,
+                body=Do(
+                    form=form.rest,
+                    statements=vec.vector(stmts),
+                    ret=ret,
+                    is_body=True,
+                    # Use the argument vector or first body statement, whichever
+                    # exists, for metadata.
+                    env=ctx.get_node_env(),
+                ),
                 env=ctx.get_node_env(),
-            ),
-            env=ctx.get_node_env(),
-        )
-        method.visit(_assert_no_recur)
-        return method
+            )
+            method.visit(_assert_no_recur)
+            return method
 
 
 def __deftype_prop_or_method_arity(  # pylint: disable=too-many-branches
@@ -1802,7 +1808,9 @@ def _fn_ast(  # pylint: disable=too-many-branches
                 form=form,
             )
 
-        with ctx.new_func_ctx(is_async=is_async):
+        with ctx.new_func_ctx(
+            FunctionContext.ASYNC_FUNCTION if is_async else FunctionContext.FUNCTION
+        ):
             if isinstance(arity_or_args, llist.List):
                 arities = vec.vector(
                     map(

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -3045,6 +3045,7 @@ def __resolve_bare_symbol(
             env=ctx.get_node_env(pos=ctx.syntax_position),
         )
 
+    # Allow users to resolve imported module names directly
     maybe_import = current_ns.get_import(form)
     if maybe_import is not None:
         return MaybeClass(

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -283,7 +283,17 @@ class SymbolTable:
 
     @property
     def context_boundary(self) -> "SymbolTable":
-        """"""
+        """Return the nearest context boundary parent symbol table to this one. If the
+        current table is a context boundary, it will be returned directly.
+
+        Context boundary symbol tables are symbol tables defined at the top level for
+        major Python execution boundaries, such as modules (namespaces), functions
+        (sync and async), and methods.
+
+        Certain symbols (such as imports) are globally available in the execution
+        context they are defined in once they have been created, context boundary
+        symbol tables serve as the anchor points where we hoist these global symbols
+        so they do not go out of scope when the table frame is popped."""
         if self._is_context_boundary:
             return self
         assert self._parent is not None, ""

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -296,7 +296,9 @@ class SymbolTable:
         so they do not go out of scope when the table frame is popped."""
         if self._is_context_boundary:
             return self
-        assert self._parent is not None, ""
+        assert (
+            self._parent is not None
+        ), "Top symbol table must always be a context boundary"
         return self._parent.context_boundary
 
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -3016,6 +3016,15 @@ def __resolve_bare_symbol(
             env=ctx.get_node_env(pos=ctx.syntax_position),
         )
 
+    maybe_import = current_ns.get_import(form)
+    if maybe_import is not None:
+        return MaybeClass(
+            form=form,
+            class_=munge(form.name),
+            target=maybe_import,
+            env=ctx.get_node_env(pos=ctx.syntax_position),
+        )
+
     if ctx.should_allow_unresolved_symbols:
         return _const_node(ctx, form)
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -131,7 +131,7 @@ _MULTI_ARITY_ARG_NAME = "multi_arity_args"
 _SET_BANG_TEMP_PREFIX = "set_bang_val"
 _THROW_PREFIX = "lisp_throw"
 _TRY_PREFIX = "lisp_try"
-_NS_VAR = "__NS"
+_NS_VAR = "_NS"
 
 
 GeneratorException = partial(CompilerException, phase=CompilerPhase.CODE_GENERATION)

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -2393,8 +2393,6 @@ def _require_to_py_ast(_: GeneratorContext, node: Require) -> GeneratedPyAST:
         py_require_alias = _var_ns_as_python_sym(alias.name)
         last = ast.Name(id=py_require_alias, ctx=ast.Load())
 
-        if node.env.func_ctx is not None:
-            deps.append(ast.Global(names=[py_require_alias]))
         deps.append(
             ast.Try(
                 body=[

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1994,17 +1994,13 @@ def _import_to_py_ast(ctx: GeneratorContext, node: Import) -> GeneratedPyAST:
         if alias.alias is not None:
             py_import_alias = munge(alias.alias)
             import_func = _IMPORTLIB_IMPORT_MODULE_FN_NAME
-
-            ctx.symbol_table.new_symbol(
-                sym.symbol(alias.alias), py_import_alias, LocalType.IMPORT
-            )
         else:
             py_import_alias = safe_name.split(".", maxsplit=1)[0]
             import_func = _BUILTINS_IMPORT_FN_NAME
 
-            ctx.symbol_table.new_symbol(
-                sym.symbol(alias.name), py_import_alias, LocalType.IMPORT
-            )
+        ctx.symbol_table.new_symbol(
+            sym.symbol(alias.alias or alias.name), py_import_alias, LocalType.IMPORT
+        )
 
         deps.append(
             ast.Assign(
@@ -2338,7 +2334,7 @@ def _recur_to_py_ast(ctx: GeneratorContext, node: Recur) -> GeneratedPyAST:
 
 
 @_with_ast_loc_deps
-def _require_to_py_ast(_: GeneratorContext, node: Require) -> GeneratedPyAST:
+def _require_to_py_ast(ctx: GeneratorContext, node: Require) -> GeneratedPyAST:
     """Return a Python AST node for a Basilisp `require*` expression.
 
     In Clojure, `require` simply loads the file corresponding to the required
@@ -2376,6 +2372,10 @@ def _require_to_py_ast(_: GeneratorContext, node: Require) -> GeneratedPyAST:
     for alias in node.aliases:
         py_require_alias = _var_ns_as_python_sym(alias.name)
         last = ast.Name(id=py_require_alias, ctx=ast.Load())
+
+        ctx.symbol_table.new_symbol(
+            sym.symbol(alias.alias or alias.name), py_require_alias, LocalType.REQUIRE
+        )
         deps.append(
             ast.Try(
                 body=[

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1978,7 +1978,7 @@ def _if_to_py_ast(ctx: GeneratorContext, node: If) -> GeneratedPyAST:
 
 
 @_with_ast_loc_deps
-def _import_to_py_ast(_: GeneratorContext, node: Import) -> GeneratedPyAST:
+def _import_to_py_ast(ctx: GeneratorContext, node: Import) -> GeneratedPyAST:
     """Return a Python AST node for a Basilisp `import*` expression."""
     assert node.op == NodeOp.IMPORT
 
@@ -1994,9 +1994,17 @@ def _import_to_py_ast(_: GeneratorContext, node: Import) -> GeneratedPyAST:
         if alias.alias is not None:
             py_import_alias = munge(alias.alias)
             import_func = _IMPORTLIB_IMPORT_MODULE_FN_NAME
+
+            ctx.symbol_table.new_symbol(
+                sym.symbol(alias.alias), py_import_alias, LocalType.IMPORT
+            )
         else:
             py_import_alias = safe_name.split(".", maxsplit=1)[0]
             import_func = _BUILTINS_IMPORT_FN_NAME
+
+            ctx.symbol_table.new_symbol(
+                sym.symbol(alias.name), py_import_alias, LocalType.IMPORT
+            )
 
         deps.append(
             ast.Assign(

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -188,7 +188,9 @@ class SymbolTable:
         so they do not go out of scope when the table frame is popped."""
         if self._is_context_boundary:
             return self
-        assert self._parent is not None, ""
+        assert (
+            self._parent is not None
+        ), "Top symbol table must always be a context boundary"
         return self._parent.context_boundary
 
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -175,7 +175,17 @@ class SymbolTable:
 
     @property
     def context_boundary(self) -> "SymbolTable":
-        """"""
+        """Return the nearest context boundary parent symbol table to this one. If the
+        current table is a context boundary, it will be returned directly.
+
+        Context boundary symbol tables are symbol tables defined at the top level for
+        major Python execution boundaries, such as modules (namespaces), functions
+        (sync and async), and methods.
+
+        Certain symbols (such as imports) are globally available in the execution
+        context they are defined in once they have been created, context boundary
+        symbol tables serve as the anchor points where we hoist these global symbols
+        so they do not go out of scope when the table frame is popped."""
         if self._is_context_boundary:
             return self
         assert self._parent is not None, ""

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -185,7 +185,7 @@ class SymbolTable:
         Certain symbols (such as imports) are globally available in the execution
         context they are defined in once they have been created, context boundary
         symbol tables serve as the anchor points where we hoist these global symbols
-        so they do not go out of scope when the table frame is popped."""
+        so they do not go out of scope when the local table frame is popped."""
         if self._is_context_boundary:
             return self
         assert (
@@ -2354,7 +2354,7 @@ def _recur_to_py_ast(ctx: GeneratorContext, node: Recur) -> GeneratedPyAST:
 
 
 @_with_ast_loc_deps
-def _require_to_py_ast(ctx: GeneratorContext, node: Require) -> GeneratedPyAST:
+def _require_to_py_ast(_: GeneratorContext, node: Require) -> GeneratedPyAST:
     """Return a Python AST node for a Basilisp `require*` expression.
 
     In Clojure, `require` simply loads the file corresponding to the required
@@ -2393,9 +2393,6 @@ def _require_to_py_ast(ctx: GeneratorContext, node: Require) -> GeneratedPyAST:
         py_require_alias = _var_ns_as_python_sym(alias.name)
         last = ast.Name(id=py_require_alias, ctx=ast.Load())
 
-        ctx.symbol_table.context_boundary.new_symbol(
-            sym.symbol(alias.alias or alias.name), py_require_alias, LocalType.REQUIRE
-        )
         if node.env.func_ctx is not None:
             deps.append(ast.Global(names=[py_require_alias]))
         deps.append(

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -272,7 +272,7 @@ NodeMeta = Union[None, "Const", "Map"]
 LoopID = str
 
 
-class FunctionContext:
+class FunctionContext(Enum):
     FUNCTION = kw.keyword("function")
     ASYNC_FUNCTION = kw.keyword("async-function")
     METHOD = kw.keyword("method")

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -296,7 +296,6 @@ class LocalType(Enum):
     LET = kw.keyword("let")
     LETFN = kw.keyword("letfn")
     LOOP = kw.keyword("loop")
-    REQUIRE = kw.keyword("require")
     THIS = kw.keyword("this")
 
 

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -272,6 +272,15 @@ NodeMeta = Union[None, "Const", "Map"]
 LoopID = str
 
 
+class FunctionContext:
+    FUNCTION = kw.keyword("function")
+    ASYNC_FUNCTION = kw.keyword("async-function")
+    METHOD = kw.keyword("method")
+    CLASSMETHOD = kw.keyword("classmethod")
+    STATICMETHOD = kw.keyword("staticmethod")
+    PROPERTY = kw.keyword("property")
+
+
 class KeywordArgSupport(Enum):
     APPLY_KWARGS = kw.keyword("apply")
     COLLECT_KWARGS = kw.keyword("collect")

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -296,6 +296,7 @@ class LocalType(Enum):
     LET = kw.keyword("let")
     LETFN = kw.keyword("letfn")
     LOOP = kw.keyword("loop")
+    REQUIRE = kw.keyword("require")
     THIS = kw.keyword("this")
 
 

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -307,6 +307,7 @@ class NodeEnv:
     line: Optional[int] = None
     col: Optional[int] = None
     pos: Optional[NodeSyntacticPosition] = None
+    func_ctx: Optional[FunctionContext] = None
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -371,7 +372,6 @@ class Def(Node[SpecialForm]):
     var: Var
     init: Optional[Node]
     doc: Optional[str]
-    in_func_ctx: bool
     env: NodeEnv
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.Vector.empty()

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -292,6 +292,7 @@ class LocalType(Enum):
     DEFTYPE = kw.keyword("deftype")
     FIELD = kw.keyword("field")
     FN = kw.keyword("fn")
+    IMPORT = kw.keyword("import")
     LET = kw.keyword("let")
     LETFN = kw.keyword("letfn")
     LOOP = kw.keyword("loop")

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1656,13 +1656,13 @@ def init_ns_var() -> Var:
 def bootstrap_core(compiler_opts: CompilerOpts) -> None:
     """Bootstrap the environment with functions that are either difficult to express
     with the very minimal Lisp environment or which are expected by the compiler."""
-    __NS = Maybe(Var.find(NS_VAR_SYM)).or_else_raise(
+    _NS = Maybe(Var.find(NS_VAR_SYM)).or_else_raise(
         lambda: RuntimeException(f"Dynamic Var {NS_VAR_SYM} not bound!")
     )
 
     def in_ns(s: sym.Symbol):
         ns = Namespace.get_or_create(s)
-        __NS.value = ns
+        _NS.value = ns
         return ns
 
     # Vars used in bootstrapping the runtime

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -4270,12 +4270,20 @@ class TestSymbolResolution:
             "(import* abc) abc",
             "(do (import* abc) abc)",
             "((fn [] (import* abc) abc))",
+            "((fn [] (import* abc))) abc",
             """
             (import* collections.abc)
             (deftype* Importer []
               :implements [collections.abc/Callable]
               (--call-- [this] (import* abc) abc))
             ((Importer))""",
+            """
+            (import* collections.abc)
+            (deftype* Importer []
+              :implements [collections.abc/Callable]
+              (--call-- [this] (import* abc)))
+            ((Importer))
+            abc""",
         ],
     )
     def test_imported_module_sym_resolves(self, lcompile: CompileFn, code: str):
@@ -4290,12 +4298,20 @@ class TestSymbolResolution:
             "(import* abc) abc/ABC",
             "(do (import* abc) abc/ABC)",
             "((fn [] (import* abc) abc/ABC))",
+            "((fn [] (import* abc))) abc/ABC",
             """
             (import* collections.abc)
             (deftype* Importer []
               :implements [collections.abc/Callable]
               (--call-- [this] (import* abc) abc/ABC))
             ((Importer))""",
+            """
+            (import* collections.abc)
+            (deftype* Importer []
+              :implements [collections.abc/Callable]
+              (--call-- [this] (import* abc)))
+            ((Importer))
+            abc/ABC""",
         ],
     )
     def test_sym_from_import_resolves(self, lcompile: CompileFn, code: str):


### PR DESCRIPTION
This PR introduces the concept of a "context boundary" Symbol Table into the analyzer. Such Symbol Tables are defined at the top level of execution contexts such as modules (namespaces), functions (sync and async), and methods. Because imports are globally available once they have been called, we hoist imported symbols to the nearest context boundary Symbol Table, which is considerably different from the standard `let` style case, where a name becomes unavailable after it goes out of scope.

Fixes #544