### PR TITLE
Add support for serializing EDN strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added the current Python version (`:lpy36`, `:lpy37`, etc.) as a default reader feature for reader conditionals (#585)
  * Added default reader features for matching Python version ranges (`:lpy36+`, `:lpy38-`, etc.) (#593)
  * Added `lazy-cat` function for lazily concatenating sequences (#588)
+ * Added support for writing EDN strings from `basilisp.edn` (#600)
 
 ### Changed
  * Moved `basilisp.lang.runtime.to_seq` to `basilisp.lang.seq` so it can be used within that module and by `basilisp.lang.runtime` without circular import (#588)

--- a/src/basilisp/edn.lpy
+++ b/src/basilisp/edn.lpy
@@ -1,6 +1,7 @@
 (ns basilisp.edn
   (:refer-basilisp :exclude [read read-string])
-  (:require [basilisp.string :as str]))
+  (:require [basilisp.string :as str])
+  (:import datetime uuid))
 
 (declare ^:private read-next
          ^:private read-sym-or-num)
@@ -492,6 +493,66 @@
                 {:error :eof}))
       e)))
 
+;;;;;;;;;;;;;
+;; Writers ;;
+;;;;;;;;;;;;;
+
+(defprotocol EDNEncodeable
+  (write* [this writer]
+    "Write the EDN encoded `this` to the stream `writer`."))
+
+(defn ^:private write-seq
+  [e writer start-token end-token]
+  (.write writer start-token)
+  (doseq [entry (map-indexed (fn [i v] [i v]) (seq e))
+          :let  [[i v] entry]]
+    (when (pos? i)
+      (.write writer " "))
+    (write* v writer))
+  (.write writer end-token))
+
+(defn ^:private write-scalar
+  [e writer]
+  (.write writer (repr e)))
+
+(extend-protocol EDNEncodeable
+  basilisp.lang.interfaces/IPersistentMap
+  (write* [this writer]
+    (.write writer "{")
+    (doseq [entry (map-indexed (fn [i [k v]] [i k v]) (seq this))
+            :let  [[i k v] entry]]
+      (when (pos? i)
+        (.write writer " "))
+      (write* k writer)
+      (.write writer " ")
+      (write* v writer))
+    (.write writer "}"))
+  basilisp.lang.interfaces/IPersistentList
+  (write* [this writer]
+    (write-seq this writer "(" ")"))
+  basilisp.lang.interfaces/IPersistentSet
+  (write* [this writer]
+    (write-seq this writer "#{" "}"))
+  basilisp.lang.interfaces/IPersistentVector
+  (write* [this writer]
+    (write-seq this writer "[" "]"))
+  basilisp.lang.symbol/Symbol
+  (write* [this writer]
+    (if-let [ns (namespace this)]
+      (.write (str (namespace this) "/" (name this)))
+      (.write (str (name this))))))
+
+(extend basilisp.lang.keyword/Keyword EDNEncodeable {:write* write-scalar})
+
+(extend python/str   EDNEncodeable {:write* write-scalar})
+(extend python/int   EDNEncodeable {:write* write-scalar})
+(extend python/float EDNEncodeable {:write* write-scalar})
+(extend python/bool  EDNEncodeable {:write* write-scalar})
+(extend nil          EDNEncodeable {:write* write-scalar})
+
+(extend datetime/datetime  EDNEncodeable {:write* write-scalar})
+(extend uuid/UUID          EDNEncodeable {:write* write-scalar})
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Public Interface ;;
 ;;;;;;;;;;;;;;;;;;;;;;
@@ -527,3 +588,26 @@
    (when-not (and (nil? s) (= "" s))
      (-> (io/StringIO s)
          (read opts)))))
