### PR TITLE
Improve the lookup speed for Keywords by pre-computing hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  * Moved `basilisp.lang.runtime.to_seq` to `basilisp.lang.seq` so it can be used within that module and by `basilisp.lang.runtime` without circular import (#588)
+ * Keyword hashes are now pre-computed when they are created, so they do not need to be recomputed again to be fetched from the intern cache (#592)
+ * The compiler now uses the pre-computed hash to lookup keywords directly, which should improve lookup time for repeated invocations (#592)
+ * Symbol hashes are now pre-computed when they are created (#592)
 
 ### Fixed
  * Fixed a bug where `def` forms did not permit recursive references to the `def`'ed Vars (#578)

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -629,7 +629,7 @@ _NS_VAR_NAME = _load_attr(f"{_NS_VAR_VALUE}.name")
 _NEW_DECIMAL_FN_NAME = _load_attr(f"{_UTIL_ALIAS}.decimal_from_str")
 _NEW_FRACTION_FN_NAME = _load_attr(f"{_UTIL_ALIAS}.fraction")
 _NEW_INST_FN_NAME = _load_attr(f"{_UTIL_ALIAS}.inst_from_str")
-_NEW_KW_FN_NAME = _load_attr(f"{_KW_ALIAS}.keyword")
+_NEW_KW_FN_NAME = _load_attr(f"{_KW_ALIAS}.keyword_from_hash")
 _NEW_LIST_FN_NAME = _load_attr(f"{_LIST_ALIAS}.list")
 _EMPTY_LIST_FN_NAME = _load_attr(f"{_LIST_ALIAS}.List.empty")
 _NEW_MAP_FN_NAME = _load_attr(f"{_MAP_ALIAS}.map")
@@ -1302,7 +1302,10 @@ def __deftype_or_reify_bases_to_py_ast(
                     args=[
                         ast.Call(
                             func=_NEW_KW_FN_NAME,
-                            args=[ast.Constant("interface")],
+                            args=[
+                                ast.Constant(kw.hash_kw("interface")),
+                                ast.Constant("interface"),
+                            ],
                             keywords=[],
                         )
                     ],
@@ -1530,7 +1533,10 @@ def __fn_decorator(arities: Iterable[int], has_rest_arg: bool = False,) -> ast.C
                             [
                                 ast.Call(
                                     func=_NEW_KW_FN_NAME,
-                                    args=[ast.Constant("rest")],
+                                    args=[
+                                        ast.Constant(kw.hash_kw("rest")),
+                                        ast.Constant("rest"),
+                                    ],
                                     keywords=[],
                                 )
                             ]
@@ -3160,7 +3166,9 @@ def _kw_to_py_ast(_: GeneratorContext, form: kw.Keyword) -> ast.AST:
         .or_else(list)
     )
     return ast.Call(
-        func=_NEW_KW_FN_NAME, args=[ast.Constant(form.name)], keywords=kwarg
+        func=_NEW_KW_FN_NAME,
+        args=[ast.Constant(kw.hash_kw(form.name, form.ns)), ast.Constant(form.name)],
+        keywords=kwarg,
     )
 
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -132,6 +132,10 @@ _THROW_PREFIX = "lisp_throw"
 _TRY_PREFIX = "lisp_try"
 _NS_VAR = "_NS"
 
+# Keyword constants used in generating code
+_INTERFACE_KW = kw.keyword("interface")
+_REST_KW = kw.keyword("rest")
+
 
 GeneratorException = partial(CompilerException, phase=CompilerPhase.CODE_GENERATION)
 
@@ -1303,7 +1307,7 @@ def __deftype_or_reify_bases_to_py_ast(
                         ast.Call(
                             func=_NEW_KW_FN_NAME,
                             args=[
-                                ast.Constant(kw.hash_kw("interface")),
+                                ast.Constant(hash(_INTERFACE_KW)),
                                 ast.Constant("interface"),
                             ],
                             keywords=[],
@@ -1534,7 +1538,7 @@ def __fn_decorator(arities: Iterable[int], has_rest_arg: bool = False,) -> ast.C
                                 ast.Call(
                                     func=_NEW_KW_FN_NAME,
                                     args=[
-                                        ast.Constant(kw.hash_kw("rest")),
+                                        ast.Constant(hash(_REST_KW)),
                                         ast.Constant("rest"),
                                     ],
                                     keywords=[],
@@ -3167,7 +3171,7 @@ def _kw_to_py_ast(_: GeneratorContext, form: kw.Keyword) -> ast.AST:
     )
     return ast.Call(
         func=_NEW_KW_FN_NAME,
-        args=[ast.Constant(kw.hash_kw(form.name, form.ns)), ast.Constant(form.name)],
+        args=[ast.Constant(hash(form)), ast.Constant(form.name)],
         keywords=kwarg,
     )
 

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -98,6 +98,7 @@ def keyword_from_hash(kw_hash: int, name: str, ns: Optional[str] = None) -> Keyw
     with _LOCK:
         found = _INTERN.val_at(kw_hash)
         if found:
+            assert hash(found) == kw_hash
             return found
         kw = Keyword(name, ns=ns)
         _INTERN = _INTERN.assoc(kw_hash, kw)

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -98,7 +98,6 @@ def keyword_from_hash(kw_hash: int, name: str, ns: Optional[str] = None) -> Keyw
     with _LOCK:
         found = _INTERN.val_at(kw_hash)
         if found:
-            assert hash(found) == kw_hash
             return found
         kw = Keyword(name, ns=ns)
         _INTERN = _INTERN.assoc(kw_hash, kw)

--- a/src/basilisp/lang/symbol.py
+++ b/src/basilisp/lang/symbol.py
@@ -6,7 +6,7 @@ from basilisp.lang.util import munge
 
 
 class Symbol(ILispObject, IWithMeta):
-    __slots__ = ("_name", "_ns", "_meta")
+    __slots__ = ("_name", "_ns", "_meta", "_hash")
 
     def __init__(
         self, name: str, ns: Optional[str] = None, meta: Optional[IPersistentMap] = None
@@ -14,6 +14,7 @@ class Symbol(ILispObject, IWithMeta):
         self._name = name
         self._ns = ns
         self._meta = meta
+        self._hash = hash((ns, name))
 
     def _lrepr(self, **kwargs) -> str:
         print_meta = kwargs["print_meta"]
@@ -53,7 +54,7 @@ class Symbol(ILispObject, IWithMeta):
         return self._ns == other._ns and self._name == other._name
 
     def __hash__(self):
-        return hash((self._ns, self._name))
+        return self._hash
 
 
 def symbol(name: str, ns: Optional[str] = None, meta=None) -> Symbol:


### PR DESCRIPTION
This PR includes a change to pre-compute the hash of a Keyword a new instance is created. Keyword hashes are used as the lookup key for Keywords inside the intern cache. Keywords are also commonly used as map keys and in other collections requiring hashability, so having a pre-computed hash should help improve performance by not requiring repeated computations of the otherwise static hash.

The compiler now also uses the pre-computed Keyword hash to lookup Keywords directly from the intern cache, which should reduce the cost of repeated lookups (particularly if a function makes heavy use of keywords).

This change appears to have improved the lookup speed by around 9%.

Before these changes:

```
basilisp.user=> (import timeit)
<module 'timeit' from '/Users/christopher/.pyenv/versions/3.6.9/lib/python3.6/timeit.py'>

basilisp.user=> (timeit/timeit (fn [] :abc))
0.7336159450060222
```

Afterwards:

```
basilisp.user=> (import timeit)
<module 'timeit' from '/Users/christopher/.pyenv/versions/3.6.9/lib/python3.6/timeit.py'>

basilisp.user=> (timeit/timeit (fn [] :abc))
0.668459995999001
```

Fixes #591