### PR TITLE
Fix several small bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Keyword hashes are now pre-computed when they are created, so they do not need to be recomputed again to be fetched from the intern cache (#592)
  * The compiler now uses the pre-computed hash to lookup keywords directly, which should improve lookup time for repeated invocations (#592)
  * Symbol hashes are now pre-computed when they are created (#592)
+ * Moved `basilisp.core.template` to `basilisp.template` to match Clojure (#599)
 
 ### Fixed
  * Fixed a bug where `def` forms did not permit recursive references to the `def`'ed Vars (#578)
  * Fixed a bug where `concat` could cause a `RecursionEror` if used on a `LazySeq` instance which itself calls `concat` (#588)
+ * Fixed a bug where map literals in function reader macro forms caused errors during reading (#599)
+ * Fixed a bug where `some->` and `some->>` threading macros would thread `nil` first arguments (#599)
 
 ### Removed
  * Removed `pyfunctional` dependency in favor of Python standard library functions (#589)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3345,8 +3345,8 @@
   is nil or there are no more forms."
   [x & forms]
   (if (seq forms)
-    `(let [result# (-> ~x ~(first forms))]
-       (when-not (nil? result#)
+    `(when-not (nil? ~x)
+       (let [result# (-> ~x ~(first forms))]
          (some-> result# ~@(next forms))))
     x))
 
@@ -3355,8 +3355,8 @@
   is nil or there are no more forms."
   [x & forms]
   (if (seq forms)
-    `(let [result# (->> ~x ~(first forms))]
-       (when-not (nil? result#)
+    `(when-not (nil? ~x)
+       (let [result# (->> ~x ~(first forms))]
          (some->> result# ~@(next forms))))
     x))
 

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -951,7 +951,7 @@ def _walk(inner_f, outer_f, form):
     elif isinstance(form, IPersistentVector):
         return outer_f(vector.vector(map(inner_f, form)))
     elif isinstance(form, IPersistentMap):
-        return outer_f(lmap.from_entries(map(inner_f, form)))
+        return outer_f(lmap.hash_map(*chain.from_iterable(map(inner_f, form.seq()))))
     elif isinstance(form, IPersistentSet):
         return outer_f(lset.set(map(inner_f, form)))
     else:

--- a/src/basilisp/template.lpy
+++ b/src/basilisp/template.lpy
@@ -1,4 +1,4 @@
-(ns basilisp.core.template
+(ns basilisp.template
   (:require
    [basilisp.walk :refer [postwalk-replace]]))
 

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -2,7 +2,7 @@
   (:import
    inspect)
   (:require
-   [basilisp.core.template :as template]))
+   [basilisp.template :as template]))
 
 (def ^:private current-test-number
   (atom 0))

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -1157,6 +1157,13 @@ def test_function_reader_macro():
         ),
         llist.l(sym.symbol("identity"), sym.symbol("arg-3"), sym.symbol("arg-rest")),
     )
+    assert read_str_first("#(identity {:arg %})") == llist.l(
+        sym.symbol("fn*"),
+        vec.v(sym.symbol("arg-1"),),
+        llist.l(
+            sym.symbol("identity"), lmap.map({kw.keyword("arg"): sym.symbol("arg-1")})
+        ),
+    )
 
     with pytest.raises(reader.SyntaxError):
         read_str_first("#(identity #(%1 %2))")

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -563,18 +563,22 @@
   (is (= 2 (some-> 1 inc)))
   (is (= 1 (some-> 1 inc dec)))
   (is (= 4 (some-> 10 inc (- 7))))
+  (is (= "the-key" (some-> (:key {:key :the-key}) (name))))
 
   (is (= nil (some-> {:a 3} :b inc)))
-  (is (= 4 (some-> {:a 3} :a inc))))
+  (is (= 4 (some-> {:a 3} :a inc)))
+  (is (= nil (some-> (:key {}) (name)))))
 
 (deftest some->>-test
   (is (= :a (some->> :a)))
   (is (= 2 (some->> 1 inc)))
   (is (= 1 (some->> 1 inc dec)))
   (is (= -4 (some->> 10 inc (- 7))))
+  (is (= "the-key" (some->> (:key {:key :the-key}) (name))))
 
   (is (= nil (some->> {:a 3} :b (- 7))))
-  (is (= 5 (some->> {:a 3} :a (- 8)))))
+  (is (= 5 (some->> {:a 3} :a (- 8))))
+  (is (= nil (some->> (:key {}) (name)))))
 
 (deftest cond->-test
   (is (= 1 (cond-> 1)))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -1,4 +1,4 @@
-(ns basilisp.test-edn
+(ns tests.basilisp.test-edn
   (:require
    [basilisp.edn :as edn]
    [basilisp.test :refer [deftest are is testing]]))

--- a/tests/basilisp/test_walk.lpy
+++ b/tests/basilisp/test_walk.lpy
@@ -1,4 +1,4 @@
-(ns tests.basilisp.walk-test
+(ns tests.basilisp.test-walk
   (:require
    [basilisp.test :refer [deftest is testing]]
    [basilisp.walk :as walk]))
@@ -104,9 +104,9 @@
   `(pl ~c1 (minus ~c1 ~c2)))
 
 (deftest macroexpand-all-test
-  (is (= '(tests.basilisp.walk-test/pl 20 (tests.basilisp.walk-test/minus 20 30))
+  (is (= '(tests.basilisp.test-walk/pl 20 (tests.basilisp.test-walk/minus 20 30))
          (macroexpand-1 '(calc 20 30))))
-  (is (= '(basilisp.core/+ 20 (tests.basilisp.walk-test/minus 20 30))
+  (is (= '(basilisp.core/+ 20 (tests.basilisp.test-walk/minus 20 30))
          (macroexpand '(calc 20 30))))
   (is (= '(basilisp.core/+ 20 (basilisp.core/- 20 30))
          (walk/macroexpand-all '(calc 20 30)))))


### PR DESCRIPTION
Fixes #597 
Fixes #598 

Two other smaller issues that didn't warrant writing up as issues:
 * Rename `tests.basilisp.test-edn` and ` tests.basilisp.test-walk` namespaces so they would be correctly picked up for timing info by CircleCI (and just generally to match the patterns used by the other Basilisp tests).
 * Rename `basilisp.core.template` to `basilisp.template` to match Clojure's organization.