+
+(defn write
+  "Serialize the object `o` as EDN to the writer object `writer` (which must be
+  any file-like object supporting `.write()` method).
+
+  All Basilisp data structures are serializable to EDN by default. UUIDs and
+  Instants (Python `datetime`s) are also supported by default. Support for other
+  types may be added by extending the `EDNEncodeable` protocol for that type."
+  ([o]
+   (write o *out*))
+  ([o writer]
+   (write* o writer)))
+
+(defn write-string
+  "Serialize the object `o` as EDN and return the serialized object as a string.
+
+  All Basilisp data structures are serializable to EDN by default. UUIDs and
+  Instants (Python `datetime`s) are also supported by default. Support for other
+  types may be added by extending the `EDNEncodeable` protocol for that type."
+  [o]
+  (let [buf (io/StringIO "")]
+    (write o buf)
+    (.getvalue buf)))

--- a/src/basilisp/edn.lpy
+++ b/src/basilisp/edn.lpy
@@ -1,7 +1,7 @@
 (ns basilisp.edn
   (:refer-basilisp :exclude [read read-string])
   (:require [basilisp.string :as str])
-  (:import datetime uuid))
+  (:import datetime math uuid))
 
 (declare ^:private read-next
          ^:private read-sym-or-num)
@@ -15,22 +15,37 @@
   (python/object))
 
 (def ^:private default-edn-data-readers
-  "Map of default data readers, which wrap the default readers and convert the
-  SyntaxErrors into standard ExceptionInfo types."
-  (reduce-kv (fn [m k tag-reader]
-               (assoc m k (fn [v]
-                            (try
-                              (tag-reader v)
-                              (catch basilisp.lang.reader/SyntaxError e
-                                (throw
-                                 (ex-info (get (.-args e) 0)
-                                          {:error :tag-reader-error})))))))
-             {}
-             (dissoc default-data-readers 'py)))
+  {'inst (fn [v]
+           (try
+             (basilisp.lang.util/inst-from-str v)
+             (catch python/OverflowError _
+               (throw
+                (ex-info (str "Unrecognized date/time syntax: " v)
+                         {:error :tag-reader-error})))
+             (catch python/ValueError _
+               (throw
+                (ex-info (str "Unrecognized date/time syntax: " v)
+                         {:error :tag-reader-error})))))
+   'uuid (fn [v]
+           (try
+             (basilisp.lang.util/uuid-from-str v)
+             (catch python/TypeError _
+               (throw
+                (ex-info (str "Unrecognized UUID format: " v)
+                         {:error :tag-reader-error})))
+             (catch python/ValueError _
+               (throw
+                (ex-info (str "Unrecognized UUID syntax: " v)
+                         {:error :tag-reader-error})) )))})
 
 (def ^:private eof
   "EOF marker if none is supplied."
   (python/object))
