### PR TITLE
Convert Map to use `immutables.Map` rather than `pyrsistent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for Volatiles (#460)
  * Add JSON encoder and decoder in `basilisp.json` namespace (#484)
 
+### Changed
+ * Basilisp set and map types are now backed by the HAMT provided by `immutables` (#557)
+
 ### Fixed
  * Fixed a bug where the Basilisp AST nodes for return values of `deftype` members could be marked as _statements_ rather than _expressions_, resulting in an incorrect `nil` return (#523)
  * Fixed a bug where `defonce` would throw a Python SyntaxError due to a superfluous `global` statement in the generated Python (#525)
@@ -27,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed a bug where not all builtin Basilisp types could be pickled (#518)
  * Fixed a bug where `deftype` forms could not be created interfaces declared not at the top-level of a code block in a namespace (#376)
  * Fixed multiple bugs relating to symbol resolution of `import`ed symbols in various contexts (#544)
+ * Fixed a bug where the `=` function did not respect the equality partition for various builtin collection types (#556)
 
 ## [v0.1.dev13] - 2020-03-16
 ### Added

--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ pyfunctional = "*"
 pyrsistent = "*"
 python-dateutil = "*"
 pytest = "*"
+immutables = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "efb4a5f10d963a10c5ac384bc0f9665df172d51147422fe477f30c96ab62465a"
+            "sha256": "c496b6e77ba4cbec0aa1f96310a7b6b3760c96009adea0c81b81297613adf5d3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -81,15 +81,34 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
+        },
+        "immutables": {
+            "hashes": [
+                "sha256:1c11050c49e193a1ec9dda1747285333f6ba6a30bbeb2929000b9b1192097ec0",
+                "sha256:33ce2f977da7b5e0dddd93744862404bdb316ffe5853ec853e53141508fa2e6a",
+                "sha256:6c8eace4d98988c72bcb37c05e79aae756832738305ae9497670482a82db08bc",
+                "sha256:714aedbdeba4439d91cb5e5735cb10631fc47a7a69ea9cc8ecbac90322d50a4a",
+                "sha256:860666fab142401a5535bf65cbd607b46bc5ed25b9d1eb053ca8ed9a1a1a80d6",
+                "sha256:8797eed4042f4626b0bc04d9cf134208918eb0c937a8193a2c66df5041e62d2e",
+                "sha256:a0a1cc238b678455145bae291d8426f732f5255537ed6a5b7645949704c70a78",
+                "sha256:ab6c18b7b2b2abc83e0edc57b0a38bf0915b271582a1eb8c7bed1c20398f8040",
+                "sha256:c099212fd6504513a50e7369fe281007c820cf9d7bb22a336486c63d77d6f0b2",
+                "sha256:c453e12b95e1d6bb4909e8743f88b7f5c0c97b86a8bc0d73507091cb644e3c1e",
+                "sha256:ce01788878827c3f0331c254a4ad8d9721489a5e65cc43e19c80040b46e0d297",
+                "sha256:ef9da20ec0f1c5853b5c8f8e3d9e1e15b8d98c259de4b7515d789a606af8745e"
+            ],
+            "index": "pypi",
+            "version": "==0.14"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
+                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.6.1"
         },
         "importlib-resources": {
             "hashes": [
@@ -104,6 +123,7 @@
                 "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
                 "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==8.3.0"
         },
         "packaging": {
@@ -111,6 +131,7 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pluggy": {
@@ -118,6 +139,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "prompt-toolkit": {
@@ -133,6 +155,7 @@
                 "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
                 "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.8.1"
         },
         "pyfunctional": {
@@ -146,10 +169,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pyrsistent": {
             "hashes": [
@@ -160,11 +184,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
-                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
+                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
+                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
             ],
             "index": "pypi",
-            "version": "==5.4.2"
+            "version": "==5.4.3"
         },
         "python-dateutil": {
             "hashes": [
@@ -179,6 +203,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "tabulate": {
@@ -197,24 +222,26 @@
         },
         "tox": {
             "hashes": [
-                "sha256:322dfdf007d7d53323f767badcb068a5cfa7c44d8aabb698d131b28cf44e62c4",
-                "sha256:8c9ad9b48659d291c5bc78bcabaa4d680d627687154b812fa52baedaa94f9f83"
+                "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e",
+                "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"
             ],
-            "version": "==3.15.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.15.2"
         },
         "virtualenv": {
             "hashes": [
                 "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf",
                 "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.0.21"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
+                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
             ],
-            "version": "==0.1.9"
+            "version": "==0.2.4"
         },
         "zipp": {
             "hashes": [
@@ -253,6 +280,7 @@
                 "sha256:1aac2ae2d0d8ea368fa90906567f5c08463d98ade155c0c4bfedd6a0f7160e38",
                 "sha256:d670ea0b10f8b723672d3a6abeb87b565b244da220d76b4dba1b66269ec152d4"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.0"
         },
         "black": {
@@ -268,14 +296,15 @@
                 "sha256:2bce3d8fab545a6528c8fa5d9f9ae8ebc85a56da365c7f85180bfe96a35ef22f",
                 "sha256:3c4c520fdb9db59ef139915a5db79f8b51bc2a7257ea0389f30c846883430a4b"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==3.1.5"
         },
         "certifi": {
             "hashes": [
-                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
-                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+                "sha256:5ad7e9a056d25ffa5082862e36f119f7f7cec6457fa07ee2f8c339814b80c9b1",
+                "sha256:9cd41137dc19af6a5e03b630eefe7d1f458d964d406342dd3edf625839b944cc"
             ],
-            "version": "==2020.4.5.1"
+            "version": "==2020.4.5.2"
         },
         "chardet": {
             "hashes": [
@@ -301,6 +330,7 @@
         "docutils": {
             "hashes": [
                 "sha256:54a349c622ff31c91cbec43b0b512f113b5b24daf00e2ea530bb1bd9aac14849",
+                "sha256:ba4584f9107571ced0d2c7f56a5499c696215ba90797849c92d395979da68521",
                 "sha256:d2ddba74835cb090a1b627d3de4e7835c628d07ee461f7b4480f51af2fe4d448"
             ],
             "index": "pypi",
@@ -318,6 +348,7 @@
                 "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9"
         },
         "imagesize": {
@@ -325,15 +356,16 @@
                 "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
                 "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f",
-                "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"
+                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
+                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==1.6.0"
+            "version": "==1.6.1"
         },
         "importlib-resources": {
             "hashes": [
@@ -353,50 +385,65 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:c10142f819c2d22bdcd17548c46fa9b77cf4fda45097854c689666bf425e7484",
-                "sha256:c922560ac46888d47384de1dbdc3daaa2ea993af4b26a436dec31fa2c19ec668"
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.2"
         },
         "keyring": {
             "hashes": [
                 "sha256:3401234209015144a5d75701e71cb47239e552b0882313e9f51e8976f9e27843",
                 "sha256:c53e0e5ccde3ad34284a40ce7976b5b3a3d6de70344c3f8ee44364cc340976ec"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==21.2.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:06358015a4dee8ee23ae426bf885616ab3963622defd829eb45b44e3dee3515f",
-                "sha256:0b0c4fc852c5f02c6277ef3b33d23fcbe89b1b227460423e3335374da046b6db",
-                "sha256:267677fc42afed5094fc5ea1c4236bbe4b6a00fe4b08e93451e65ae9048139c7",
-                "sha256:303cb70893e2c345588fb5d5b86e0ca369f9bb56942f03064c5e3e75fa7a238a",
-                "sha256:3c9b624a0d9ed5a5093ac4edc4e823e6b125441e60ef35d36e6f4a6fdacd5054",
-                "sha256:42033e14cae1f6c86fc0c3e90d04d08ce73ac8e46ba420a0d22d545c2abd4977",
-                "sha256:4e4a99b6af7bdc0856b50020c095848ec050356a001e1f751510aef6ab14d0e0",
-                "sha256:4eb07faad54bb07427d848f31030a65a49ebb0cec0b30674f91cf1ddd456bfe4",
-                "sha256:63a7161cd8c2bc563feeda45df62f42c860dd0675e2b8da2667f25bb3c95eaba",
-                "sha256:68e0fd039b68d2945b4beb947d4023ca7f8e95b708031c345762efba214ea761",
-                "sha256:8092a63397025c2f655acd42784b2a1528339b90b987beb9253f22e8cdbb36c3",
-                "sha256:841218860683c0f2223e24756843d84cc49cccdae6765e04962607754a52d3e0",
-                "sha256:94076b2314bd2f6cfae508ad65b4d493e3a58a50112b7a2cbb6287bdbc404ae8",
-                "sha256:9d22aff1c5322e402adfb3ce40839a5056c353e711c033798cf4f02eb9f5124d",
-                "sha256:b0e4584f62b3e5f5c1a7bcefd2b52f236505e6ef032cc508caa4f4c8dc8d3af1",
-                "sha256:b1163ffc1384d242964426a8164da12dbcdbc0de18ea36e2c34b898ed38c3b45",
-                "sha256:beac28ed60c8e838301226a7a85841d0af2068eba2dcb1a58c2d32d6c05e440e",
-                "sha256:c29f096ce79c03054a1101d6e5fe6bf04b0bb489165d5e0e9653fb4fe8048ee1",
-                "sha256:c58779966d53e5f14ba393d64e2402a7926601d1ac8adeb4e83893def79d0428",
-                "sha256:cfe14b37908eaf7d5506302987228bff69e1b8e7071ccd4e70fd0283b1b47f0b",
-                "sha256:e834249c45aa9837d0753351cdca61a4b8b383cc9ad0ff2325c97ff7b69e72a6",
-                "sha256:eed1b234c4499811ee85bcefa22ef5e466e75d132502226ed29740d593316c1f"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
-            "version": "==2.0.0a1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.1"
         },
         "more-itertools": {
             "hashes": [
                 "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be",
                 "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==8.3.0"
         },
         "packaging": {
@@ -404,6 +451,7 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pathspec": {
@@ -425,6 +473,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -432,6 +481,7 @@
                 "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
                 "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.8.1"
         },
         "pygments": {
@@ -444,18 +494,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:67199f0c41a9c702154efb0e7a8cc08accf830eb003b4d9fa42c4059002e2492",
-                "sha256:700d17888d441604b0bd51535908dcb297561b040819cccde647a92439db5a2a"
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "version": "==3.0.0a1"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
-                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
+                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
+                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
             ],
             "index": "pypi",
-            "version": "==5.4.2"
+            "version": "==5.4.3"
         },
         "pytest-pycharm": {
             "hashes": [
@@ -481,35 +532,36 @@
         },
         "regex": {
             "hashes": [
-                "sha256:1386e75c9d1574f6aa2e4eb5355374c8e55f9aac97e224a8a5a6abded0f9c927",
-                "sha256:27ff7325b297fb6e5ebb70d10437592433601c423f5acf86e5bc1ee2919b9561",
-                "sha256:329ba35d711e3428db6b45a53b1b13a0a8ba07cbbcf10bbed291a7da45f106c3",
-                "sha256:3a9394197664e35566242686d84dfd264c07b20f93514e2e09d3c2b3ffdf78fe",
-                "sha256:51f17abbe973c7673a61863516bdc9c0ef467407a940f39501e786a07406699c",
-                "sha256:579ea215c81d18da550b62ff97ee187b99f1b135fd894a13451e00986a080cad",
-                "sha256:70c14743320a68c5dac7fc5a0f685be63bc2024b062fe2aaccc4acc3d01b14a1",
-                "sha256:7e61be8a2900897803c293247ef87366d5df86bf701083b6c43119c7c6c99108",
-                "sha256:8044d1c085d49673aadb3d7dc20ef5cb5b030c7a4fa253a593dda2eab3059929",
-                "sha256:89d76ce33d3266173f5be80bd4efcbd5196cafc34100fdab814f9b228dee0fa4",
-                "sha256:99568f00f7bf820c620f01721485cad230f3fb28f57d8fbf4a7967ec2e446994",
-                "sha256:a7c37f048ec3920783abab99f8f4036561a174f1314302ccfa4e9ad31cb00eb4",
-                "sha256:c2062c7d470751b648f1cacc3f54460aebfc261285f14bc6da49c6943bd48bdd",
-                "sha256:c9bce6e006fbe771a02bda468ec40ffccbf954803b470a0345ad39c603402577",
-                "sha256:ce367d21f33e23a84fb83a641b3834dd7dd8e9318ad8ff677fbfae5915a239f7",
-                "sha256:ce450ffbfec93821ab1fea94779a8440e10cf63819be6e176eb1973a6017aff5",
-                "sha256:ce5cc53aa9fbbf6712e92c7cf268274eaff30f6bd12a0754e8133d85a8fb0f5f",
-                "sha256:d466967ac8e45244b9dfe302bbe5e3337f8dc4dec8d7d10f5e950d83b140d33a",
-                "sha256:d881c2e657c51d89f02ae4c21d9adbef76b8325fe4d5cf0e9ad62f850f3a98fd",
-                "sha256:e565569fc28e3ba3e475ec344d87ed3cd8ba2d575335359749298a0899fe122e",
-                "sha256:ea55b80eb0d1c3f1d8d784264a6764f931e172480a2f1868f2536444c5f01e01"
+                "sha256:08997a37b221a3e27d68ffb601e45abfb0093d39ee770e4257bd2f5115e8cb0a",
+                "sha256:112e34adf95e45158c597feea65d06a8124898bdeac975c9087fe71b572bd938",
+                "sha256:1700419d8a18c26ff396b3b06ace315b5f2a6e780dad387e4c48717a12a22c29",
+                "sha256:2f6f211633ee8d3f7706953e9d3edc7ce63a1d6aad0be5dcee1ece127eea13ae",
+                "sha256:52e1b4bef02f4040b2fd547357a170fc1146e60ab310cdbdd098db86e929b387",
+                "sha256:55b4c25cbb3b29f8d5e63aeed27b49fa0f8476b0d4e1b3171d85db891938cc3a",
+                "sha256:5aaa5928b039ae440d775acea11d01e42ff26e1561c0ffcd3d805750973c6baf",
+                "sha256:654cb773b2792e50151f0e22be0f2b6e1c3a04c5328ff1d9d59c0398d37ef610",
+                "sha256:690f858d9a94d903cf5cada62ce069b5d93b313d7d05456dbcd99420856562d9",
+                "sha256:6ad8663c17db4c5ef438141f99e291c4d4edfeaacc0ce28b5bba2b0bf273d9b5",
+                "sha256:89cda1a5d3e33ec9e231ece7307afc101b5217523d55ef4dc7fb2abd6de71ba3",
+                "sha256:92d8a043a4241a710c1cf7593f5577fbb832cf6c3a00ff3fc1ff2052aff5dd89",
+                "sha256:95fa7726d073c87141f7bbfb04c284901f8328e2d430eeb71b8ffdd5742a5ded",
+                "sha256:97712e0d0af05febd8ab63d2ef0ab2d0cd9deddf4476f7aa153f76feef4b2754",
+                "sha256:b2ba0f78b3ef375114856cbdaa30559914d081c416b431f2437f83ce4f8b7f2f",
+                "sha256:bae83f2a56ab30d5353b47f9b2a33e4aac4de9401fb582b55c42b132a8ac3868",
+                "sha256:c78e66a922de1c95a208e4ec02e2e5cf0bb83a36ceececc10a72841e53fbf2bd",
+                "sha256:cf59bbf282b627130f5ba68b7fa3abdb96372b24b66bdf72a4920e8153fc7910",
+                "sha256:e3cdc9423808f7e1bb9c2e0bdb1c9dc37b0607b30d646ff6faf0d4e41ee8fee3",
+                "sha256:e9b64e609d37438f7d6e68c2546d2cb8062f3adb27e6336bc129b51be20773ac",
+                "sha256:fbff901c54c22425a5b809b914a3bfaf4b9570eee0e5ce8186ac71eb2025191c"
             ],
-            "version": "==2020.5.14"
+            "version": "==2020.6.8"
         },
         "requests": {
             "hashes": [
                 "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
                 "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.23.0"
         },
         "requests-toolbelt": {
@@ -524,6 +576,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "snowballstemmer": {
@@ -535,25 +588,26 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:62edfd92d955b868d6c124c0942eba966d54b5f3dcb4ded39e65f74abac3f572",
-                "sha256:f5505d74cf9592f3b997380f9bdb2d2d0320ed74dd69691e3ee0644b956b8d83"
+                "sha256:1c445320a3310baa5ccb8d957267ef4a0fc930dc1234db5098b3d7af14fbb242",
+                "sha256:7d3d5087e39ab5a031b75588e9859f011de70e213cd0080ccbc28079fb0786d1"
             ],
             "index": "pypi",
-            "version": "==3.0.3"
+            "version": "==3.1.0"
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:1ba9bbc8898ed8531ac8d140b4ff286d57010fb878303b2efae3303726ec821b",
-                "sha256:a18194ae459f6a59b0d56e4a8b4c576c0125fb9a12f2211e652b4a8133092e14"
+                "sha256:00cf895504a7895ee433807c62094cf1e95f065843bf3acd17037c3e9a2becd4",
+                "sha256:728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a"
             ],
             "index": "pypi",
-            "version": "==0.5.0rc1"
+            "version": "==0.4.3"
         },
         "sphinxcontrib-applehelp": {
             "hashes": [
                 "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
                 "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-devhelp": {
@@ -561,6 +615,7 @@
                 "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
                 "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.2"
         },
         "sphinxcontrib-htmlhelp": {
@@ -568,6 +623,7 @@
                 "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f",
                 "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-jsmath": {
@@ -575,6 +631,7 @@
                 "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
                 "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.1"
         },
         "sphinxcontrib-qthelp": {
@@ -582,6 +639,7 @@
                 "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
                 "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.3"
         },
         "sphinxcontrib-serializinghtml": {
@@ -589,6 +647,7 @@
                 "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc",
                 "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.1.4"
         },
         "toml": {
@@ -600,10 +659,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:322dfdf007d7d53323f767badcb068a5cfa7c44d8aabb698d131b28cf44e62c4",
-                "sha256:8c9ad9b48659d291c5bc78bcabaa4d680d627687154b812fa52baedaa94f9f83"
+                "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e",
+                "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"
             ],
-            "version": "==3.15.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.15.2"
         },
         "tox-pyenv": {
             "hashes": [
@@ -615,10 +675,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:4733c4a10d0f2a4d098d801464bdaf5240c7dadd2a7fde4ee93b0a0efd9fb25e",
-                "sha256:acdafb20f51637ca3954150d0405ff1a7edde0ff19e38fb99a80a66210d2a28f"
+                "sha256:07c06493f1403c1380b630ae3dcbe5ae62abcf369a93bbc052502279f189ab8c",
+                "sha256:cd140979c2bebd2311dfb14781d8f19bd5a9debb92dcab9f6ef899c987fcf71f"
             ],
-            "version": "==4.46.0"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.46.1"
         },
         "twine": {
             "hashes": [
@@ -659,6 +720,7 @@
                 "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
                 "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.9"
         },
         "virtualenv": {
@@ -666,14 +728,15 @@
                 "sha256:a116629d4e7f4d03433b8afa27f43deba09d48bc48f5ecefa4f015a178efb6cf",
                 "sha256:a730548b27366c5e6cbdf6f97406d861cccece2e22275e8e1a757aeff5e00c70"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.0.21"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1",
-                "sha256:ee73862862a156bf77ff92b09034fc4825dd3af9cf81bc5b360668d425f3c5f1"
+                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
+                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
             ],
-            "version": "==0.1.9"
+            "version": "==0.2.4"
         },
         "webencodings": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ REQUIRED = [
     "atomos",
     "attrs",
     "click",
+    "immutables",
     "prompt-toolkit>=3.0.0",
     "pyfunctional",
     "pyrsistent",

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -241,10 +241,7 @@
     :arglists '([coll])}
   count
   (fn count [coll]
-    (try
-      (python/len coll)
-      (catch TypeError _
-        (count (apply vector coll))))))
+    (basilisp.lang.runtime/count coll)))
 
 (def
   ^{:doc      "Returns a basilisp.lang.exception/ExceptionInfo instance with
@@ -1097,6 +1094,11 @@
   they are not proper function types."
   [x]
   (python/callable x))
+
+(defn indexed?
+  "Return true if elements of x can be accessed by index efficiently."
+  [x]
+  (instance? basilisp.lang.interfaces/IIndexed x))
 
 (def ^{:doc "Return true if x is an integer.
 

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -9,7 +9,6 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
-    Sized,
     TypeVar,
     Union,
 )
@@ -37,7 +36,7 @@ class IBlockingDeref(IDeref[T]):
         raise NotImplementedError()
 
 
-class ICounted(Sized, ABC):
+class ICounted(ABC):
     """ICounted types can produce their length in constant time.
 
     All of the builtin collections are ICountable, except Lists whose length is
@@ -53,10 +52,6 @@ class IIndexed(ICounted, Generic[T], ABC):
     True to the `indexed?` predicate."""
 
     __slots__ = ()
-
-    @abstractmethod
-    def __getitem__(self, item) -> T:
-        raise NotImplementedError()
 
 
 # Making this interface Generic causes the __repr__ to differ between

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -45,7 +45,7 @@ class ICounted(ABC):
     __slots__ = ()
 
 
-class IIndexed(ICounted, Generic[T], ABC):
+class IIndexed(ICounted, ABC):
     """IIndexed types can be accessed by index.
 
     Of the builtin collections, only Vectors are IIndexed. IIndexed types respond
@@ -252,7 +252,7 @@ T_vec = TypeVar("T_vec", bound="IPersistentVector")
 class IPersistentVector(
     Sequence[T],
     IAssociative[int, T],
-    IIndexed[T],
+    IIndexed,
     IReversible[T],
     ISequential,
     IPersistentStack[T],

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -9,6 +9,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Sized,
     TypeVar,
     Union,
 )
@@ -36,8 +37,26 @@ class IBlockingDeref(IDeref[T]):
         raise NotImplementedError()
 
 
-class ICounted(ABC):
+class ICounted(Sized, ABC):
+    """ICounted types can produce their length in constant time.
+
+    All of the builtin collections are ICountable, except Lists whose length is
+    determined by counting all of the elements in the list in linear time."""
+
     __slots__ = ()
+
+
+class IIndexed(ICounted, Generic[T], ABC):
+    """IIndexed types can be accessed by index.
+
+    Of the builtin collections, only Vectors are IIndexed. IIndexed types respond
+    True to the `indexed?` predicate."""
+
+    __slots__ = ()
+
+    @abstractmethod
+    def __getitem__(self, item) -> T:
+        raise NotImplementedError()
 
 
 # Making this interface Generic causes the __repr__ to differ between
@@ -107,6 +126,12 @@ class IReference(IMeta):
 
 
 class IReversible(Generic[T]):
+    """IReversible types can produce a sequences of their elements in reverse in
+    constant time.
+
+    Of the builtin collections, only Vectors are IReversible. IIndexed types respond
+    True to the `reversible` predicate."""
+
     __slots__ = ()
 
     @abstractmethod
@@ -115,6 +140,11 @@ class IReversible(Generic[T]):
 
 
 class ISeqable(Iterable[T]):
+    """ISeqable types can produce sequences of their elements, but are not ISeqs.
+
+    All of the builtin collections are ISeqable, except Lists which directly
+    implement ISeq. Values of type ISeqable respond True to the `seqable?` predicate."""
+
     __slots__ = ()
 
     @abstractmethod
@@ -123,6 +153,11 @@ class ISeqable(Iterable[T]):
 
 
 class ISequential(ABC):
+    """ISequential is a marker interface for sequential types.
+
+    Lists and Vectors are both considered ISequential and respond True to the
+    `sequential?` predicate."""
+
     __slots__ = ()
 
 
@@ -222,7 +257,7 @@ T_vec = TypeVar("T_vec", bound="IPersistentVector")
 class IPersistentVector(
     Sequence[T],
     IAssociative[int, T],
-    ICounted,
+    IIndexed[T],
     IReversible[T],
     ISequential,
     IPersistentStack[T],
@@ -243,6 +278,10 @@ class IPersistentVector(
 
 
 class IRecord(ILispObject):
+    """IRecord is a marker interface for types def'ed by `defrecord` forms.
+
+    All types created by `defrecord` are automatically marked with IRecord."""
+
     __slots__ = ()
 
     @classmethod
@@ -347,4 +386,8 @@ class ISeq(ILispObject, ISeqable[T]):
 
 
 class IType(ABC):
+    """IType is a marker interface for types def'ed by `deftype` forms.
+
+    All types created by `deftype` are automatically marked with IType."""
+
     __slots__ = ()

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -39,7 +39,7 @@ class IBlockingDeref(IDeref[T]):
 class ICounted(ABC):
     """ICounted types can produce their length in constant time.
 
-    All of the builtin collections are ICountable, except Lists whose length is
+    All of the builtin collections are ICounted, except Lists whose length is
     determined by counting all of the elements in the list in linear time."""
 
     __slots__ = ()

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -157,6 +157,10 @@ class Map(IPersistentMap[K, V], ILispObject, IWithMeta):
 
 def map(kvs: Mapping[K, V], meta=None) -> Map[K, V]:  # pylint:disable=redefined-builtin
     """Creates a new map."""
+    # For some reason, creating a new `immutables.Map` instance from an existing
+    # `basilisp.lang.map.Map` instance causes issues because the `__iter__` returns
+    # only the keys rather than tuple of key/value pairs, even though it adheres to
+    # the `Mapping` protocol. Passing the `.items()` directly bypasses this problem.
     return Map(kvs.items(), meta=meta)
 
 

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -8,6 +8,7 @@ import math
 import re
 import threading
 import types
+from collections.abc import Sequence
 from fractions import Fraction
 from typing import (
     AbstractSet,
@@ -20,9 +21,7 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Sequence,
     Set,
-    Sized,
     Tuple,
     Type,
     TypeVar,
@@ -1018,17 +1017,14 @@ def apply_kw(f, args):
     return f(*final, **kwargs)
 
 
-@functools.singledispatch
 def count(coll) -> int:
     try:
-        return sum(1 for _ in coll)
-    except TypeError:
-        raise TypeError(f"count not supported on object of type {type(coll)}")
-
-
-@count.register(Sized)
-def _count_sized(coll: Sized) -> int:
-    return len(coll)
+        return len(coll)
+    except (AttributeError, TypeError):
+        try:
+            return sum(1 for _ in coll)
+        except TypeError:
+            raise TypeError(f"count not supported on object of type {type(coll)}")
 
 
 __nth_sentinel = object()

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -20,9 +20,12 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Sequence,
     Set,
+    Sized,
     Tuple,
     Type,
+    TypeVar,
     Union,
     cast,
 )
@@ -838,34 +841,50 @@ def pop_thread_bindings() -> None:
 # Runtime Support #
 ###################
 
+T = TypeVar("T")
 
+
+@functools.singledispatch
 def first(o):
     """If o is a ISeq, return the first element from o. If o is None, return
     None. Otherwise, coerces o to a Seq and returns the first."""
-    if o is None:
-        return None
-    if isinstance(o, ISeq):
-        return o.first
     s = to_seq(o)
     if s is None:
         return None
     return s.first
 
 
+@first.register(type(None))
+def _first_none(_: None) -> None:
+    return None
+
+
+@first.register(ISeq)
+def _first_iseq(o: ISeq[T]) -> Optional[T]:
+    return o.first
+
+
+@functools.singledispatch
 def rest(o) -> ISeq:
     """If o is a ISeq, return the elements after the first in o. If o is None,
     returns an empty seq. Otherwise, coerces o to a seq and returns the rest."""
-    if o is None:
-        return lseq.EMPTY
-    if isinstance(o, ISeq):
-        s = o.rest
-        if s is None:
-            return lseq.EMPTY
-        return s
     n = to_seq(o)
     if n is None:
         return lseq.EMPTY
     return n.rest
+
+
+@rest.register(type(None))
+def _rest_none(_: None) -> ISeq:
+    return lseq.EMPTY
+
+
+@rest.register(type(ISeq))
+def _rest_iseq(o: ISeq[T]) -> ISeq:
+    s = o.rest
+    if s is None:
+        return lseq.EMPTY
+    return s
 
 
 def nthrest(coll, i: int):
@@ -899,15 +918,26 @@ def nthnext(coll, i: int) -> Optional[ISeq]:
         coll = next_(coll)
 
 
+@functools.singledispatch
+def _cons(seq, o) -> ISeq:
+    return Maybe(to_seq(seq)).map(lambda s: s.cons(o)).or_else(lambda: llist.l(o))
+
+
+@_cons.register(type(None))
+def _cons_none(_: None, o) -> ISeq:
+    return llist.l(o)
+
+
+@_cons.register(ISeq)
+def _cons_iseq(seq: ISeq, o) -> ISeq:
+    return seq.cons(o)
+
+
 def cons(o, seq) -> ISeq:
     """Creates a new sequence where o is the first element and seq is the rest.
     If seq is None, return a list containing o. If seq is not a ISeq, attempt
     to coerce it to a ISeq and then cons o onto the resulting sequence."""
-    if seq is None:
-        return llist.l(o)
-    if isinstance(seq, ISeq):
-        return seq.cons(o)
-    return Maybe(to_seq(seq)).map(lambda s: s.cons(o)).or_else(lambda: llist.l(o))
+    return _cons(seq, o)
 
 
 def _seq_or_nil(s: ISeq) -> Optional[ISeq]:
@@ -917,15 +947,25 @@ def _seq_or_nil(s: ISeq) -> Optional[ISeq]:
     return s
 
 
+@functools.singledispatch
 def to_seq(o) -> Optional[ISeq]:
     """Coerce the argument o to a ISeq. If o is None, return None."""
-    if o is None:
-        return None
-    if isinstance(o, ISeq):
-        return _seq_or_nil(o)
-    if isinstance(o, ISeqable):
-        return _seq_or_nil(o.seq())
     return _seq_or_nil(lseq.sequence(o))
+
+
+@to_seq.register(type(None))
+def _to_seq_none(_) -> None:
+    return None
+
+
+@to_seq.register(ISeq)
+def _to_seq_iseq(o: ISeq) -> Optional[ISeq]:
+    return _seq_or_nil(o)
+
+
+@to_seq.register(ISeqable)
+def _to_seq_iseqable(o: ISeqable) -> Optional[ISeq]:
+    return _seq_or_nil(o.seq())
 
 
 def concat(*seqs) -> ISeq:
@@ -978,16 +1018,48 @@ def apply_kw(f, args):
     return f(*final, **kwargs)
 
 
+@functools.singledispatch
+def count(coll) -> int:
+    try:
+        return sum(1 for _ in coll)
+    except TypeError:
+        raise TypeError(f"count not supported on object of type {type(coll)}")
+
+
+@count.register(Sized)
+def _count_sized(coll: Sized) -> int:
+    return len(coll)
+
+
 __nth_sentinel = object()
 
 
-def nth(coll, i, notfound=__nth_sentinel):
+@functools.singledispatch
+def nth(coll, i: int, notfound=__nth_sentinel):
     """Returns the ith element of coll (0-indexed), if it exists.
     None otherwise. If i is out of bounds, throws an IndexError unless
     notfound is specified."""
-    if coll is None:
-        return None
+    try:
+        for j, e in enumerate(coll):
+            if i == j:
+                return e
+    except TypeError:
+        pass
+    else:
+        if notfound is not __nth_sentinel:
+            return notfound
+        raise IndexError(f"Index {i} out of bounds")
 
+    raise TypeError(f"nth not supported on object of type {type(coll)}")
+
+
+@nth.register(type(None))
+def _nth_none(_: None, i: int, notfound=__nth_sentinel) -> None:
+    return None
+
+
+@nth.register(Sequence)
+def _nth_sequence(coll: Sequence, i: int, notfound=__nth_sentinel):
     try:
         return coll[i]
     except IndexError as ex:
@@ -999,58 +1071,67 @@ def nth(coll, i, notfound=__nth_sentinel):
         # cases where this exception occurs are not bugs.
         logger.log(TRACE, "Ignored %s: %s", type(ex).__name__, ex)
 
-    try:
-        for j, e in enumerate(coll):
-            if i == j:
-                return e
-        if notfound is not __nth_sentinel:
-            return notfound
-        raise IndexError(f"Index {i} out of bounds")
-    except TypeError:
-        pass
 
-    raise TypeError(f"nth not supported on object of type {type(coll)}")
-
-
+@functools.singledispatch
 def assoc(m, *kvs):
     """Associate keys to values in associative data structure m. If m is None,
     returns a new Map with key-values kvs."""
-    if m is None:
-        return lmap.Map.empty().assoc(*kvs)
-    if isinstance(m, IAssociative):
-        return m.assoc(*kvs)
     raise TypeError(
         f"Object of type {type(m)} does not implement Associative interface"
     )
 
 
+@assoc.register(type(None))
+def _assoc_none(_: None, *kvs) -> lmap.Map:
+    return lmap.Map.empty().assoc(*kvs)
+
+
+@assoc.register(IAssociative)
+def _assoc_iassociative(m: IAssociative, *kvs):
+    return m.assoc(*kvs)
+
+
+@functools.singledispatch
 def update(m, k, f, *args):
     """Updates the value for key k in associative data structure m with the return value from
     calling f(old_v, *args). If m is None, use an empty map. If k is not in m, old_v will be
     None."""
-    if m is None:
-        return lmap.Map.empty().assoc(k, f(None, *args))
-    if isinstance(m, IAssociative):
-        old_v = m.val_at(k)
-        new_v = f(old_v, *args)
-        return m.assoc(k, new_v)
     raise TypeError(
         f"Object of type {type(m)} does not implement Associative interface"
     )
 
 
+@update.register(type(None))
+def _update_none(_: None, k, f, *args) -> lmap.Map:
+    return lmap.Map.empty().assoc(k, f(None, *args))
+
+
+@update.register(IAssociative)
+def _update_iassociative(m: IAssociative, k, f, *args):
+    old_v = m.val_at(k)
+    new_v = f(old_v, *args)
+    return m.assoc(k, new_v)
+
+
+@functools.singledispatch
 def conj(coll, *xs):
     """Conjoin xs to collection. New elements may be added in different positions
     depending on the type of coll. conj returns the same type as coll. If coll
     is None, return a list with xs conjoined."""
-    if coll is None:
-        l = llist.List.empty()
-        return l.cons(*xs)
-    if isinstance(coll, IPersistentCollection):
-        return coll.cons(*xs)
     raise TypeError(
         f"Object of type {type(coll)} does not implement Collection interface"
     )
+
+
+@conj.register(type(None))
+def _conj_none(_: None, *xs):
+    l = llist.List.empty()
+    return l.cons(*xs)
+
+
+@conj.register(IPersistentCollection)
+def _conj_ipersistentcollection(coll: IPersistentCollection, *xs):
+    return coll.cons(*xs)
 
 
 def partial(f, *args, **kwargs):
@@ -1063,6 +1144,7 @@ def partial(f, *args, **kwargs):
     return partial_f
 
 
+@functools.singledispatch
 def deref(o, timeout_s=None, timeout_val=None):
     """Dereference a Deref object and return its contents.
 
@@ -1070,11 +1152,19 @@ def deref(o, timeout_s=None, timeout_val=None):
     timeout_val are supplied, deref will wait at most timeout_s seconds,
     returning timeout_val if timeout_s seconds elapse and o has not
     returned."""
-    if isinstance(o, IBlockingDeref):
-        return o.deref(timeout_s, timeout_val)
-    elif isinstance(o, IDeref):
-        return o.deref()
     raise TypeError(f"Object of type {type(o)} cannot be dereferenced")
+
+
+@deref.register(IBlockingDeref)
+def _deref_blocking(
+    o: IBlockingDeref, timeout_s: Optional[float] = None, timeout_val=None
+):
+    return o.deref(timeout_s, timeout_val)
+
+
+@deref.register(IDeref)
+def _deref(o: IDeref):
+    return o.deref()
 
 
 def equals(v1, v2) -> bool:
@@ -1086,10 +1176,16 @@ def equals(v1, v2) -> bool:
     return v1 == v2
 
 
+@functools.singledispatch
 def divide(x: LispNumber, y: LispNumber) -> LispNumber:
     """Division reducer. If both arguments are integers, return a Fraction.
     Otherwise, return the true division of x and y."""
-    if isinstance(x, int) and isinstance(y, int):
+    return x / y
+
+
+@divide.register(int)
+def _divide_ints(x: int, y: LispNumber) -> LispNumber:
+    if isinstance(y, int):
         return Fraction(x, y)
     return x / y
 
@@ -1139,23 +1235,30 @@ def sort_by(keyfn, coll, cmp=None) -> Optional[ISeq]:
     return lseq.sequence(sorted(coll, key=key))
 
 
+@functools.singledispatch
 def contains(coll, k):
     """Return true if o contains the key k."""
-    if isinstance(coll, IAssociative):
-        return coll.contains(k)
     return k in coll
 
 
+@contains.register(IAssociative)
+def _contains_iassociative(coll, k):
+    return coll.contains(k)
+
+
+@functools.singledispatch
 def get(m, k, default=None):
     """Return the value of k in m. Return default if k not found in m."""
-    if isinstance(m, ILookup):
-        return m.val_at(k, default)
-
     try:
         return m[k]
     except (KeyError, IndexError, TypeError) as e:
         logger.log(TRACE, "Ignored %s: %s", type(e).__name__, e)
         return default
+
+
+@get.register(ILookup)
+def _get_ilookup(m, k, default=None):
+    return m.val_at(k, default)
 
 
 def is_special_form(s: sym.Symbol) -> bool:
@@ -1291,11 +1394,15 @@ def repl_completions(text: str) -> Iterable[str]:
 ####################
 
 
+@functools.singledispatch
 def _collect_args(args) -> ISeq:
     """Collect Python starred arguments into a Basilisp list."""
-    if isinstance(args, tuple):
-        return llist.list(args)
     raise TypeError("Python variadic arguments should always be a tuple")
+
+
+@_collect_args.register(tuple)
+def _collect_args_tuple(args: tuple) -> ISeq:
+    return llist.list(args)
 
 
 class _TrampolineArgs:

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -1,7 +1,7 @@
 from collections.abc import Set as _PySet
 from typing import AbstractSet, Iterable, Optional, TypeVar
 
-from pyrsistent import PSet, pset  # noqa # pylint: disable=unused-import
+from immutables import Map as _Map
 
 from basilisp.lang.interfaces import (
     ILispObject,
@@ -24,8 +24,8 @@ class Set(IPersistentSet[T], ILispObject, IWithMeta):
 
     __slots__ = ("_inner", "_meta")
 
-    def __init__(self, wrapped: "PSet[T]", meta=None) -> None:
-        self._inner = wrapped
+    def __init__(self, members: Optional[Iterable[T]], meta=None) -> None:
+        self._inner = _Map((m, m) for m in (members or ()))
         self._meta = meta
 
     def __call__(self, key, default=None):
@@ -43,23 +43,11 @@ class Set(IPersistentSet[T], ILispObject, IWithMeta):
             return NotImplemented
         return _PySet.__eq__(self, other)
 
-    def __ge__(self, other):
-        return self._inner >= other
-
-    def __gt__(self, other):
-        return self._inner > other
-
-    def __le__(self, other):
-        return self._inner <= other
-
-    def __lt__(self, other):
-        return self._inner < other
-
     def __hash__(self):
-        return hash(self._inner)
+        return self._hash()  # type: ignore[attr-defined]
 
     def __iter__(self):
-        yield from self._inner
+        yield from self._inner.keys()
 
     def __len__(self):
         return len(self._inner)
@@ -67,38 +55,32 @@ class Set(IPersistentSet[T], ILispObject, IWithMeta):
     def _lrepr(self, **kwargs):
         return _seq_lrepr(self._inner, "#{", "}", meta=self._meta, **kwargs)
 
+    issubset = _PySet.__le__
+    issuperset = _PySet.__ge__
+
     def difference(self, *others):
-        e = self._inner
+        e = self
         for other in others:
-            e = e.difference(other)
-        return Set(e)
+            e = e - other
+        return e
 
     def intersection(self, *others):
-        e = self._inner
+        e = self
         for other in others:
-            e = e.intersection(other)
-        return Set(e)
+            e = e & other
+        return e
 
     def symmetric_difference(self, *others):
         e = self._inner
         for other in others:
-            e = e.symmetric_difference(other)
-        return Set(e)
+            e = e ^ other
+        return e
 
     def union(self, *others):
         e = self._inner
         for other in others:
-            e = e.union(other)
-        return Set(e)
-
-    def isdisjoint(self, s):
-        return self._inner.isdisjoint(s)
-
-    def issuperset(self, other):
-        return self._inner >= other
-
-    def issubset(self, other):
-        return self._inner <= other
+            e = e | other
+        return e
 
     @property
     def meta(self) -> Optional[IPersistentMap]:
@@ -108,19 +90,19 @@ class Set(IPersistentSet[T], ILispObject, IWithMeta):
         return set(self._inner, meta=meta)
 
     def cons(self, *elems: T) -> "Set[T]":
-        e = self._inner.evolver()
-        for elem in elems:
-            e.add(elem)
-        return Set(e.persistent(), meta=self.meta)
+        with self._inner.mutate() as m:
+            for elem in elems:
+                m.set(elem, elem)
+            return Set(m.finish(), meta=self.meta)
 
     def disj(self, *elems: T) -> "Set[T]":
-        e = self._inner.evolver()
-        for elem in elems:
-            try:
-                e.remove(elem)
-            except KeyError:
-                pass
-        return Set(e.persistent(), meta=self.meta)
+        with self._inner.mutate() as m:
+            for elem in elems:
+                try:
+                    del m[elem]
+                except KeyError:
+                    pass
+            return Set(m.finish(), meta=self.meta)
 
     @staticmethod
     def empty() -> "Set":
@@ -132,9 +114,9 @@ class Set(IPersistentSet[T], ILispObject, IWithMeta):
 
 def set(members: Iterable[T], meta=None) -> Set[T]:  # pylint:disable=redefined-builtin
     """Creates a new set."""
-    return Set(pset(members), meta=meta)
+    return Set(members, meta=meta)
 
 
 def s(*members: T, meta=None) -> Set[T]:
     """Creates a new set from members."""
-    return Set(pset(members), meta=meta)
+    return Set(members, meta=meta)

--- a/tests/basilisp/map_test.py
+++ b/tests/basilisp/map_test.py
@@ -53,6 +53,14 @@ def test_assoc():
     assert lmap.map({"a": 3, "b": 2}) == m1.assoc("b", 2)
 
 
+def test_map_as_function():
+    assert None is lmap.m()(1)
+    assert None is lmap.m()("abc")
+    assert None is lmap.map({1: True, "2": 2, 3: "string"})("abc")
+    assert "string" == lmap.map({1: True, "2": 2, 3: "string"})(3)
+    assert 2 == lmap.map({1: True, "2": 2, 3: "string"})("2")
+
+
 def test_contains():
     assert True is lmap.map({"a": 1}).contains("a")
     assert False is lmap.map({"a": 1}).contains("b")

--- a/tests/basilisp/set_test.py
+++ b/tests/basilisp/set_test.py
@@ -39,7 +39,7 @@ def test_set_as_function():
     assert None is lset.s()("abc")
     assert None is lset.s(1, 2, 3)("abc")
     assert 1 == lset.s(1, 2, 3)(1)
-    assert 1 == lset.s(1, 2, 3)(3)
+    assert 3 == lset.s(1, 2, 3)(3)
 
 
 def test_set_conj():

--- a/tests/basilisp/set_test.py
+++ b/tests/basilisp/set_test.py
@@ -34,6 +34,14 @@ def test_set_interface_membership(interface):
     assert issubclass(lset.Set, interface)
 
 
+def test_set_as_function():
+    assert None is lset.s()(1)
+    assert None is lset.s()("abc")
+    assert None is lset.s(1, 2, 3)("abc")
+    assert 1 == lset.s(1, 2, 3)(1)
+    assert 1 == lset.s(1, 2, 3)(3)
+
+
 def test_set_conj():
     meta = lmap.m(tag="async")
     s1 = lset.s(keyword("kw1"), meta=meta)


### PR DESCRIPTION
Convert `basilisp.lang.map.Map` and `basilisp.lang.set.Set` to use `immutables.Map` under the hood, rather than the Python-only implementation provided by `pyrsistent`, which should offer some decent performance improvements for both types.

As another performance improvement, most of the basic runtime functions like `first`, `rest`, `cons`, et al were converted to single dispatch (using `@functools.singledispatch`), which should be a little faster than a series of `isinstance` checks.

Fixes #557