### PR TITLE
Include the Function or Method context in the AST Node environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for calling Python functions and methods with keyword arguments (#531)
  * Added support for Lisp functions being called with keyword arguments (#528)
  * Added support for multi-arity methods on `deftype`s (#534)
- * Added metadata about the function or method context of a Lisp AST node in the `NodeEnv`
+ * Added metadata about the function or method context of a Lisp AST node in the `NodeEnv` (#548)
 
 ### Fixed
  * Fixed a bug where the Basilisp AST nodes for return values of `deftype` members could be marked as _statements_ rather than _expressions_, resulting in an incorrect `nil` return (#523)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for calling Python functions and methods with keyword arguments (#531)
  * Added support for Lisp functions being called with keyword arguments (#528)
  * Added support for multi-arity methods on `deftype`s (#534)
+ * Added metadata about the function or method context of a Lisp AST node in the `NodeEnv`
 
 ### Fixed
  * Fixed a bug where the Basilisp AST nodes for return values of `deftype` members could be marked as _statements_ rather than _expressions_, resulting in an incorrect `nil` return (#523)

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -2336,7 +2336,7 @@ def _recur_to_py_ast(ctx: GeneratorContext, node: Recur) -> GeneratedPyAST:
 
 
 @_with_ast_loc_deps
-def _require_to_py_ast(ctx: GeneratorContext, node: Require) -> GeneratedPyAST:
+def _require_to_py_ast(_: GeneratorContext, node: Require) -> GeneratedPyAST:
     """Return a Python AST node for a Basilisp `require*` expression.
 
     In Clojure, `require` simply loads the file corresponding to the required

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -272,6 +272,15 @@ NodeMeta = Union[None, "Const", "Map"]
 LoopID = str
 
 
+class FunctionContext(Enum):
+    FUNCTION = kw.keyword("function")
+    ASYNC_FUNCTION = kw.keyword("async-function")
+    METHOD = kw.keyword("method")
+    CLASSMETHOD = kw.keyword("classmethod")
+    STATICMETHOD = kw.keyword("staticmethod")
+    PROPERTY = kw.keyword("property")
+
+
 class KeywordArgSupport(Enum):
     APPLY_KWARGS = kw.keyword("apply")
     COLLECT_KWARGS = kw.keyword("collect")
@@ -296,6 +305,7 @@ class NodeEnv:
     line: Optional[int] = None
     col: Optional[int] = None
     pos: Optional[NodeSyntacticPosition] = None
+    func_ctx: Optional[FunctionContext] = None
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -360,7 +370,6 @@ class Def(Node[SpecialForm]):
     var: Var
     init: Optional[Node]
     doc: Optional[str]
-    in_func_ctx: bool
     env: NodeEnv
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.Vector.empty()

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1656,13 +1656,13 @@ def init_ns_var() -> Var:
 def bootstrap_core(compiler_opts: CompilerOpts) -> None:
     """Bootstrap the environment with functions that are either difficult to express
     with the very minimal Lisp environment or which are expected by the compiler."""
-    __NS = Maybe(Var.find(NS_VAR_SYM)).or_else_raise(
+    _NS = Maybe(Var.find(NS_VAR_SYM)).or_else_raise(
         lambda: RuntimeException(f"Dynamic Var {NS_VAR_SYM} not bound!")
     )
 
     def in_ns(s: sym.Symbol):
         ns = Namespace.get_or_create(s)
-        __NS.value = ns
+        _NS.value = ns
         return ns
 
     # Vars used in bootstrapping the runtime


### PR DESCRIPTION
This PR is a set of otherwise-independent changes I pulled out of #547. It includes the following changes:
 * The titular Function/Method context stored in the `NodeEnv` object of Lisp AST nodes
 * Changing the generated module-wide `__NS` variable to `_NS` because I learned that variables prefixed by double underscores are [always mangled](https://bugs.python.org/issue27793) in a class lexical context in Python regardless of the presence of a `global` statement.
 * Added a few tests for asserting the resolution of `def`'ed Basilisp Vars match the expected behavior from Clojure

Fixes #548 