+
+(def ^:private numeric-constants
+  {'Inf  (python/float "inf")
+   '-Inf (- (python/float "inf"))
+   'NaN  (python/float "nan")})
 
 (def ^:private special-chars
   "A mapping of special character names to the characters they represent."
@@ -190,6 +205,7 @@
     (case (.peek reader)
       "_" :comment
       "{" :set
+      "#" :constant
       :tag)))
 
 (defmethod read-dispatch :comment
@@ -197,6 +213,23 @@
   (assert-starts reader "_")
   (read-next reader opts)
   comment)
+
+(defmethod read-dispatch :constant
+  [reader opts]
+  (assert-starts reader "#")
+  (let [const-sym (read-sym-or-num reader opts)]
+    (when-not (symbol? const-sym)
+      (throw
+       (ex-info "Reader constant must be a symbol"
+                {:error :reader-constant-not-symbol
+                 :type  (type const-sym)
+                 :value const-sym})))
+    (if-let [const (get numeric-constants const-sym)]
+      const
+      (throw
+       (ex-info "Unrecognized reader constant"
+                {:error :no-reader-constant-for-symbol
+                 :sym   const-sym})))))
 
 (defmethod read-dispatch :set
   [reader opts]
@@ -503,6 +536,12 @@
 
      Writer will be a file-like object supporting a `.write()` method."))
 
+;; Rather than relying on the existing Lisp representations, we use custom
+;; implementations to avoid picking up any of the dynamic Vars which affect
+;; the result of `repr` calls. These include things like writing metadata or
+;; printing strings without quotes, neither of which is supported by the EDN
+;; spec.
+
 (defn ^:private write-seq
   [e writer start-token end-token]
   (.write writer start-token)
@@ -512,11 +551,6 @@
       (.write writer " "))
     (write* v writer))
   (.write writer end-token)
-  nil)
-
-(defn ^:private write-scalar
-  [e writer]
-  (.write writer (repr e))
   nil)
 
 (extend-protocol EDNEncodeable
@@ -542,36 +576,59 @@
   (write* [this writer]
     (write-seq this writer "[" "]"))
 
-  ;; Use a custom implementation for symbols and strings rather than `write-scalar`
-  ;; to avoid picking up any of the dynamic Vars which affect `repr` calls.
-  ;; These could include things like writing metadata (which is not supported by
-  ;; the EDN spec) or print strings without quotes, which would obviously screw
-  ;; up the emitted EDN.
+  basilisp.lang.keyword/Keyword
+  (write* [this writer]
+    (.write writer ":")
+    (if-let [ns (namespace this)]
+      (.write writer (str ns "/" (name this)))
+      (.write writer (str (name this))))
+    nil)
   basilisp.lang.symbol/Symbol
   (write* [this writer]
     (if-let [ns (namespace this)]
-      (.write (str (namespace this) "/" (name this)))
-      (.write (str (name this))))
+      (.write writer (str ns "/" (name this)))
+      (.write writer (str (name this))))
+    nil)
+
+  python/bool
+  (write* [this writer]
+    (.write writer (str/lower-case (python/repr this)))
+    nil)
+  python/int
+  (write* [this writer]
+    (.write writer (python/repr this))
+    nil)
+  python/float
+  (write* [this writer]
+    (->> (cond
+           (math/isinf this) (if (pos? this) "##Inf" "##-Inf")
+           (math/isnan this) "##NaN"
+           :else             (python/repr this))
+         (.write writer))
     nil)
   python/str
   (write* [this writer]
-    (let [encoded (-> this
-                      (.encode "unicode_escape")
-                      (.decode "utf-8"))]
-      (.write writer "\"")
-      (.write writer encoded)
-      (.write writer "\"")
-      nil)))
+    (.write writer "\"")
+    (.write writer this)
+    (.write writer "\"")
+    nil)
+  nil
+  (write* [this writer]
+    (.write writer "nil")
+    nil)
 
-(extend basilisp.lang.keyword/Keyword EDNEncodeable {:write* write-scalar})
-
-(extend python/int   EDNEncodeable {:write* write-scalar})
-(extend python/float EDNEncodeable {:write* write-scalar})
-(extend python/bool  EDNEncodeable {:write* write-scalar})
-(extend nil          EDNEncodeable {:write* write-scalar})
-
-(extend datetime/datetime  EDNEncodeable {:write* write-scalar})
-(extend uuid/UUID          EDNEncodeable {:write* write-scalar})
+  datetime/datetime
+  (write* [this writer]
+    (.write writer "#inst \"")
+    (.write writer (.isoformat this))
+    (.write writer "\"")
+    nil)
+  uuid/UUID
+  (write* [this writer]
+    (.write writer "#uuid \"")
+    (.write writer (python/str this))
+    (.write writer "\"")
+    nil))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Public Interface ;;

--- a/src/basilisp/edn.lpy
+++ b/src/basilisp/edn.lpy
@@ -499,7 +499,9 @@
 
 (defprotocol EDNEncodeable
   (write* [this writer]
-    "Write the EDN encoded `this` to the stream `writer`."))
+    "Write the object `this` to the stream `writer` encoded as EDN.
+
+     Writer will be a file-like object supporting a `.write()` method."))
 
 (defn ^:private write-seq
   [e writer start-token end-token]

--- a/src/basilisp/edn.lpy
+++ b/src/basilisp/edn.lpy
@@ -509,11 +509,13 @@
     (when (pos? i)
       (.write writer " "))
     (write* v writer))
