### PR TITLE
Allow recursive `def` references inside `def` init values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for auto-resolving namespaces for keyword from the current namespace using the `::kw` syntax (#576)
  * Added support for namespaced map syntax (#577)
 
+### Fixed
+ * Fixed a bug where `def` forms did not permit recursive references to the `def`'ed Vars (#578)
+
 ## [v0.1.dev14] - 2020-06-18
 ### Added
  * Added support for `future`s (#441)

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -288,6 +288,12 @@ class TestDef:
         assert var.root == runtime.Unbound(var)
         assert not var.is_bound
 
+    def test_recursive_def(self, lcompile: CompileFn, ns: runtime.Namespace):
+        lcompile("(def a a)")
+        var = Var.find_in_ns(sym.symbol(ns.name), sym.symbol("a"))
+        assert var.root == runtime.Unbound(var)
+        assert var.is_bound
+
     def test_def_number_of_elems(self, lcompile: CompileFn, ns: runtime.Namespace):
         with pytest.raises(compiler.CompilerException):
             lcompile("(def)")


### PR DESCRIPTION
Fixes #553 