### PR TITLE
Support artificially abstract base classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for multi-arity methods on `definterface` (#538)
  * Added support for Protocols (#460)
  * Added support for Volatiles (#460)
- * Add JSON encoder and decoder in `basilisp.json` namespace (#484)
+ * Added JSON encoder and decoder in `basilisp.json` namespace (#484)
+ * Added support for generically diffing Basilisp data structures in `basilisp.data` namespace (#555)
+ * Added support for artificially abstract bases classes in `deftype`, `defrecord`, and `reify` types (#565)
 
 ### Changed
  * Basilisp set and map types are now backed by the HAMT provided by `immutables` (#557)

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1630,7 +1630,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-bran
 __DEFTYPE_DEFAULT_SENTINEL = object()
 
 
-def _deftype_ast(  # pylint: disable=too-many-branches
+def _deftype_ast(  # pylint: disable=too-many-branches,too-many-locals
     ctx: AnalyzerContext, form: ISeq
 ) -> DefType:
     assert form.first == SpecialForm.DEFTYPE

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1584,6 +1584,8 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-bran
                     "and cannot be checked for abstractness; deferring to runtime",
                 )
                 unverifiably_abstract.add(interface)
+                if _is_artificially_abstract(interface.form):
+                    artificially_abstract.add(interface)
                 continue
 
             # Protocols are defined as maps, with the interface being simply a member
@@ -1634,7 +1636,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-bran
             artificially_abstract_base_members.update(
                 map(
                     lambda v: v[0],
-                    inspect.getmembers(interface_type, predicate=is_member,),
+                    inspect.getmembers(interface_type, predicate=is_member),
                 )
             )
         else:

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1559,7 +1559,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-bran
     assert special_form in {SpecialForm.DEFTYPE, SpecialForm.REIFY}
 
     unverifiably_abstract = set()
-    artificially_abstract = set()
+    artificially_abstract: Set[DefTypeBase] = set()
     artificially_abstract_base_members: Set[str] = set()
     is_member = {
         SpecialForm.DEFTYPE: __is_deftype_member,

--- a/src/basilisp/lang/compiler/constants.py
+++ b/src/basilisp/lang/compiler/constants.py
@@ -31,6 +31,7 @@ AMPERSAND = sym.symbol("&")
 
 DEFAULT_COMPILER_FILE_PATH = "NO_SOURCE_PATH"
 
+SYM_ABSTRACT_META_KEY = kw.keyword("abstract")
 SYM_ASYNC_META_KEY = kw.keyword("async")
 SYM_KWARGS_META_KEY = kw.keyword("kwargs")
 SYM_PRIVATE_META_KEY = kw.keyword("private")

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -10,6 +10,7 @@ from fractions import Fraction
 from functools import partial, wraps
 from itertools import chain
 from typing import (
+    AbstractSet,
     Callable,
     Collection,
     Deque,
@@ -52,6 +53,7 @@ from basilisp.lang.compiler.nodes import (
     ConstType,
     Def,
     DefType,
+    DefTypeBase,
     DefTypeClassMethod,
     DefTypeMember,
     DefTypeMethod,
@@ -397,6 +399,7 @@ def _class_ast(  # pylint: disable=too-many-arguments
     fields: Iterable[str] = (),
     members: Iterable[str] = (),
     verified_abstract: bool = False,
+    artificially_abstract_bases: Iterable[ast.AST] = (),
     is_frozen: bool = True,
     use_slots: bool = _ATTR_SLOTS_ON,
 ) -> ast.ClassDef:
@@ -425,6 +428,10 @@ def _class_ast(  # pylint: disable=too-many-arguments
                             ast.keyword(
                                 arg="interfaces",
                                 value=ast.Tuple(elts=list(bases), ctx=ast.Load()),
+                            ),
+                            ast.keyword(
+                                arg="artificially_abstract_bases",
+                                value=ast.Set(elts=list(artificially_abstract_bases)),
                             ),
                             ast.keyword(
                                 arg="members",
@@ -1268,13 +1275,15 @@ def __deftype_member_to_py_ast(
 
 
 def __deftype_or_reify_bases_to_py_ast(
-    ctx: GeneratorContext, node: Union[DefType, Reify]
+    ctx: GeneratorContext,
+    node: Union[DefType, Reify],
+    interfaces: Iterable[DefTypeBase],
 ) -> List[ast.AST]:
     """Return a list of AST nodes for the base classes for a `deftype*` or `reify*`."""
     assert node.op in {NodeOp.DEFTYPE, NodeOp.REIFY}
 
     bases: List[ast.AST] = []
-    for base in node.interfaces:
+    for base in interfaces:
         base_node = gen_py_ast(ctx, base)
         assert (
             count(base_node.dependencies) == 0
@@ -1316,7 +1325,10 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-branches,too-many-locals
     type_name = munge(node.name)
     ctx.symbol_table.new_symbol(sym.symbol(node.name), type_name, LocalType.DEFTYPE)
 
-    bases = __deftype_or_reify_bases_to_py_ast(ctx, node)
+    bases = __deftype_or_reify_bases_to_py_ast(ctx, node, node.interfaces)
+    artificially_abstract_bases = __deftype_or_reify_bases_to_py_ast(
+        ctx, node, node.artificially_abstract
+    )
 
     with ctx.new_symbol_table(node.name):
         fields = []
@@ -1363,6 +1375,7 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-branches,too-many-locals
                             fields=fields,
                             members=node.python_member_names,
                             verified_abstract=node.verified_abstract,
+                            artificially_abstract_bases=artificially_abstract_bases,
                             is_frozen=node.is_frozen,
                             use_slots=True,
                         ),
@@ -2374,8 +2387,11 @@ def _reify_to_py_ast(
 
     bases: List[ast.AST] = [
         _BASILISP_WITH_META_INTERFACE_NAME,
-        *__deftype_or_reify_bases_to_py_ast(ctx, node),
+        *__deftype_or_reify_bases_to_py_ast(ctx, node, node.interfaces),
     ]
+    artificially_abstract_bases = __deftype_or_reify_bases_to_py_ast(
+        ctx, node, node.artificially_abstract
+    )
     type_name = munge(genname("ReifiedType"))
 
     with ctx.new_symbol_table("reify"):
@@ -2454,6 +2470,7 @@ def _reify_to_py_ast(
                                 ["meta", "with_meta"], node.python_member_names
                             ),
                             verified_abstract=node.verified_abstract,
+                            artificially_abstract_bases=artificially_abstract_bases,
                             is_frozen=True,
                             use_slots=_ATTR_SLOTS_ON,
                         )

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -10,7 +10,6 @@ from fractions import Fraction
 from functools import partial, wraps
 from itertools import chain
 from typing import (
-    AbstractSet,
     Callable,
     Collection,
     Deque,

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -20,7 +20,7 @@ import basilisp.lang.map as lmap
 import basilisp.lang.set as lset
 import basilisp.lang.symbol as sym
 import basilisp.lang.vector as vec
-from basilisp.lang.interfaces import IPersistentMap, IPersistentVector
+from basilisp.lang.interfaces import IPersistentMap, IPersistentSet, IPersistentVector
 from basilisp.lang.runtime import Namespace, Var, to_lisp
 from basilisp.lang.typing import LispForm, ReaderForm as ReaderLispForm, SpecialForm
 from basilisp.lang.util import munge
@@ -405,6 +405,7 @@ class DefType(Node[SpecialForm]):
     members: Iterable["DefTypeMember"]
     env: NodeEnv
     verified_abstract: bool = False
+    artificially_abstract: IPersistentSet[DefTypeBase] = lset.Set.empty()
     is_frozen: bool = True
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(FIELDS, MEMBERS)
@@ -802,6 +803,7 @@ class Reify(Node[SpecialForm]):
     members: Iterable["DefTypeMember"]
     env: NodeEnv
     verified_abstract: bool = False
+    artificially_abstract: IPersistentSet[DefTypeBase] = lset.Set.empty()
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(MEMBERS)
     op: NodeOp = NodeOp.REIFY

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -772,6 +772,92 @@ class TestDefType:
         """
             )
 
+    class TestDefTypeBases:
+        @pytest.mark.parametrize(
+            "code",
+            [
+                """
+                (import* argparse)
+                (deftype* SomeAction []
+                  :implements [^:abstract argparse/Action]
+                  (__call__ [this]))""",
+                """
+                (def AABase
+                  (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                (deftype* SomeAction []
+                  :implements [^:abstract AABase]
+                  (some-method [this]))""",
+                """
+                (do
+                  (import* argparse)
+                  (deftype* SomeAction []
+                    :implements [^:abstract argparse/Action]
+                    (__call__ [this])))""",
+                """
+                (do
+                  (def AABase
+                    (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                  (deftype* SomeAction []
+                    :implements [^:abstract AABase]
+                    (some-method [this])))""",
+            ],
+        )
+        def test_deftype_allows_artificially_abstract_super_type(
+            self, lcompile: CompileFn, code: str
+        ):
+            lcompile(code)
+
+        @pytest.mark.parametrize(
+            "code,ExceptionType",
+            [
+                (
+                    """
+                    (import* argparse)
+                    (deftype* SomeAction []
+                      :implements [^:abstract argparse/Action]
+                      (__call__ [this])
+                      (do-action [this]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (def AABase
+                      (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                    (deftype* SomeAction []
+                      :implements [^:abstract AABase]
+                      (some-method [this])
+                      (other-method [this]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (do
+                      (import* argparse)
+                      (deftype* SomeAction []
+                        :implements [^:abstract argparse/Action]
+                        (__call__ [this])
+                        (do-action [this])))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (do
+                      (def AABase
+                        (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                      (deftype* SomeAction []
+                        :implements [^:abstract AABase]
+                        (some-method [this])
+                        (other-method [this])))""",
+                    runtime.RuntimeException,
+                ),
+            ],
+        )
+        def test_deftype_disallows_extra_methods_if_not_in_aa_super_type(
+            self, lcompile: CompileFn, code: str, ExceptionType
+        ):
+            with pytest.raises(ExceptionType):
+                lcompile(code)
+
     class TestDefTypeFields:
         def test_deftype_fields(self, lcompile: CompileFn):
             Point = lcompile("(deftype* Point [x y z])")
@@ -3895,6 +3981,84 @@ class TestReify:
         assert kw.keyword("x") == new_o()
 
         assert type(o) is type(new_o)
+
+    class TestReifyBases:
+        @pytest.mark.parametrize(
+            "code",
+            [
+                """
+                (import* argparse)
+                (reify* :implements [^:abstract argparse/Action]
+                  (__call__ [this]))""",
+                """
+                (def AABase
+                  (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                (reify* :implements [^:abstract AABase]
+                  (some-method [this]))""",
+                """
+                (do
+                  (import* argparse)
+                  (reify* :implements [^:abstract argparse/Action]
+                    (__call__ [this])))""",
+                """
+                (do
+                  (def AABase
+                    (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                  (reify* :implements [^:abstract AABase]
+                    (some-method [this])))""",
+            ],
+        )
+        def test_reify_allows_artificially_abstract_super_type(
+            self, lcompile: CompileFn, code: str
+        ):
+            lcompile(code)
+
+        @pytest.mark.parametrize(
+            "code,ExceptionType",
+            [
+                (
+                    """
+                    (import* argparse)
+                    (reify* :implements [^:abstract argparse/Action]
+                      (__call__ [this])
+                      (do-action [this]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (def AABase
+                      (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                    (reify* :implements [^:abstract AABase]
+                      (some-method [this])
+                      (other-method [this]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (do
+                      (import* argparse)
+                      (reify* :implements [^:abstract argparse/Action]
+                        (__call__ [this])
+                        (do-action [this])))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (do
+                      (def AABase
+                        (python/type "AABase" #py () #py {"some_method" (fn [this])}))
+                      (reify* :implements [^:abstract AABase]
+                        (some-method [this])
+                        (other-method [this])))""",
+                    runtime.RuntimeException,
+                ),
+            ],
+        )
+        def test_reify_disallows_extra_methods_if_not_in_aa_super_type(
+            self, lcompile: CompileFn, code: str, ExceptionType
+        ):
+            with pytest.raises(ExceptionType):
+                lcompile(code)
 
     class TestReifyMember:
         @pytest.mark.parametrize(

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1,4 +1,4 @@
-(ns tests.basilisp.core-fns-test
+(ns tests.basilisp.test-core-fns
   (:import time)
   (:require
    [basilisp.set :as set]

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1,4 +1,4 @@
-(ns tests.basilisp.core-macros-test
+(ns tests.basilisp.test-core-macros
   (:import inspect os tempfile)
   (:require
    [basilisp.test :refer [deftest is testing]]))

--- a/tests/basilisp/test_defrecord.lpy
+++ b/tests/basilisp/test_defrecord.lpy
@@ -1,4 +1,4 @@
-(ns tests.basilisp.defrecord-test
+(ns tests.basilisp.test-defrecord
   (:import abc)
   (:require
    [basilisp.test :refer [deftest is testing]]))

--- a/tests/basilisp/test_defrecord.lpy
+++ b/tests/basilisp/test_defrecord.lpy
@@ -152,19 +152,19 @@
       (is (= {:tag Point} (meta (with-meta p {:tag Point})))))
 
     (testing "repr"
-      (is (contains? #{"#tests.basilisp.defrecord-test.Point{:x 1 :y 2 :z 3}"
-                       "#tests.basilisp.defrecord-test.Point{:y 2 :z 3 :x 1}"
-                       "#tests.basilisp.defrecord-test.Point{:z 3 :x 1 :y 2}"
-                       "#tests.basilisp.defrecord-test.Point{:y 2 :x 1 :z 3}"
-                       "#tests.basilisp.defrecord-test.Point{:x 1 :z 3 :y 2}"
-                       "#tests.basilisp.defrecord-test.Point{:z 3 :y 2 :x 1}"}
+      (is (contains? #{"#tests.basilisp.test-defrecord.Point{:x 1 :y 2 :z 3}"
+                       "#tests.basilisp.test-defrecord.Point{:y 2 :z 3 :x 1}"
+                       "#tests.basilisp.test-defrecord.Point{:z 3 :x 1 :y 2}"
+                       "#tests.basilisp.test-defrecord.Point{:y 2 :x 1 :z 3}"
+                       "#tests.basilisp.test-defrecord.Point{:x 1 :z 3 :y 2}"
+                       "#tests.basilisp.test-defrecord.Point{:z 3 :y 2 :x 1}"}
                      (str p)))
-      (is (contains? #{"^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:x 1 :y 2 :z 3}"
-                       "^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:y 2 :z 3 :x 1}"
-                       "^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:z 3 :x 1 :y 2}"
-                       "^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:y 2 :x 1 :z 3}"
-                       "^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:x 1 :z 3 :y 2}"
-                       "^{:interesting :yes} #tests.basilisp.defrecord-test.Point{:z 3 :y 2 :x 1}"}
+      (is (contains? #{"^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:x 1 :y 2 :z 3}"
+                       "^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:y 2 :z 3 :x 1}"
+                       "^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:z 3 :x 1 :y 2}"
+                       "^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:y 2 :x 1 :z 3}"
+                       "^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:x 1 :z 3 :y 2}"
+                       "^{:interesting :yes} #tests.basilisp.test-defrecord.Point{:z 3 :y 2 :x 1}"}
                      (binding [*print-meta* true]
                        (str (with-meta p {:interesting :yes}))))))))
 
@@ -188,13 +188,13 @@
       (is (instance? Shape c1)))
 
     (testing "repr"
-      (is (= "#tests.basilisp.defrecord-test.Circle{:radius 1}"
+      (is (= "#tests.basilisp.test-defrecord.Circle{:radius 1}"
              (str c)))
-      (is (= "^{:interesting :yes} #tests.basilisp.defrecord-test.Circle{:radius 1}"
+      (is (= "^{:interesting :yes} #tests.basilisp.test-defrecord.Circle{:radius 1}"
              (binding [*print-meta* true]
                (str (with-meta c {:interesting :yes})))))
-      (is (contains? #{"#tests.basilisp.defrecord-test.Circle{:radius 1 :name \"Kurt\"}"
-                       "#tests.basilisp.defrecord-test.Circle{:name \"Kurt\" :radius 1}"}
+      (is (contains? #{"#tests.basilisp.test-defrecord.Circle{:radius 1 :name \"Kurt\"}"
+                       "#tests.basilisp.test-defrecord.Circle{:name \"Kurt\" :radius 1}"}
                      (str c1))))))
 
 (deftest defrecord-reader-form
@@ -207,7 +207,7 @@
       (is (= p1 (eval (read-string (str p1)))))
       (is (= p2 (eval (read-string (str p2)))))
       (is (= p3 (eval (read-string (str p3)))))
-      (is (= p #tests.basilisp.defrecord-test.Point[1 2 3]))))
+      (is (= p #tests.basilisp.test-defrecord.Point[1 2 3]))))
 
   (testing "record with methods"
     (let [c  (->Circle 1)
@@ -216,13 +216,13 @@
       (is (= c (eval (read-string (str c)))))
       (is (= c1 (eval (read-string (str c1)))))
       (is (= c2 (eval (read-string (str c2)))))
-      (is (= c #tests.basilisp.defrecord-test.Circle[1]))))
+      (is (= c #tests.basilisp.test-defrecord.Circle[1]))))
 
   (testing "illegal other forms"
     (is (thrown? basilisp.lang.reader/SyntaxError
-                 (read-string "#tests.basilisp.defrecord-test.Circle#{1}")))
+                 (read-string "#tests.basilisp.test-defrecord.Circle#{1}")))
     (is (thrown? basilisp.lang.reader/SyntaxError
-                 (read-string "#tests.basilisp.defrecord-test.Point(1 2 3)")))))
+                 (read-string "#tests.basilisp.test-defrecord.Point(1 2 3)")))))
 
 (deftest defrecord-field-restrictions
   (testing "reserved fields"

--- a/tests/basilisp/test_defrecord.lpy
+++ b/tests/basilisp/test_defrecord.lpy
@@ -10,11 +10,11 @@
 
 (deftest deftype-reader-form
   (testing "type"
-    (is (= (->Square 5) #tests.basilisp.defrecord-test.Square[5])))
+    (is (= (->Square 5) #tests.basilisp.test-defrecord.Square[5])))
 
   (testing "illegal other forms"
     (is (thrown? basilisp.lang.reader/SyntaxError
-                 (read-string "#tests.basilisp.defrecord-test.Square{:dim 5}")))))
+                 (read-string "#tests.basilisp.test-defrecord.Square{:dim 5}")))))
 
 (defrecord Point [x y z])
 


### PR DESCRIPTION
Add support for "artificially abstract" base classes. The Python ecosystem is much less strict with its use of `abc.ABC` to interfaces than Java (which has a native `interface` construct), so even in where a type may be _in practice_ an interface or ABC, the compiler would not permit you to declare such types as supertypes because they do not inherit from `abc.ABC`. In these cases, users can mark the type as  abstract with the `:abstract` metadata key to force the compiler to accept that it is abstract.

In this case, the compiler will attempt to verify that any extra methods present on the `deftype`, `defrecord`, or `reify` are present on any one of the artificially abstract base classes. This will allow users to override existing class members, but not introduce new ones without a true interface.

Fixes #562