-  (.write writer end-token))
+  (.write writer end-token)
+  nil)
 
 (defn ^:private write-scalar
   [e writer]
-  (.write writer (repr e)))
+  (.write writer (repr e))
+  nil)
 
 (extend-protocol EDNEncodeable
   basilisp.lang.interfaces/IPersistentMap
@@ -526,7 +528,8 @@
       (write* k writer)
       (.write writer " ")
       (write* v writer))
-    (.write writer "}"))
+    (.write writer "}")
+    nil)
   basilisp.lang.interfaces/IPersistentList
   (write* [this writer]
     (write-seq this writer "(" ")"))
@@ -536,15 +539,30 @@
   basilisp.lang.interfaces/IPersistentVector
   (write* [this writer]
     (write-seq this writer "[" "]"))
+
+  ;; Use a custom implementation for symbols and strings rather than `write-scalar`
+  ;; to avoid picking up any of the dynamic Vars which affect `repr` calls.
+  ;; These could include things like writing metadata (which is not supported by
+  ;; the EDN spec) or print strings without quotes, which would obviously screw
+  ;; up the emitted EDN.
   basilisp.lang.symbol/Symbol
   (write* [this writer]
     (if-let [ns (namespace this)]
       (.write (str (namespace this) "/" (name this)))
-      (.write (str (name this))))))
+      (.write (str (name this))))
+    nil)
+  python/str
+  (write* [this writer]
+    (let [encoded (-> this
+                      (.encode "unicode_escape")
+                      (.decode "utf-8"))]
+      (.write writer "\"")
+      (.write writer encoded)
+      (.write writer "\"")
+      nil)))
 
 (extend basilisp.lang.keyword/Keyword EDNEncodeable {:write* write-scalar})
 
-(extend python/str   EDNEncodeable {:write* write-scalar})
 (extend python/int   EDNEncodeable {:write* write-scalar})
 (extend python/float EDNEncodeable {:write* write-scalar})
 (extend python/bool  EDNEncodeable {:write* write-scalar})

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -367,3 +367,38 @@
     "Regular string"               "\"Regular string\""
     "String with 'inner string'"   "\"String with 'inner string'\""
     "String with \"inner string\"" "\"String with \"inner string\"\""))
