### PR TITLE
Optimizing CircleCI config to reduce build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
             mkdir coverage
             mv .coverage "coverage/.coverage.py<< parameters.python_version >>"
       - save_cache:
-          key: py<< parameters.python_version >>-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
@@ -96,7 +96,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           command: |
@@ -104,13 +104,10 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            # Split tests by timing and print out the test files on each node
             CCI_NODE_TESTS=$(circleci tests glob "tests/**/*_test.py" "tests/**/test_*.py" | circleci tests split --split-by=timings)
             printf "Test files:\n"
             echo "$CCI_NODE_TESTS"
             printf "\n"
-
-            # Run the tests on the subset defined for this node
             tox -e pypy3 -- $CCI_NODE_TESTS
       - save_cache:
           key: pypy-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run-tests
+      - run-tests:
           tox_envs: py36,mypy-py36,format,lint,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
@@ -50,7 +50,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run_tests
+      - run_tests:
           tox_envs: py37,mypy-py37,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
@@ -68,7 +68,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run_tests
+      - run_tests:
           tox_envs: py38,mypy-py38,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run:
           name: Report Coverage
           command: |
-            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/coverahealth/analyzer/$CIRCLE_BUILD_NUM/artifacts?circle-token=$CIRCLECI_API_TOKEN"
+            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$CIRCLE_BUILD_NUM/artifacts?circle-token=$CIRCLECI_API_TOKEN"
             ARTIFACT_URLS=$(curl "$ARTIFACT_META_URL" | jq -r '.[].url' | sed "s/$/?circle-token=$CIRCLECI_API_TOKEN/")
             curl -L --remote-name-all $ARTIFACT_URLS
             for file in .coverage.node-*; do mv $file $(echo $file | cut -d '?' -f 1); done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
 version: 2.1
 commands:
-  run_tests:
+  run_cpython_tests:
     description: "Install Tox and run tests."
     parameters:
+      python_version:
+        description: "Required. Python version as `major.minor`."
+        type: string
       tox_envs:
         description: "Required. Set of Tox environments to run on this node."
         type: string
@@ -11,6 +14,11 @@ commands:
         type: integer
         default: 2
     steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - restore_cache:
+          key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           shell: /bin/bash -leo pipefail
@@ -24,60 +32,38 @@ commands:
             TOX_SHOW_OUTPUT: "True"
           command: |
             tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
+      - save_cache:
+          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "/home/circleci/project/.tox"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
+            - store_test_results:
+                path: junit
 jobs:
   test-cpython-36:
     docker:
       - image: circleci/python:3.6-buster
     steps:
-      - checkout
-      - restore_cache:
-          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run_tests:
+      - run_cpython_tests:
+          python_version: 3.6
           tox_envs: py36,py36-mypy,format,lint,safety
-      - save_cache:
-          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "/home/circleci/project/.tox"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.6/site-packages"
-      - store_test_results:
-          path: junit
 
   test-cpython-37:
     docker:
       - image: circleci/python:3.7-buster
     steps:
-      - checkout
-      - restore_cache:
-          key: py37-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run_tests:
+      - run_cpython_tests:
+          python_version: 3.7
           tox_envs: py37,py37-mypy,safety
-      - save_cache:
-          key: py37-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "/home/circleci/project/.tox"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.7/site-packages"
-      - store_test_results:
-          path: junit
 
   test-cpython-38:
     docker:
       - image: circleci/python:3.8-buster
     steps:
-      - checkout
-      - restore_cache:
-          key: py38-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run_tests:
+      - run_cpython_tests:
+          python_version: 3.8
           tox_envs: py38,py38-mypy,safety
-      - save_cache:
-          key: py38-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "/home/circleci/project/.tox"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.8/site-packages"
-      - store_test_results:
-          path: junit
 
   test-pypy:
     docker:
@@ -85,6 +71,8 @@ jobs:
     parallelism: 3
     steps:
       - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
       - restore_cache:
           key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             # Run the tests on the subset defined for this node
             tox -e pypy3 -- $CCI_NODE_TESTS
       - save_cache:
