### PR TITLE
Fix some small issues in CircleCI configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            CCI_NODE_TESTS=$(circleci tests glob "tests/**/*_test.py" "tests/**/test_*.py" | circleci tests split --split-by=timings)
+            CCI_NODE_TESTS=$(circleci tests glob "tests/**/*_test.*py" "tests/**/test_*.*py" | circleci tests split --split-by=timings)
             printf "Test files:\n"
             echo "$CCI_NODE_TESTS"
             printf "\n"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ setenv =
 deps =
     coverage
     pygments
-    six==1.10.0
 commands =
     coverage run \
              --source={envsitepackagesdir}/basilisp \
@@ -22,7 +21,6 @@ depends = py36, py37, py38
 deps =
     coveralls
     coverage
-    six==1.10.0
 passenv =
     COVERALLS_REPO_TOKEN
 usedevelop = true
@@ -54,7 +52,7 @@ exclude_lines =
     if __name__ == .__main__.:
 
 [pytest]
-junit_family = xunit2
+junit_family = legacy
 
 [testenv:format]
 deps =


### PR DESCRIPTION
Three fixes for CircleCI:
 * No longer lock the version of `six` for tests, since `tox` requires a much higher version of `six` now.
 * Include `*.lpy` test files.
 * Revert to the `legacy` JUnit family output from PyTest since that seems to be what CircleCI understands for test timings.