### PR TITLE
Couple of small performance improvements

### DIFF
--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -77,7 +77,10 @@ def complete(
 def keyword(name: str, ns: Optional[str] = None) -> Keyword:
     """Create a new keyword with name and optional namespace.
 
-    Keywords are stored in a global cache by their hash"""
+    Keywords are stored in a global cache by their hash. If a keyword with the same
+    hash already exists in the cache, that keyword will be returned. If no keyword
+    exists in the global cache, one will be created, entered into the cache, and then
+    returned."""
     global _INTERN
 
     h = hash((name, ns))

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -2,7 +2,7 @@ import threading
 from typing import Iterable, Optional
 
 import basilisp.lang.map as lmap
-from basilisp.lang.interfaces import IAssociative, ILispObject, IPersistentMap
+from basilisp.lang.interfaces import IAssociative, ILispObject
 
 _LOCK = threading.Lock()
 _INTERN: lmap.Map[int, "Keyword"] = lmap.Map.empty()

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -73,6 +73,15 @@ class Map(IPersistentMap[K, V], ILispObject, IWithMeta):
     def values(self):
         return self._inner.values()
 
+    def iteritems(self):
+        return self._inner.iteritems()
+
+    def iterkeys(self):
+        return self._inner.iterkeys()
+
+    def itervalues(self):
+        return self._inner.itervalues()
+
     @property
     def meta(self) -> Optional[IPersistentMap]:
         return self._meta

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -140,7 +140,8 @@ def seq_lrepr(
     return f"{start}{seq_lrepr}{end}"
 
 
-def lrepr(  # pylint: disable=too-many-arguments
+@singledispatch
+def lrepr(  # pylint: disable=too-many-arguments,unused-arguments
     o: Any,
     human_readable: bool = False,
     print_dup: bool = PRINT_DUP,
@@ -170,29 +171,11 @@ def lrepr(  # pylint: disable=too-many-arguments
     runtime to the basilisp.core dynamic variables which correspond to each
     of the keyword arguments to this function. To use a version of lrepr
     which does capture those values, call basilisp.lang.runtime.lrepr directly."""
-    if isinstance(o, LispObject):
-        return o._lrepr(
-            human_readable=human_readable,
-            print_dup=print_dup,
-            print_length=print_length,
-            print_level=print_level,
-            print_meta=print_meta,
-            print_readably=print_readably,
-        )
-    else:  # pragma: no cover
-        return _lrepr_fallback(
-            o,
-            human_readable=human_readable,
-            print_dup=print_dup,
-            print_length=print_length,
-            print_level=print_level,
-            print_meta=print_meta,
-            print_readably=print_readably,
-        )
+    return repr(o)
 
 
-@singledispatch
-def _lrepr_fallback(  # pylint: disable=too-many-arguments
+@lrepr.register(LispObject)
+def _lrepr_lisp_obj(  # pylint: disable=too-many-arguments
     o: Any,
     human_readable: bool = False,
     print_dup: bool = PRINT_DUP,
@@ -201,62 +184,27 @@ def _lrepr_fallback(  # pylint: disable=too-many-arguments
     print_meta: bool = PRINT_META,
     print_readably: bool = PRINT_READABLY,
 ) -> str:  # pragma: no cover
-    """Fallback function for lrepr for subclasses of standard types.
-
-    The singledispatch used for standard lrepr dispatches using an exact
-    type match on the first argument, so we will only hit this function
-    for subclasses of common Python types like strings or lists."""
-    kwargs = {
-        "human_readable": human_readable,
-        "print_dup": print_dup,
-        "print_length": print_length,
-        "print_level": print_level,
-        "print_meta": print_meta,
-        "print_readably": print_readably,
-    }
-    if isinstance(o, bool):
-        return _lrepr_bool(o)
-    elif o is None:
-        return _lrepr_nil(o)
-    elif isinstance(o, str):
-        return _lrepr_str(
-            o, human_readable=human_readable, print_readably=print_readably
-        )
-    elif isinstance(o, dict):
-        return _lrepr_py_dict(o, **kwargs)
-    elif isinstance(o, list):
-        return _lrepr_py_list(o, **kwargs)
-    elif isinstance(o, set):
-        return _lrepr_py_set(o, **kwargs)
-    elif isinstance(o, tuple):
-        return _lrepr_py_tuple(o, **kwargs)
-    elif isinstance(o, complex):
-        return _lrepr_complex(o)
-    elif isinstance(o, datetime.datetime):
-        return _lrepr_datetime(o)
-    elif isinstance(o, Decimal):
-        return _lrepr_decimal(o, print_dup=print_dup)
-    elif isinstance(o, Fraction):
-        return _lrepr_fraction(o)
-    elif isinstance(o, Pattern):
-        return _lrepr_pattern(o)
-    elif isinstance(o, uuid.UUID):
-        return _lrepr_uuid(o)
-    else:
-        return repr(o)
+    return o._lrepr(
+        human_readable=human_readable,
+        print_dup=print_dup,
+        print_length=print_length,
+        print_level=print_level,
+        print_meta=print_meta,
+        print_readably=print_readably,
+    )
 
 
-@_lrepr_fallback.register(bool)
+@lrepr.register(bool)
 def _lrepr_bool(o: bool, **_) -> str:
     return repr(o).lower()
 
 
-@_lrepr_fallback.register(type(None))
+@lrepr.register(type(None))
 def _lrepr_nil(_: None, **__) -> str:
     return "nil"
 
 
-@_lrepr_fallback.register(str)
+@lrepr.register(str)
 def _lrepr_str(
     o: str, human_readable: bool = False, print_readably: bool = PRINT_READABLY, **_
 ) -> str:
@@ -267,53 +215,53 @@ def _lrepr_str(
     return f'"{o.encode("unicode_escape").decode("utf-8")}"'
 
 
-@_lrepr_fallback.register(list)
+@lrepr.register(list)
 def _lrepr_py_list(o: list, **kwargs) -> str:
     return f"#py {seq_lrepr(o, '[', ']', **kwargs)}"
 
 
-@_lrepr_fallback.register(dict)
+@lrepr.register(dict)
 def _lrepr_py_dict(o: dict, **kwargs) -> str:
     return f"#py {map_lrepr(o.items, '{', '}', **kwargs)}"
 
 
-@_lrepr_fallback.register(set)
+@lrepr.register(set)
 def _lrepr_py_set(o: set, **kwargs) -> str:
     return f"#py {seq_lrepr(o, '#{', '}', **kwargs)}"
 
 
-@_lrepr_fallback.register(tuple)
+@lrepr.register(tuple)
 def _lrepr_py_tuple(o: tuple, **kwargs) -> str:
     return f"#py {seq_lrepr(o, '(', ')', **kwargs)}"
 
 
-@_lrepr_fallback.register(complex)
+@lrepr.register(complex)
 def _lrepr_complex(o: complex, **_) -> str:
     return repr(o).upper()
 
 
-@_lrepr_fallback.register(datetime.datetime)
+@lrepr.register(datetime.datetime)
 def _lrepr_datetime(o: datetime.datetime, **_) -> str:
     return f'#inst "{o.isoformat()}"'
 
 
-@_lrepr_fallback.register(Decimal)
+@lrepr.register(Decimal)
 def _lrepr_decimal(o: Decimal, print_dup: bool = PRINT_DUP, **_) -> str:
     if print_dup:
         return f"{str(o)}M"
     return str(o)
 
 
-@_lrepr_fallback.register(Fraction)
+@lrepr.register(Fraction)
 def _lrepr_fraction(o: Fraction, **_) -> str:
     return f"{o.numerator}/{o.denominator}"
 
 
-@_lrepr_fallback.register(type(re.compile("")))
+@lrepr.register(type(re.compile("")))
 def _lrepr_pattern(o: Pattern, **_) -> str:
     return f'#"{o.pattern}"'
 
 
-@_lrepr_fallback.register(uuid.UUID)
+@lrepr.register(uuid.UUID)
 def _lrepr_uuid(o: uuid.UUID, **_) -> str:
     return f'#uuid "{str(o)}"'

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -140,8 +140,9 @@ def seq_lrepr(
     return f"{start}{seq_lrepr}{end}"
 
 
+# pylint: disable=unused-argument
 @singledispatch
-def lrepr(  # pylint: disable=too-many-arguments,unused-arguments
+def lrepr(  # pylint: disable=too-many-arguments
     o: Any,
     human_readable: bool = False,
     print_dup: bool = PRINT_DUP,

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -231,22 +231,22 @@ def _py_from_lisp(
     raise SyntaxError(f"Unrecognized Python type: {type(form)}")
 
 
-@_py_from_lisp.register(llist.List)
+@_py_from_lisp.register(IPersistentList)
 def _py_tuple_from_list(form: llist.List) -> tuple:
     return tuple(form)
 
 
-@_py_from_lisp.register(lmap.Map)
+@_py_from_lisp.register(IPersistentMap)
 def _py_dict_from_map(form: lmap.Map) -> dict:
     return dict(form)
 
 
-@_py_from_lisp.register(lset.Set)
+@_py_from_lisp.register(IPersistentSet)
 def _py_set_from_set(form: lset.Set) -> set:
     return set(form)
 
 
-@_py_from_lisp.register(vector.Vector)
+@_py_from_lisp.register(IPersistentVector)
 def _py_list_from_vec(form: vector.Vector) -> list:
     return list(form)
 

--- a/tests/basilisp/keyword_test.py
+++ b/tests/basilisp/keyword_test.py
@@ -64,25 +64,25 @@ def test_keyword_pickleability(pickle_protocol: int, o: Keyword):
 
 class TestKeywordCompletion:
     @pytest.fixture
-    def empty_cache(self) -> Atom["PMap[int, Keyword]"]:
-        return Atom(pmap())
+    def empty_cache(self) -> lmap.Map[int, Keyword]:
+        return lmap.Map.empty()
 
-    def test_empty_cache_no_completion(self, empty_cache: Atom["PMap[int, Keyword]"]):
+    def test_empty_cache_no_completion(self, empty_cache: lmap.Map[int, Keyword]):
         assert [] == list(complete(":", kw_cache=empty_cache))
 
     @pytest.fixture
-    def cache(self) -> Atom["PMap[int, Keyword]"]:
+    def cache(self) -> lmap.Map[int, Keyword]:
         values = [Keyword("kw"), Keyword("ns"), Keyword("kw", ns="ns")]
-        return Atom(pmap({hash(v): v for v in values}))
+        return lmap.map({hash(v): v for v in values})
 
-    def test_no_ns_completion(self, cache: Atom["PMap[int, Keyword]"]):
+    def test_no_ns_completion(self, cache: lmap.Map[int, Keyword]):
         assert [] == list(complete(":v", kw_cache=cache))
         assert {":kw", ":ns/kw"} == set(complete(":k", kw_cache=cache))
         assert {":kw", ":ns/kw"} == set(complete(":kw", kw_cache=cache))
         assert {":ns", ":ns/kw"} == set(complete(":n", kw_cache=cache))
         assert {":ns", ":ns/kw"} == set(complete(":ns", kw_cache=cache))
 
-    def test_ns_completion(self, cache: Atom["PMap[int, Keyword]"]):
+    def test_ns_completion(self, cache: lmap.Map[int, Keyword]):
         assert [] == list(complete(":v/", kw_cache=cache))
         assert [] == list(complete(":k/", kw_cache=cache))
         assert [] == list(complete(":kw/", kw_cache=cache))


### PR DESCRIPTION
 * Correctly use `functools.singledispatch`. Rather than checking `isinstance()` manually and then dispatching to a secondary function via `singledispatch` (_and_ having a backup function with thousands of pointless `isinstance()` branches), I've corrected all of the relevant uses to use `singledispatch` correctly since it's capable of using the object MRO to find the most appropriate implementation.

 * Update the Keyword intern cache to just use a simple `threading.Lock` instance rather than using an Atom, since the performance is much better.