-          key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/home/pyenv/.tox"
             - "/usr/local/bin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,10 @@ jobs:
       - image: circleci/python:3.8-buster
     steps:
       - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.8/site-packages
+      - restore_cache:
+          key: report-coverage-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           shell: /bin/bash -leo pipefail
@@ -102,6 +106,12 @@ jobs:
               fi
             done
             tox -v -e coverage
+      - save_cache:
+          key: report-coverage-deps-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "/home/circleci/project/.tox"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.8/site-packages"
 
   test-pypy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,45 @@
 version: 2.1
 
 commands:
+  setup_tests:
+    description: "Check out code, install Tox, and prepare the test environment."
+    parameters:
+      python_version:
+        description: "Required. Python version as `major.minor`."
+        type: string
+      cache_key_prefix:
+        description: "Required. Prefix used for the CircleCI cache key."
+        type: string
+    steps:
+      - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python<< parameters.python_version >>/site-packages
+      - restore_cache:
+          key: << parameters.cache_key_prefix >>1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+      - run:
+          name: Install tox
+          shell: /bin/bash -leo pipefail
+          command: |
+            pip install -U pip
+            pip install tox
+
+  teardown_tests:
+    description: "Store the cache for the current run."
+    parameters:
+      python_version:
+        description: "Required. Python version as `major.minor`."
+        type: string
+      cache_key_prefix:
+        description: "Required. Prefix used for the CircleCI cache key."
+        type: string
+    steps:
+      - save_cache:
+          key: << parameters.cache_key_prefix >>1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "/home/circleci/project/.tox"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
+
   run_cpython_tests:
     description: "Install Tox and run tests."
     parameters:
@@ -15,16 +54,9 @@ commands:
         type: integer
         default: 2
     steps:
-      - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python<< parameters.python_version >>/site-packages
-      - restore_cache:
-          key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run:
-          name: Install tox
-          shell: /bin/bash -leo pipefail
-          command: |
-            pip install tox
+      - setup_tests:
+          python_version: << parameters.python_version >>
+          cache_key_prefix: py<< parameters.python_version >>-deps
       - run:
           name: Run Tests
           shell: /bin/bash -leo pipefail
@@ -35,12 +67,9 @@ commands:
             tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
             mkdir coverage
             mv .coverage.* "coverage/.coverage.py<< parameters.python_version >>"
-      - save_cache:
-          key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "/home/circleci/project/.tox"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
+      - teardown_tests:
+          python_version: << parameters.python_version >>
+          cache_key_prefix: py<< parameters.python_version >>-deps
       - store_artifacts:
           path: coverage
       - store_test_results:
@@ -75,16 +104,9 @@ jobs:
     docker:
       - image: circleci/python:3.8-buster
     steps:
-      - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.8/site-packages
-      - restore_cache:
-          key: report-coverage-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run:
-          name: Install tox
-          shell: /bin/bash -leo pipefail
-          command: |
-            pip install tox
+      - setup_tests:
+          python_version: "3.8"
+          cache_key_prefix: report-coverage-deps
       - run:
           name: Report Coverage
           command: |