+
+(deftest write-dispatch
+  (are [v s] (= s (edn/write-string v))
+    #inst "2018-01-18T03:26:57.296-00:00"        "#inst \"2018-01-18T03:26:57.296000+00:00\""
+    #uuid "4ba98ef0-0620-4966-af61-f0f6c2dbf230" "#uuid \"4ba98ef0-0620-4966-af61-f0f6c2dbf230\""))
+
+(deftest write-map
+  (are [v s] (= s (edn/write-string v))
+    {}                      "{}"
+    {:a 1}                  "{:a 1}"
+    {:a {:b 1}}             "{:a {:b 1}}"
+    {:a [true false 1 2 3]} "{:a [true false 1 2 3]}"
+    {:b '(:a 5 "string")}   "{:b (:a 5 \"string\")}"))
+
+(deftest write-list
+  (are [v s] (= s (edn/write-string v))
+    '()                                      "()"
+    '(:a)                                    "(:a)"
+    '([:a])                                  "([:a])"
+    '(:a :b 3 "4")                           "(:a :b 3 \"4\")"
+    '(:a :c {:ns/kw [thing "other thing"]}) "(:a :c {:ns/kw [thing \"other thing\"]})"))
+
+(deftest write-set
+  (are [v s] (contains? s (edn/write-string v))
+    #{}        #{"#{}"}
+    #{:a}      #{"#{:a}"}
+    #{:a [:c]} #{"#{:a [:c]}" "#{[:c] :a}"}
+    #{:a :b}   #{"#{:a :b}" "#{:b a}"}))
+
+(deftest write-vector
+  (are [v s] (= s (edn/write-string v))
+    []                                        "[]"
+    [:a]                                      "[:a]"
+    [:a :a :b :c]                             "[:a :a :b :c]"
+    [:a :c {:d #{:e} :f '(1 2 3)} [:h :i :j]] "[:a :c {:d #{:e} :f (1 2 3)} [:h :i :j]]"))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -1,7 +1,12 @@
 (ns tests.basilisp.test-edn
   (:require
    [basilisp.edn :as edn]
-   [basilisp.test :refer [deftest are is testing]]))
+   [basilisp.test :refer [deftest are is testing]])
+  (:import math))
+
+;;;;;;;;;;;;;;;;;;
+;; Reader Tests ;;
+;;;;;;;;;;;;;;;;;;
 
 (deftest read-base-cases
   (are [s v] (= v (edn/read-string s))
@@ -31,6 +36,10 @@
     "-1.332"     -1.332
     "-1.0"       -1.0
     "-0.332"     -0.332)
+
+  (is (math/isinf (edn/read-string "##Inf")))
+  (is (math/isinf (edn/read-string "##-Inf")))
+  (is (math/isnan (edn/read-string "##NaN")))
 
   (are [s] (thrown? basilisp.lang.exception/ExceptionInfo
                     (edn/read-string s))
@@ -239,3 +248,122 @@
     "["
     "[:a"
     "[:a :b"))
+
+;;;;;;;;;;;;;;;;;;
+;; Writer Tests ;;
+;;;;;;;;;;;;;;;;;;
+
+(deftest write-constants
+  (are [v s] (= s (edn/write-string v))
+    nil    "nil"
+    true   "true"
+    false  "false"
+    ##-Inf "##-Inf"
+    ##Inf  "##Inf"
+    ##NaN  "##NaN"))
+
+(deftest write-numeric
+  (are [v s] (= s (edn/write-string v))
+    0        "0"
+    1        "1"
+    100      "100"
+    99927273 "99927273"
+    -1       "-1"
+    -538282  "-538282"
+
+    0.0        "0.0"
+    0.09387372 "0.09387372"
+    1.0        "1.0"
+    -1.332     "-1.332"
+    -1.0       "-1.0"
+    -0.332     "-0.332"))
+
+(deftest write-symbol
+  (are [v s] (= s (edn/write-string v))
+    'sym           "sym"
+    'kebab-kw      "kebab-kw"
+    'underscore_kw "underscore_kw"
+    'kw?           "kw?"
+    '+             "+"
+    '?             "?"
+    '=             "="
+    '!             "!"
+    '-             "-"
+    '*             "*"
+    '/             "/"
+    '>             ">"
+    '->            "->"
+    '->>           "->>"
+    '-->           "-->"
+    '<             "<"
+    '<-            "<-"
+    '<--           "<--"
+    '<body>        "<body>"
+    '*muffs*       "*muffs*"
+    'yay!          "yay!"
+    '.interop      ".interop"
+    'ns.name       "ns.name"
+
+    'ns/sym                  "ns/sym"
+    'qualified.ns/sym        "qualified.ns/sym"
+    'really.qualified.ns/sym "really.qualified.ns/sym"))
+
+(deftest write-keyword
+  (are [v s] (= s (edn/write-string v))
+    :kw               ":kw"
+    :kebab-kw         ":kebab-kw"
+    :underscore_kw    ":underscore_kw"
+    :kw?              ":kw?"
+    :+                ":+"
+    :?                ":?"
+    :=                ":="
+    :!                ":!"
+    :-                ":-"
+    :*                ":*"
+    :/                ":/"
+    :>                ":>"
+    :->               ":->"
+    :->>              ":->>"
+    :-->              ":-->"
+    :---------------> ":--------------->"
+    :<                ":<"
+    :<-               ":<-"
+    :<--              ":<--"
+    :<body>           ":<body>"
+    :*muffs*          ":*muffs*"
+    :yay!             ":yay!"
+
+    :ns/kw                   ":ns/kw"
+    :qualified.ns/kw         ":qualified.ns/kw"
+    :really.qualified.ns/kw ":really.qualified.ns/kw"))
+
+(deftest write-character
+  (are [v s] (= s (edn/write-string v))
+    \a "\"a\""
+    \Ω "\"Ω\""
+
+    \u03A9 "\"Ω\""
+
+    \space   "\" \""
+    \newline "\"\n\""
+    \tab     "\"\t\""
+    \return  "\"\r\""))
+
+(deftest write-string
+  (are [v s] (= s (edn/write-string v))
+    ""   "\"\""
+    " "  "\" \""
+    "\"" "\"\"\""
+    "\\" "\"\\\""
+    "\a" "\"\a\""
+    "\b" "\"\b\""
+    "\f" "\"\f\""
+    "\n" "\"\n\""
+    "\r" "\"\r\""
+    "\t" "\"\t\""
+    "\v" "\"\v\""
+
+    "Hello,\nmy name is\tChris."   "\"Hello,\nmy name is\tChris.\""
+    "Regular string"               "\"Regular string\""
+    "String with 'inner string'"   "\"String with 'inner string'\""
+    "String with \"inner string\"" "\"String with \"inner string\"\""))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -44,7 +44,9 @@
   (are [s] (thrown? basilisp.lang.exception/ExceptionInfo
                     (edn/read-string s))
     "0..11"
-    "0.111.9"))
+    "0.111.9"
+    "##pi"
+    "##:NaN"))
 
 (deftest read-symbol
   (are [s v] (= v (edn/read-string s))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -412,7 +412,7 @@
     #{}        #{"#{}"}
     #{:a}      #{"#{:a}"}
     #{:a [:c]} #{"#{:a [:c]}" "#{[:c] :a}"}
-    #{:a :b}   #{"#{:a :b}" "#{:b a}"}))
+    #{:a :b}   #{"#{:a :b}" "#{:b :a}"}))
 
 (deftest write-vector
   (are [v s] (= s (edn/write-string v))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -398,7 +398,7 @@
 
 (deftest write-vector
   (are [v s] (= s (edn/write-string v))
-    []                                        "[]"
-    [:a]                                      "[:a]"
-    [:a :a :b :c]                             "[:a :a :b :c]"
-    [:a :c {:d #{:e} :f '(1 2 3)} [:h :i :j]] "[:a :c {:d #{:e} :f (1 2 3)} [:h :i :j]]"))
+    []                                          "[]"
+    [:a]                                        "[:a]"
+    [:a :a :b :c]                               "[:a :a :b :c]"
+    [:a :c {:d #{:e}} {:f '(1 2 3)} [:h :i :j]] "[:a :c {:d #{:e}} {:f (1 2 3)} [:h :i :j]]"))

--- a/tests/basilisp/test_edn.lpy
+++ b/tests/basilisp/test_edn.lpy
@@ -253,6 +253,22 @@
 ;; Writer Tests ;;
 ;;;;;;;;;;;;;;;;;;
 
+(deftest write-base-cases
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string #py ())))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string #py #{})))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string #py [])))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string #py {})))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string (python/object))))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string 3.14M)))
+  (is (thrown? basilisp.lang.exception/ExceptionInfo
+               (edn/write-string 22/7))))
+
 (deftest write-constants
   (are [v s] (= s (edn/write-string v))
     nil    "nil"


### PR DESCRIPTION
 * Add a safe `basilisp.edn/write-string` function for emitting only the EDN subset of Clojure data structures (which should be safer than using `pr-str` to print EDN).
 * Detach `basilisp.edn`'s default reader tags from those defined in `basilisp.lang.reader`, since we wouldn't want to accidentally add new default reader tags and have `basilisp.edn` support those tags unwittingly.
 * Add support for reading `##Inf`, `##-Inf`, and `##NaN` reader constants.

Fixes #560 