@@ -92,26 +114,24 @@ jobs:
             RECENT_BUILDS_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/tree/$CIRCLE_BRANCH"
             BUILD_NUMS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$RECENT_BUILDS_URL" | \
               jq -r "map(select(.workflows.workflow_id == \"$CIRCLE_WORKFLOW_ID\")) | map(.build_num) | .[]")
-            echo "build url: $RECENT_BUILDS_URL"
-            echo "build nums: $BUILD_NUMS"
+            echo "CircleCI build URL: $RECENT_BUILDS_URL"
+            echo "CircleCI build numbers: $(echo "$BUILD_NUMS" | tr '\n' ' ')"
 
             # Fetch all of the artifacts for the build numbers
             for build_num in $BUILD_NUMS
             do
               ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$build_num/artifacts"
-              echo "fetching build num: $ARTIFACT_META_URL"
+              echo "Fetching artifacts for CircleCI build from: $ARTIFACT_META_URL"
               ARTIFACT_URLS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$ARTIFACT_META_URL" | jq -r '.[].url')
               if [ -n "$ARTIFACT_URLS" ]; then
+                echo "Found artifact URLs: $(echo "$ARTIFACT_URLS" | tr '\n' ' ')"
                 curl -L --remote-name-all $ARTIFACT_URLS
               fi
             done
             tox -v -e coverage
-      - save_cache:
-          key: report-coverage-deps-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-          paths:
-            - "/home/circleci/project/.tox"
-            - "/usr/local/bin"
-            - "/usr/local/lib/python3.8/site-packages"
+      - teardown_tests:
+          python_version: "3.8"
+          cache_key_prefix: report-coverage-deps
 
   test-pypy:
     docker:
@@ -120,10 +140,11 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pypy-deps1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps2-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           command: |
+            pip install -U pip
             pip install tox
       - run:
           name: Run Tests
@@ -134,7 +155,7 @@ jobs:
             printf "\n"
             tox -e pypy3 -- $CCI_NODE_TESTS
       - save_cache:
-          key: pypy-deps1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps2-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/root/project/.tox"
             - "/usr/local/bin"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run_tests:
-          tox_envs: py36,mypy-py36,format,lint,safety
+          tox_envs: py36,py36-mypy,format,lint,safety
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
-            - "/home/pyenv/.tox"
+            - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"
       - store_test_results:
@@ -49,13 +49,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py37-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run_tests:
-          tox_envs: py37,mypy-py37,safety
+          tox_envs: py37,py37-mypy,safety
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py37-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
-            - "/home/pyenv/.tox"
+            - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.7/site-packages"
       - store_test_results:
@@ -67,13 +67,13 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py38-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run_tests:
-          tox_envs: py38,mypy-py38,safety
+          tox_envs: py38,py38-mypy,safety
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py38-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
-            - "/home/pyenv/.tox"
+            - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.8/site-packages"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,6 @@ jobs:
     parallelism: 3
     steps:
       - checkout
-      - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
       - restore_cache:
           key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - run_cpython_tests:
           python_version: "3.6"
-          tox_envs: py36,py36-mypy,format,lint,safety
+          tox_envs: py36,py36-mypy,py36-lint,safety
 
   test-cpython-37:
     docker:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - run_cpython_tests:
           python_version: "3.7"
-          tox_envs: py37,py37-mypy,safety
+          tox_envs: py37,py37-mypy,py37-lint,safety
 
   test-cpython-38:
     docker:
@@ -98,7 +98,7 @@ jobs:
     steps:
       - run_cpython_tests:
           python_version: "3.8"
-          tox_envs: py38,py38-mypy,safety
+          tox_envs: py38,py38-mypy,py38-lint,format,safety
 
   report-coverage:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 commands:
   run_cpython_tests:
     description: "Install Tox and run tests."
@@ -38,8 +39,9 @@ commands:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
-            - store_test_results:
-                path: junit
+      - store_test_results:
+          path: junit
+
 jobs:
   test-cpython-36:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
             TOX_PARALLEL_NO_SPINNER: 1
             TOX_SHOW_OUTPUT: "True"
           command: |
-            tox -p $TOX_NUM_CORES -e << parameters.tox_envs >>
+            tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
 jobs:
   test-cpython-36:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
-      - store_artifact:
+      - store_artifacts:
           path: coverage
       - store_test_results:
           path: junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
     docker:
       - image: circleci/python:3.8-buster
     steps:
+      - checkout
       - run:
           name: Install tox
           shell: /bin/bash -leo pipefail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,11 +87,14 @@ jobs:
             RECENT_BUILDS_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/tree/$CIRCLE_BRANCH"
             BUILD_NUMS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$RECENT_BUILDS_URL" | \
               jq -r "map(select(.workflows.workflow_id == \"$CIRCLE_WORKFLOW_ID\")) | map(.build_num) | .[]")
+            echo "build url: $RECENT_BUILDS_URL"
+            echo "build nums: $BUILD_NUMS"
 
             # Fetch all of the artifacts for the build numbers
-            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$CIRCLE_BUILD_NUM/artifacts"
             for build_num in $BUILD_NUMS
             do
+              ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$build_num/artifacts"
+              echo "fetching build num: $ARTIFACT_META_URL"
               ARTIFACT_URLS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$ARTIFACT_META_URL" | jq -r '.[].url')
               curl -L --remote-name-all $ARTIFACT_URLS
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - image: circleci/python:3.6-buster
     steps:
       - run_cpython_tests:
-          python_version: 3.6
+          python_version: "3.6"
           tox_envs: py36,py36-mypy,format,lint,safety
 
   test-cpython-37:
@@ -54,7 +54,7 @@ jobs:
       - image: circleci/python:3.7-buster
     steps:
       - run_cpython_tests:
-          python_version: 3.7
+          python_version: "3.7"
           tox_envs: py37,py37-mypy,safety
 
   test-cpython-38:
@@ -62,7 +62,7 @@ jobs:
       - image: circleci/python:3.8-buster
     steps:
       - run_cpython_tests:
-          python_version: 3.8
+          python_version: "3.8"
           tox_envs: py38,py38-mypy,safety
 
   test-pypy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python<< parameters.python_version >>/site-packages
       - restore_cache:
           key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,16 @@ commands:
             TOX_SHOW_OUTPUT: "True"
           command: |
             tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
+            mkdir coverage
+            mv .coverage "coverage/.coverage.py<< parameters.python_version >>"
       - save_cache:
-          key: py36-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: py<< parameters.python_version >>-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
+      - store_artifact:
+          path: coverage
       - store_test_results:
           path: junit
 
@@ -66,6 +70,24 @@ jobs:
       - run_cpython_tests:
           python_version: "3.8"
           tox_envs: py38,py38-mypy,safety
+
+  report-coverage:
+    docker:
+      - image: circleci/python:3.8-buster
+    steps:
+      - run:
+          name: Install tox
+          shell: /bin/bash -leo pipefail
+          command: |
+            pip install tox
+      - run:
+          name: Report Coverage
+          command: |
+            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/coverahealth/analyzer/$CIRCLE_BUILD_NUM/artifacts?circle-token=$CIRCLECI_API_TOKEN"
+            ARTIFACT_URLS=$(curl "$ARTIFACT_META_URL" | jq -r '.[].url' | sed "s/$/?circle-token=$CIRCLECI_API_TOKEN/")
+            curl -L --remote-name-all $ARTIFACT_URLS
+            for file in .coverage.node-*; do mv $file $(echo $file | cut -d '?' -f 1); done
+            tox -v -e coverage
 
   test-pypy:
     docker:
@@ -107,3 +129,8 @@ workflows:
       - test-cpython-37
       - test-cpython-38
       - test-pypy
+      - report-coverage:
+          requires:
+            - test-cpython-36
+            - test-cpython-37
+            - test-cpython-38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,9 @@ jobs:
               ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$build_num/artifacts"
               echo "fetching build num: $ARTIFACT_META_URL"
               ARTIFACT_URLS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$ARTIFACT_META_URL" | jq -r '.[].url')
-              curl -L --remote-name-all $ARTIFACT_URLS
+              if [ -n "$ARTIFACT_URLS" ]; then
+                curl -L --remote-name-all $ARTIFACT_URLS
+              fi
             done
             tox -v -e coverage
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - restore_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
-      - run-tests:
+      - run_tests:
           tox_envs: py36,mypy-py36,format,lint,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
           command: |
             tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
             mkdir coverage
-            mv .coverage "coverage/.coverage.py<< parameters.python_version >>"
+            mv .coverage.* "coverage/.coverage.py<< parameters.python_version >>"
       - save_cache:
           key: py<< parameters.python_version >>-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,8 @@ jobs:
 
             # Fetch all of the artifacts for the build numbers
             ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$CIRCLE_BUILD_NUM/artifacts"
-            for build_num in $BUILD_NUMS;
+            for build_num in $BUILD_NUMS
+            do
               ARTIFACT_URLS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$ARTIFACT_META_URL" | jq -r '.[].url')
               curl -L --remote-name-all $ARTIFACT_URLS
             done

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,10 +83,17 @@ jobs:
       - run:
           name: Report Coverage
           command: |
-            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$CIRCLE_BUILD_NUM/artifacts?circle-token=$CIRCLECI_API_TOKEN"
-            ARTIFACT_URLS=$(curl "$ARTIFACT_META_URL" | jq -r '.[].url' | sed "s/$/?circle-token=$CIRCLECI_API_TOKEN/")
-            curl -L --remote-name-all $ARTIFACT_URLS
-            for file in .coverage.node-*; do mv $file $(echo $file | cut -d '?' -f 1); done
+            # Fetch the build numbers for this Workflow UUID
+            RECENT_BUILDS_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/tree/$CIRCLE_BRANCH"
+            BUILD_NUMS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$RECENT_BUILDS_URL" | \
+              jq -r "map(select(.workflows.workflow_id == \"$CIRCLE_WORKFLOW_ID\")) | map(.build_num) | .[]")
+
+            # Fetch all of the artifacts for the build numbers
+            ARTIFACT_META_URL="https://circleci.com/api/v1.1/project/github/basilisp-lang/basilisp/$CIRCLE_BUILD_NUM/artifacts"
+            for build_num in $BUILD_NUMS;
+              ARTIFACT_URLS=$(curl -H "Circle-Token: $CIRCLECI_API_TOKEN" "$ARTIFACT_META_URL" | jq -r '.[].url')
+              curl -L --remote-name-all $ARTIFACT_URLS
+            done
             tox -v -e coverage
 
   test-pypy:
@@ -96,7 +103,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: pypy-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           command: |
@@ -110,9 +117,9 @@ jobs:
             printf "\n"
             tox -e pypy3 -- $CCI_NODE_TESTS
       - save_cache:
-          key: pypy-deps-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps1-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
-            - "/home/pyenv/.tox"
+            - "/root/project/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,16 @@
-version: 2
-jobs:
-  test-cpython:
-    docker:
-      - image: chrisrink10/pyenv:3.6-3.7-3.8-0.0.1
-        user: pyenv
+version: 2.1
+commands:
+  run_tests:
+    description: "Install Tox and run tests."
+    parameters:
+      tox_envs:
+        description: "Required. Set of Tox environments to run on this node."
+        type: string
+      tox_parallel:
+        description: "Optional. Number of parallel workers spawned by Tox."
+        type: integer
+        default: 2
     steps:
-      - checkout
-      - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           shell: /bin/bash -leo pipefail
@@ -17,18 +20,62 @@ jobs:
           name: Run Tests
           shell: /bin/bash -leo pipefail
           environment:
-            TOX_NUM_CORES: 2
             TOX_PARALLEL_NO_SPINNER: 1
             TOX_SHOW_OUTPUT: "True"
-            TOX_SKIP_ENV: pypy3
           command: |
-            tox -p $TOX_NUM_CORES
+            tox -p $TOX_NUM_CORES -e << parameters.tox_envs >>
+jobs:
+  test-cpython-36:
+    docker:
+      - image: circleci/python:3.6-buster
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+      - run-tests
+          tox_envs: py36,mypy-py36,format,lint,safety
       - save_cache:
           key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/home/pyenv/.tox"
             - "/usr/local/bin"
             - "/usr/local/lib/python3.6/site-packages"
+      - store_test_results:
+          path: junit
+
+  test-cpython-37:
+    docker:
+      - image: circleci/python:3.7-buster
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+      - run_tests
+          tox_envs: py37,mypy-py37,safety
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "/home/pyenv/.tox"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.7/site-packages"
+      - store_test_results:
+          path: junit
+
+  test-cpython-38:
+    docker:
+      - image: circleci/python:3.8-buster
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+      - run_tests
+          tox_envs: py38,mypy-py38,safety
+      - save_cache:
+          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          paths:
+            - "/home/pyenv/.tox"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.8/site-packages"
       - store_test_results:
           path: junit
 
@@ -39,7 +86,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
       - run:
           name: Install tox
           command: |
@@ -56,7 +103,7 @@ jobs:
             # Run the tests on the subset defined for this node
             tox -e pypy3 -- $CCI_NODE_TESTS
       - save_cache:
-          key: deps9-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
+          key: pypy-deps-{{ .Branch }}-{{ checksum "tox.ini" }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "/home/pyenv/.tox"
             - "/usr/local/bin"
@@ -68,5 +115,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-cpython
+      - test-cpython-36
+      - test-cpython-37
+      - test-cpython-38
       - test-pypy

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -259,5 +259,5 @@ __all__ = [
 ]
 
 if sys.version_info >= (3, 8):  # pragma: no cover
-    Module = partial(Module, type_ignores=[])
-    arguments = partial(arguments, posonlyargs=[])
+    Module = partial(Module, type_ignores=[])  # type: ignore
+    arguments = partial(arguments, posonlyargs=[])  # type: ignore

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -64,7 +64,7 @@ from ast import (  # noqa
     LtE,
     MatMult,
     Mod,
-    Module,
+    Module as _Module,
     Mult,
     Name,
     NameConstant,
@@ -102,7 +102,7 @@ from ast import (  # noqa
     YieldFrom,
     alias,
     arg,
-    arguments,
+    arguments as _arguments,
     boolop,
     cmpop,
     comprehension,
@@ -127,7 +127,24 @@ from ast import (  # noqa
     walk,
     withitem,
 )
-from functools import partial
+
+if sys.version_info >= (3, 8):  # pragma: no cover
+
+    class Module(_Module):
+        def __init__(self, *args, **kwargs):
+            kwargs["posonlyargs"] = []
+            super().__init__(*args, **kwargs)
+
+    class arguments(_arguments):
+        def __init__(self, *args, **kwargs):
+            kwargs["posonlyargs"] = []
+            super().__init__(*args, **kwargs)
+
+
+else:
+    Module = _Module
+    arguments = _arguments
+
 
 __all__ = [
     "AST",
@@ -257,7 +274,3 @@ __all__ = [
     "walk",
     "withitem",
 ]
-
-if sys.version_info >= (3, 8):  # pragma: no cover
-    Module = partial(Module, type_ignores=[])  # type: ignore
-    arguments = partial(arguments, posonlyargs=[])  # type: ignore

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -132,7 +132,7 @@ if sys.version_info >= (3, 8):  # pragma: no cover
 
     class Module(_Module):
         def __init__(self, *args, **kwargs):
-            kwargs["posonlyargs"] = []
+            kwargs["type_ignores"] = []
             super().__init__(*args, **kwargs)
 
     class arguments(_arguments):

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -128,7 +128,7 @@ from ast import (  # noqa
     withitem,
 )
 
-if sys.version_info >= (3, 8):  # pragma: no cover
+if sys.version_info >= (3, 8):
 
     class Module(_Module):
         def __init__(self, *args, **kwargs):

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -3382,7 +3382,7 @@ def _const_node(ctx: AnalyzerContext, form: ReaderForm) -> Const:
 
 
 @_with_loc  # noqa: MC0001
-def _analyze_form(  # pylint: disable=too-many-branches
+def _analyze_form(  # pylint: disable=too-many-branches  # noqa: MC0001
     ctx: AnalyzerContext, form: Union[ReaderForm, ISeq]
 ) -> Node:
     if isinstance(form, (llist.List, ISeq)):

--- a/src/basilisp/lang/futures.py
+++ b/src/basilisp/lang/futures.py
@@ -64,6 +64,7 @@ class ProcessPoolExecutor(_ProcessPoolExecutor):  # pragma: no cover
     def __init__(self, max_workers: Optional[int] = None):
         super().__init__(max_workers=max_workers)
 
+    # pylint: disable=arguments-differ
     def submit(  # type: ignore
         self, fn: Callable[..., T], *args, **kwargs
     ) -> "Future[T]":
@@ -78,6 +79,7 @@ class ThreadPoolExecutor(_ThreadPoolExecutor):
     ):
         super().__init__(max_workers=max_workers, thread_name_prefix=thread_name_prefix)
 
+    # pylint: disable=arguments-differ
     def submit(  # type: ignore
         self, fn: Callable[..., T], *args, **kwargs
     ) -> "Future[T]":

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -29,6 +29,7 @@ class IDeref(Generic[T], ABC):
 class IBlockingDeref(IDeref[T]):
     __slots__ = ()
 
+    # pylint: disable=arguments-differ
     @abstractmethod
     def deref(
         self, timeout: Optional[float] = None, timeout_val: Optional[T] = None

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -110,7 +110,8 @@ LispReaderForm = Union[ReaderForm, Comment, "ReaderConditional"]
 RawReaderForm = Union[ReaderForm, "ReaderConditional"]
 
 
-@attr.s(  # pylint:disable=redefined-builtin
+# pylint:disable=redefined-builtin
+@attr.s(
     auto_attribs=True, repr=False, slots=True, str=False
 )
 class SyntaxError(Exception):

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -111,9 +111,7 @@ RawReaderForm = Union[ReaderForm, "ReaderConditional"]
 
 
 # pylint:disable=redefined-builtin
-@attr.s(
-    auto_attribs=True, repr=False, slots=True, str=False
-)
+@attr.s(auto_attribs=True, repr=False, slots=True, str=False)
 class SyntaxError(Exception):
     message: str
     line: Optional[int] = None

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -25,7 +25,7 @@ class TransientVector(ITransientVector[T]):
     __slots__ = ("_inner",)
 
     def __init__(self, wrapped: "PVectorEvolver[T]") -> None:
-        self._inner = wrapped
+        self._inner = wrapped  # pylint: disable=assigning-non-slot
 
     def __bool__(self):
         return True

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,coverage,py{36,37,38}-mypy,format,lint,safety
+envlist = py36,py37,py38,pypy3,coverage,py{36,37,38}-mypy,py{36,37,38}-lint,format,safety
 
 [testenv]
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
@@ -69,7 +69,7 @@ deps = mypy
 commands =
     mypy --config-file={toxinidir}/mypy.ini --show-error-codes src/basilisp
 
-[testenv:lint]
+[testenv:py{36,37,38}-lint]
 deps = prospector==1.2.0
 commands =
     prospector --profile-path={toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,coverage,mypy,format,lint,safety
+envlist = py36,py37,py38,pypy3,coverage,py{36,37,38}-mypy,format,lint,safety
 
 [testenv]
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
@@ -64,7 +64,7 @@ commands =
     isort --check-only
     black --check .
 
-[testenv:mypy]
+[testenv:py{36,37,38}-mypy]
 deps = mypy
 commands =
     mypy --config-file={toxinidir}/mypy.ini --show-error-codes src/basilisp


### PR DESCRIPTION
Circle builds were taking 20-40 minutes running PyPy on one node, which really discouraged me from breaking up PRs into smaller pieces since I'd have to wait often times nearly an hour just to merge in a smaller change.

This PR breaks up Circle builds into multiple different nodes. PyPy runs on three different workers using Circle's builtin `parallelism` and test-splitting features. Each of the CPython test suites run in their own node with MyPy/PyLint (to ensure we're not missing any type or linting errors across versions) and Safety (to ensure dependency versions installed on different versions do not have any known CVEs) checks. CI checks which do not vary by version are checked on Python 3.8, since it's faster than other versions.