### PR TITLE
Upgrade isort and set default dev interpreter to Python 3.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docs:
 
 .PHONY: format
 format:
-	@pipenv run sh -c 'isort -rc . && black .'
+	@pipenv run sh -c 'isort --profile black . && black .'
 
 
 lispcore.py:

--- a/Pipfile
+++ b/Pipfile
@@ -28,7 +28,7 @@ python-dateutil = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.8"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "357ef5b5261a432e607bc8bc66e3311c04b289d900af0a706c7db4b93bf6a848"
+            "sha256": "cee6b828641062855ac768372e5fab068b276edb6210d26f95685090f4600262"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.8"
         },
         "sources": [
             {
@@ -60,9 +60,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
+                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "filelock": {
             "hashes": [
@@ -88,22 +89,6 @@
             ],
             "index": "pypi",
             "version": "==0.14"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
-                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.1"
-        },
-        "importlib-resources": {
-            "hashes": [
-                "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6",
-                "sha256:f5edfcece1cc9435d0979c19e08739521f4cf1aa1adaf6e571f732df6f568962"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==2.0.1"
         },
         "more-itertools": {
             "hashes": [
@@ -139,11 +124,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44",
-                "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.8.2"
+            "version": "==1.9.0"
         },
         "pyparsing": {
             "hashes": [
@@ -193,34 +178,26 @@
         },
         "tox": {
             "hashes": [
-                "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e",
-                "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"
+                "sha256:60c3793f8ab194097ec75b5a9866138444f63742b0f664ec80be1222a40687c5",
+                "sha256:9a746cda9cadb9e1e05c7ab99f98cfcea355140d2ecac5f97520be94657c3bc7"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.15.2"
+            "version": "==3.16.1"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1b253c5d0e76afe24c76ce288cdd5dd01ac7deaa55f644998c74e5a799349522",
-                "sha256:680011aa2995fb8b7c2bbea7da7afd8dcaf382def7a3e02a1b1fba4b402aa8cf"
+                "sha256:c11a475400e98450403c0364eb3a2d25d42f71cf1493da64390487b666de4324",
+                "sha256:e10cc66f40cbda459720dfe1d334c4dc15add0d80f09108224f171006a97a172"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.0.24"
+            "version": "==20.0.26"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.1.0"
+            "version": "==0.2.5"
         }
     },
     "develop": {
@@ -292,11 +269,20 @@
             "index": "pypi",
             "version": "==7.1.2"
         },
+        "colorama": {
+            "hashes": [
+                "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
+                "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.3"
+        },
         "distlib": {
             "hashes": [
-                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
+                "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb",
+                "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "docutils": {
             "hashes": [
@@ -316,11 +302,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
-                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.9"
+            "version": "==2.10"
         },
         "imagesize": {
             "hashes": [
@@ -330,29 +316,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.2.0"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:0505dd08068cfec00f53a74a0ad927676d7757da81b7436a6eefe4c7cf75c545",
-                "sha256:15ec6c0fd909e893e3a08b3a7c76ecb149122fb14b7efe1199ddd4c7c57ea958"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==1.6.1"
-        },
-        "importlib-resources": {
-            "hashes": [
-                "sha256:83985739b3a6679702f9ab33f0ad016ad564664d0568a31ac14d7c64789453e6",
-                "sha256:f5edfcece1cc9435d0979c19e08739521f4cf1aa1adaf6e571f732df6f568962"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==2.0.1"
-        },
         "isort": {
             "hashes": [
-                "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1",
-                "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
+                "sha256:cb76a2fac5ac08eae0020f7e56bab895cf3d8982034aa16f3cd67984edf26223",
+                "sha256:e7b11f4317c0668bd2a25f924c14338ca39b92723f24bdaef37452af0dd5a87b"
             ],
             "index": "pypi",
-            "version": "==4.3.21"
+            "version": "==5.0.5"
         },
         "jinja2": {
             "hashes": [
@@ -449,11 +419,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:a673fa23d7000440cc885c17dbd34fafcb7d7a6e230b29f6766400de36a33c44",
-                "sha256:f3b3a4c36512a4c4f024041ab51866f11761cc169670204b235f6b20523d4e6b"
+                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
+                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.8.2"
+            "version": "==1.9.0"
         },
         "pygments": {
             "hashes": [
@@ -542,6 +512,13 @@
             ],
             "version": "==0.9.1"
         },
+        "rfc3986": {
+            "hashes": [
+                "sha256:112398da31a3344dc25dbf477d8df6cb34f9278a94fee2625d89e4514be8bb9d",
+                "sha256:af9147e9aceda37c91a05f4deb128d4b4b49d6b199775fd2d2927768abdc8f50"
+            ],
+            "version": "==1.4.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -559,11 +536,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:74fbead182a611ce1444f50218a1c5fc70b6cc547f64948f5182fb30a2a20258",
-                "sha256:97c9e3bcce2f61d9f5edf131299ee9d1219630598d9f9a8791459a4d9e815be5"
+                "sha256:97dbf2e31fc5684bb805104b8ad34434ed70e6c588f6896991b2fdfd2bef8c00",
+                "sha256:b9daeb9b39aa1ffefc2809b43604109825300300b987a24f45976c001ba1a8fd"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.1.2"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -630,11 +607,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:50a188b8e17580c1fb931f494a754e6507d4185f54fb18aca5ba3e12d2ffd55e",
-                "sha256:c696d36cd7c6a28ada2da780400e44851b20ee19ef08cfe73344a1dcebbbe9f3"
+                "sha256:60c3793f8ab194097ec75b5a9866138444f63742b0f664ec80be1222a40687c5",
+                "sha256:9a746cda9cadb9e1e05c7ab99f98cfcea355140d2ecac5f97520be94657c3bc7"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==3.15.2"
+            "version": "==3.16.1"
         },
         "tox-pyenv": {
             "hashes": [
@@ -646,19 +623,19 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:07c06493f1403c1380b630ae3dcbe5ae62abcf369a93bbc052502279f189ab8c",
-                "sha256:cd140979c2bebd2311dfb14781d8f19bd5a9debb92dcab9f6ef899c987fcf71f"
+                "sha256:63ef7a6d3eb39f80d6b36e4867566b3d8e5f1fe3d6cb50c5e9ede2b3198ba7b7",
+                "sha256:7810e627bcf9d983a99d9ff8a0c09674400fd2927eddabeadf153c14a2ec8656"
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.46.1"
+            "version": "==4.47.0"
         },
         "twine": {
             "hashes": [
-                "sha256:c1af8ca391e43b0a06bbc155f7f67db0bf0d19d284bfc88d1675da497a946124",
-                "sha256:d561a5e511f70275e5a485a6275ff61851c16ffcb3a95a602189161112d9f160"
+                "sha256:34352fd52ec3b9d29837e6072d5a2a7c6fe4290e97bba46bb8d478b5c598f7ab",
+                "sha256:ba9ff477b8d6de0c89dd450e70b2185da190514e91c42cc62f96850025c10472"
             ],
             "index": "pypi",
-            "version": "==3.1.1"
+            "version": "==3.2.0"
         },
         "typed-ast": {
             "hashes": [
@@ -696,18 +673,18 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1b253c5d0e76afe24c76ce288cdd5dd01ac7deaa55f644998c74e5a799349522",
-                "sha256:680011aa2995fb8b7c2bbea7da7afd8dcaf382def7a3e02a1b1fba4b402aa8cf"
+                "sha256:c11a475400e98450403c0364eb3a2d25d42f71cf1493da64390487b666de4324",
+                "sha256:e10cc66f40cbda459720dfe1d334c4dc15add0d80f09108224f171006a97a172"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.0.24"
+            "version": "==20.0.26"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:79375666b9954d4a1a10739315816324c3e73110af9d0e102d906fdb0aec009f",
-                "sha256:8c6b5b6ee1360b842645f336d9e5d68c55817c26d3050f46b235ef2bc650e48f"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
-            "version": "==0.2.4"
+            "version": "==0.2.5"
         },
         "webencodings": {
             "hashes": [
@@ -715,14 +692,6 @@
                 "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
             ],
             "version": "==0.5.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
-                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.1.0"
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,6 @@ exclude = '''
 
 [tool.isort]
 known_first_party = 'basilisp'
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-line_length = 88
-combine_as_imports = true
 skip = [
   '.env',
   '.hg',

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -1,5 +1,5 @@
 import sys
-from ast import (  # noqa
+from ast import (
     AST,
     Add,
     And,
@@ -64,7 +64,9 @@ from ast import (  # noqa
     LtE,
     MatMult,
     Mod,
-    Module as _Module,
+)
+from ast import Module as _Module  # noqa
+from ast import (
     Mult,
     Name,
     NameConstant,
@@ -102,7 +104,9 @@ from ast import (  # noqa
     YieldFrom,
     alias,
     arg,
-    arguments as _arguments,
+)
+from ast import arguments as _arguments
+from ast import (
     boolop,
     cmpop,
     comprehension,

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -1,4 +1,6 @@
 import sys
+from ast import Ellipsis  # pylint: disable=redefined-builtin
+from ast import slice  # pylint: disable=redefined-builtin
 from ast import (
     AST,
     Add,
@@ -31,7 +33,6 @@ from ast import (
     Dict,
     DictComp,
     Div,
-    Ellipsis,
     Eq,
     ExceptHandler,
     Expr,
@@ -125,7 +126,6 @@ from ast import (
     mod,
     operator,
     parse,
-    slice,
     stmt,
     unaryop,
     walk,

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -6,11 +6,11 @@ from typing import Any
 import click
 import pytest
 
-import basilisp.lang.compiler as compiler
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
-import basilisp.main as basilisp
+from basilisp import main as basilisp
+from basilisp.lang import compiler as compiler
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from basilisp.prompt import get_prompter
 
 CLI_INPUT_FILE_PATH = "<CLI Input>"

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -10,10 +10,10 @@ from importlib.abc import MetaPathFinder, SourceLoader
 from importlib.machinery import ModuleSpec
 from typing import Iterable, List, Mapping, MutableMapping, Optional, cast
 
-import basilisp.lang.compiler as compiler
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
+from basilisp.lang import compiler as compiler
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from basilisp.lang.runtime import BasilispModule
 from basilisp.lang.typing import ReaderForm
 from basilisp.lang.util import demunge

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -5,9 +5,9 @@ from typing import Any, Callable, Iterable, List, Optional
 
 from astor import code_gen as codegen
 
-import basilisp._pyast as ast
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
+from basilisp import _pyast as ast
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
 from basilisp.lang.compiler.analyzer import (  # noqa
     WARN_ON_SHADOWED_NAME,
     WARN_ON_SHADOWED_VAR,
@@ -18,16 +18,15 @@ from basilisp.lang.compiler.analyzer import (  # noqa
     macroexpand_1,
 )
 from basilisp.lang.compiler.exception import CompilerException, CompilerPhase  # noqa
-from basilisp.lang.compiler.generator import (  # noqa
+from basilisp.lang.compiler.generator import (
     USE_VAR_INDIRECTION,
     WARN_ON_VAR_INDIRECTION,
     GeneratedPyAST,
     GeneratorContext,
-    expressionize as _expressionize,
-    gen_py_ast,
-    py_module_preamble,
-    statementize as _statementize,
 )
+from basilisp.lang.compiler.generator import expressionize as _expressionize  # noqa
+from basilisp.lang.compiler.generator import gen_py_ast, py_module_preamble
+from basilisp.lang.compiler.generator import statementize as _statementize
 from basilisp.lang.compiler.optimizer import PythonASTOptimizer
 from basilisp.lang.typing import CompilerOpts, ReaderForm
 from basilisp.lang.util import genname

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -32,14 +32,14 @@ from typing import (
 
 import attr
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.compiler.constants import (
     AMPERSAND,
     ARGLISTS_KW,
@@ -101,7 +101,9 @@ from basilisp.lang.compiler.nodes import (
     Local,
     LocalType,
     Loop,
-    Map as MapNode,
+)
+from basilisp.lang.compiler.nodes import Map as MapNode
+from basilisp.lang.compiler.nodes import (
     MaybeClass,
     MaybeHostForm,
     Node,
@@ -117,16 +119,11 @@ from basilisp.lang.compiler.nodes import (
     Reify,
     Require,
     RequireAlias,
-    Set as SetNode,
-    SetBang,
-    SpecialFormNode,
-    Throw,
-    Try,
-    VarRef,
-    Vector as VectorNode,
-    WithMeta,
-    deftype_or_reify_python_member_names,
 )
+from basilisp.lang.compiler.nodes import Set as SetNode
+from basilisp.lang.compiler.nodes import SetBang, SpecialFormNode, Throw, Try, VarRef
+from basilisp.lang.compiler.nodes import Vector as VectorNode
+from basilisp.lang.compiler.nodes import WithMeta, deftype_or_reify_python_member_names
 from basilisp.lang.interfaces import IMeta, IRecord, ISeq, IType, IWithMeta
 from basilisp.lang.runtime import Var
 from basilisp.lang.typing import CompilerOpts, LispForm, ReaderForm

--- a/src/basilisp/lang/compiler/constants.py
+++ b/src/basilisp/lang/compiler/constants.py
@@ -1,5 +1,5 @@
-import basilisp.lang.keyword as kw
-import basilisp.lang.symbol as sym
+from basilisp.lang import keyword as kw
+from basilisp.lang import symbol as sym
 
 
 class SpecialForm:

--- a/src/basilisp/lang/compiler/exception.py
+++ b/src/basilisp/lang/compiler/exception.py
@@ -3,9 +3,9 @@ from typing import Optional, Union
 
 import attr
 
-import basilisp._pyast as ast
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
+from basilisp import _pyast as ast
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
 from basilisp.lang.compiler.nodes import Node
 from basilisp.lang.interfaces import IExceptionInfo, IMeta, IPersistentMap, ISeq
 from basilisp.lang.obj import lrepr

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -27,15 +27,15 @@ from typing import (
 
 import attr
 
-import basilisp._pyast as ast
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp import _pyast as ast
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.compiler.constants import (
     DEFAULT_COMPILER_FILE_PATH,
     SYM_DYNAMIC_META_KEY,
@@ -74,7 +74,9 @@ from basilisp.lang.compiler.nodes import (
     Local,
     LocalType,
     Loop,
-    Map as MapNode,
+)
+from basilisp.lang.compiler.nodes import Map as MapNode
+from basilisp.lang.compiler.nodes import (
     MaybeClass,
     MaybeHostForm,
     Node,
@@ -90,21 +92,15 @@ from basilisp.lang.compiler.nodes import (
     Recur,
     Reify,
     Require,
-    Set as SetNode,
-    SetBang,
-    Throw,
-    Try,
-    VarRef,
-    Vector as VectorNode,
-    WithMeta,
 )
+from basilisp.lang.compiler.nodes import Set as SetNode
+from basilisp.lang.compiler.nodes import SetBang, Throw, Try, VarRef
+from basilisp.lang.compiler.nodes import Vector as VectorNode
+from basilisp.lang.compiler.nodes import WithMeta
 from basilisp.lang.interfaces import IMeta, IRecord, ISeq, ISeqable, IType
-from basilisp.lang.runtime import (
-    CORE_NS,
-    NS_VAR_NAME as LISP_NS_VAR,
-    BasilispModule,
-    Var,
-)
+from basilisp.lang.runtime import CORE_NS
+from basilisp.lang.runtime import NS_VAR_NAME as LISP_NS_VAR
+from basilisp.lang.runtime import BasilispModule, Var
 from basilisp.lang.typing import CompilerOpts, LispForm
 from basilisp.lang.util import count, genname, munge
 from basilisp.util import Maybe

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -15,14 +15,16 @@ from typing import (
 
 import attr
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.interfaces import IPersistentMap, IPersistentSet, IPersistentVector
 from basilisp.lang.runtime import Namespace, Var, to_lisp
-from basilisp.lang.typing import LispForm, ReaderForm as ReaderLispForm, SpecialForm
+from basilisp.lang.typing import LispForm
+from basilisp.lang.typing import ReaderForm as ReaderLispForm
+from basilisp.lang.typing import SpecialForm
 from basilisp.lang.util import munge
 
 _CMP_OFF = getattr(attr, "__version_info__", (0,)) >= (19, 2)

--- a/src/basilisp/lang/compiler/optimizer.py
+++ b/src/basilisp/lang/compiler/optimizer.py
@@ -2,7 +2,7 @@ from collections import deque
 from contextlib import contextmanager
 from typing import Deque, Iterable, List, Optional, Set
 
-import basilisp._pyast as ast
+from basilisp import _pyast as ast
 
 
 def _filter_dead_code(nodes: Iterable[ast.AST]) -> List[ast.AST]:

--- a/src/basilisp/lang/delay.py
+++ b/src/basilisp/lang/delay.py
@@ -2,7 +2,7 @@ from typing import Callable, Generic, Optional, TypeVar
 
 import attr
 
-import basilisp.lang.atom as atom
+from basilisp.lang import atom as atom
 from basilisp.lang.interfaces import IDeref
 
 T = TypeVar("T")

--- a/src/basilisp/lang/futures.py
+++ b/src/basilisp/lang/futures.py
@@ -1,9 +1,7 @@
-from concurrent.futures import (  # noqa # pylint: disable=unused-import
-    Future as _Future,
-    ProcessPoolExecutor as _ProcessPoolExecutor,
-    ThreadPoolExecutor as _ThreadPoolExecutor,
-    TimeoutError as _TimeoutError,
-)
+from concurrent.futures import Future as _Future  # noqa # pylint: disable=unused-import
+from concurrent.futures import ProcessPoolExecutor as _ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
+from concurrent.futures import TimeoutError as _TimeoutError
 from typing import Callable, Optional, TypeVar
 
 import attr

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -13,7 +13,8 @@ from typing import (
     Union,
 )
 
-from basilisp.lang.obj import LispObject as _LispObject, seq_lrepr
+from basilisp.lang.obj import LispObject as _LispObject
+from basilisp.lang.obj import seq_lrepr
 
 T = TypeVar("T")
 

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -1,7 +1,7 @@
 import threading
 from typing import Iterable, Optional
 
-import basilisp.lang.map as lmap
+from basilisp.lang import map as lmap
 from basilisp.lang.interfaces import IAssociative, ILispObject
 
 _LOCK = threading.Lock()

--- a/src/basilisp/lang/multifn.py
+++ b/src/basilisp/lang/multifn.py
@@ -1,8 +1,8 @@
 import threading
 from typing import Any, Callable, Generic, Optional, TypeVar
 
-import basilisp.lang.map as lmap
-import basilisp.lang.symbol as sym
+from basilisp.lang import map as lmap
+from basilisp.lang import symbol as sym
 from basilisp.lang.interfaces import IPersistentMap
 from basilisp.util import Maybe
 

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -29,13 +29,13 @@ from typing import (
 
 import attr
 
-from basilisp.lang import keyword as keyword
+from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
 from basilisp.lang import map as lmap
 from basilisp.lang import set as lset
-from basilisp.lang import symbol as symbol
+from basilisp.lang import symbol as sym
 from basilisp.lang import util as langutil
-from basilisp.lang import vector as vector
+from basilisp.lang import vector as vec
 from basilisp.lang.interfaces import (
     ILispObject,
     ILookup,
@@ -70,34 +70,34 @@ fn_macro_args = re.compile("(%)(&|[0-9])?")
 unicode_char = re.compile(r"u(\w+)")
 
 DataReaders = Optional[lmap.Map]
-GenSymEnvironment = MutableMapping[str, symbol.Symbol]
-Resolver = Callable[[symbol.Symbol], symbol.Symbol]
+GenSymEnvironment = MutableMapping[str, sym.Symbol]
+Resolver = Callable[[sym.Symbol], sym.Symbol]
 LispReaderFn = Callable[["ReaderContext"], LispForm]
 W = TypeVar("W", bound=LispReaderFn)
 
-READER_LINE_KW = keyword.keyword("line", ns="basilisp.lang.reader")
-READER_COL_KW = keyword.keyword("col", ns="basilisp.lang.reader")
+READER_LINE_KW = kw.keyword("line", ns="basilisp.lang.reader")
+READER_COL_KW = kw.keyword("col", ns="basilisp.lang.reader")
 
-READER_COND_FORM_KW = keyword.keyword("form")
-READER_COND_SPLICING_KW = keyword.keyword("splicing?")
+READER_COND_FORM_KW = kw.keyword("form")
+READER_COND_SPLICING_KW = kw.keyword("splicing?")
 
-_AMPERSAND = symbol.symbol("&")
-_FN = symbol.symbol("fn*")
-_INTEROP_CALL = symbol.symbol(".")
-_INTEROP_PROP = symbol.symbol(".-")
-_QUOTE = symbol.symbol("quote")
-_VAR = symbol.symbol("var")
+_AMPERSAND = sym.symbol("&")
+_FN = sym.symbol("fn*")
+_INTEROP_CALL = sym.symbol(".")
+_INTEROP_PROP = sym.symbol(".-")
+_QUOTE = sym.symbol("quote")
+_VAR = sym.symbol("var")
 
-_APPLY = symbol.symbol("apply", ns="basilisp.core")
-_CONCAT = symbol.symbol("concat", ns="basilisp.core")
-_DEREF = symbol.symbol("deref", ns="basilisp.core")
-_HASH_MAP = symbol.symbol("hash-map", ns="basilisp.core")
-_HASH_SET = symbol.symbol("hash-set", ns="basilisp.core")
-_LIST = symbol.symbol("list", ns="basilisp.core")
-_SEQ = symbol.symbol("seq", ns="basilisp.core")
-_UNQUOTE = symbol.symbol("unquote", ns="basilisp.core")
-_UNQUOTE_SPLICING = symbol.symbol("unquote-splicing", ns="basilisp.core")
-_VECTOR = symbol.symbol("vector", ns="basilisp.core")
+_APPLY = sym.symbol("apply", ns="basilisp.core")
+_CONCAT = sym.symbol("concat", ns="basilisp.core")
+_DEREF = sym.symbol("deref", ns="basilisp.core")
+_HASH_MAP = sym.symbol("hash-map", ns="basilisp.core")
+_HASH_SET = sym.symbol("hash-set", ns="basilisp.core")
+_LIST = sym.symbol("list", ns="basilisp.core")
+_SEQ = sym.symbol("seq", ns="basilisp.core")
+_UNQUOTE = sym.symbol("unquote", ns="basilisp.core")
+_UNQUOTE_SPLICING = sym.symbol("unquote-splicing", ns="basilisp.core")
+_VECTOR = sym.symbol("vector", ns="basilisp.core")
 
 
 class Comment:
@@ -226,7 +226,7 @@ class StreamReader:
 
 @functools.singledispatch
 def _py_from_lisp(
-    form: Union[llist.List, lmap.Map, lset.Set, vector.Vector]
+    form: Union[llist.List, lmap.Map, lset.Set, vec.Vector]
 ) -> ReaderForm:
     raise SyntaxError(f"Unrecognized Python type: {type(form)}")
 
@@ -247,7 +247,7 @@ def _py_set_from_set(form: lset.Set) -> set:
 
 
 @_py_from_lisp.register(IPersistentVector)
-def _py_list_from_vec(form: vector.Vector) -> list:
+def _py_list_from_vec(form: vec.Vector) -> list:
     return list(form)
 
 
@@ -268,9 +268,9 @@ def _uuid_from_str(uuid_str: str) -> uuid.UUID:
 class ReaderContext:
     _DATA_READERS = lmap.map(
         {
-            symbol.symbol("inst"): _inst_from_str,
-            symbol.symbol("py"): _py_from_lisp,
-            symbol.symbol("uuid"): _uuid_from_str,
+            sym.symbol("inst"): _inst_from_str,
+            sym.symbol("py"): _py_from_lisp,
+            sym.symbol("uuid"): _uuid_from_str,
         }
     )
 
@@ -292,12 +292,12 @@ class ReaderContext:
         resolver: Resolver = None,
         data_readers: DataReaders = None,
         eof: Any = None,
-        features: Optional[IPersistentSet[keyword.Keyword]] = None,
+        features: Optional[IPersistentSet[kw.Keyword]] = None,
         process_reader_cond: bool = True,
     ) -> None:
         data_readers = Maybe(data_readers).or_else_get(lmap.Map.empty())
         for reader_sym in data_readers.keys():
-            if not isinstance(reader_sym, symbol.Symbol):
+            if not isinstance(reader_sym, sym.Symbol):
                 raise TypeError("Expected symbol for data reader tag")
             if not reader_sym.ns:
                 raise ValueError("Non-namespaced tags are reserved by the reader")
@@ -326,7 +326,7 @@ class ReaderContext:
         return self._eof
 
     @property
-    def reader_features(self) -> IPersistentSet[keyword.Keyword]:
+    def reader_features(self) -> IPersistentSet[kw.Keyword]:
         return self._features
 
     @property
@@ -337,7 +337,7 @@ class ReaderContext:
     def reader(self) -> StreamReader:
         return self._reader
 
-    def resolve(self, sym: symbol.Symbol) -> symbol.Symbol:
+    def resolve(self, sym: sym.Symbol) -> sym.Symbol:
         return self._resolve(sym)
 
     @contextlib.contextmanager
@@ -393,14 +393,14 @@ class ReaderContext:
         )
 
 
-class ReaderConditional(ILookup[keyword.Keyword, ReaderForm], ILispObject):
+class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
     FEATURE_NOT_PRESENT = object()
 
     __slots__ = ("_form", "_feature_vec", "_is_splicing")
 
     def __init__(
         self,
-        form: llist.List[Tuple[keyword.Keyword, ReaderForm]],
+        form: llist.List[Tuple[kw.Keyword, ReaderForm]],
         is_splicing: bool = False,
     ):
         self._form = form
@@ -408,13 +408,13 @@ class ReaderConditional(ILookup[keyword.Keyword, ReaderForm], ILispObject):
         self._is_splicing = is_splicing
 
     @staticmethod
-    def _compile_feature_vec(form: IPersistentList[Tuple[keyword.Keyword, ReaderForm]]):
-        found_features: Set[keyword.Keyword] = set()
-        feature_list: List[Tuple[keyword.Keyword, ReaderForm]] = []
+    def _compile_feature_vec(form: IPersistentList[Tuple[kw.Keyword, ReaderForm]]):
+        found_features: Set[kw.Keyword] = set()
+        feature_list: List[Tuple[kw.Keyword, ReaderForm]] = []
 
         try:
             for k, v in partition(form, 2):
-                if not isinstance(k, keyword.Keyword):
+                if not isinstance(k, kw.Keyword):
                     raise SyntaxError(
                         f"Reader conditional features must be keywords, not {type(k)}"
                     )
@@ -429,10 +429,10 @@ class ReaderConditional(ILookup[keyword.Keyword, ReaderForm], ILispObject):
                 "Reader conditionals must contain an even number of forms"
             )
 
-        return vector.vector(feature_list)
+        return vec.vector(feature_list)
 
     def val_at(
-        self, k: keyword.Keyword, default: Optional[ReaderForm] = None
+        self, k: kw.Keyword, default: Optional[ReaderForm] = None
     ) -> Optional[ReaderForm]:
         if k == READER_COND_FORM_KW:
             return self._form
@@ -446,7 +446,7 @@ class ReaderConditional(ILookup[keyword.Keyword, ReaderForm], ILispObject):
         return self._is_splicing
 
     def select_feature(
-        self, features: IPersistentSet[keyword.Keyword]
+        self, features: IPersistentSet[kw.Keyword]
     ) -> Union[ReaderForm, object]:
         for k, form in self._feature_vec:
             if k in features:
@@ -531,7 +531,7 @@ def _read_namespaced(
 
 def _read_coll(
     ctx: ReaderContext,
-    f: Callable[[Collection[Any]], Union[llist.List, lset.Set, vector.Vector]],
+    f: Callable[[Collection[Any]], Union[llist.List, lset.Set, vec.Vector]],
     end_token: str,
     coll_name: str,
 ):
@@ -557,7 +557,7 @@ def _read_coll(
             selected_feature = elem.select_feature(ctx.reader_features)
             if selected_feature is ReaderConditional.FEATURE_NOT_PRESENT:
                 continue
-            elif isinstance(selected_feature, vector.Vector):
+            elif isinstance(selected_feature, vec.Vector):
                 coll.extend(selected_feature)
             else:
                 raise ctx.syntax_error(
@@ -581,11 +581,11 @@ def _read_list(ctx: ReaderContext) -> llist.List:
 
 
 @_with_loc
-def _read_vector(ctx: ReaderContext) -> vector.Vector:
+def _read_vector(ctx: ReaderContext) -> vec.Vector:
     """Read a vector element from the input stream."""
     start = ctx.reader.advance()
     assert start == "["
-    return _read_coll(ctx, vector.vector, "]", "vector")
+    return _read_coll(ctx, vec.vector, "]", "vector")
 
 
 @_with_loc
@@ -628,7 +628,7 @@ def __read_map_elems(ctx: ReaderContext) -> Iterable[RawReaderForm]:
             selected_feature = v.select_feature(ctx.reader_features)
             if selected_feature is ReaderConditional.FEATURE_NOT_PRESENT:
                 continue
-            elif isinstance(selected_feature, vector.Vector):
+            elif isinstance(selected_feature, vec.Vector):
                 yield from selected_feature
             else:
                 raise ctx.syntax_error(
@@ -653,16 +653,16 @@ def _map_key_processor(namespace: Optional[str],) -> Callable[[Hashable], Hashab
         return lambda v: v
 
     def process_key(k: Any) -> Any:
-        if isinstance(k, keyword.Keyword):
+        if isinstance(k, kw.Keyword):
             if k.ns is None:
-                return keyword.keyword(k.name, ns=namespace)
+                return kw.keyword(k.name, ns=namespace)
             if k.ns == "_":
-                return keyword.keyword(k.name)
-        if isinstance(k, symbol.Symbol):
+                return kw.keyword(k.name)
+        if isinstance(k, sym.Symbol):
             if k.ns is None:
-                return symbol.symbol(k.name, ns=namespace)
+                return sym.symbol(k.name, ns=namespace)
             if k.ns == "_":
-                return symbol.symbol(k.name)
+                return sym.symbol(k.name)
         return k
 
     return process_key
@@ -715,7 +715,7 @@ def _read_namespaced_map(ctx: ReaderContext) -> lmap.Map:
 # Due to some ambiguities that arise in parsing symbols, numbers, and the
 # special keywords `true`, `false`, and `nil`, we have to have a looser
 # type defined for the return from these reader functions.
-MaybeSymbol = Union[bool, None, symbol.Symbol]
+MaybeSymbol = Union[bool, None, sym.Symbol]
 MaybeNumber = Union[complex, decimal.Decimal, float, Fraction, int, MaybeSymbol]
 
 
@@ -878,11 +878,11 @@ def _read_sym(ctx: ReaderContext) -> MaybeSymbol:
         elif name == "false":
             return False
     if ctx.is_syntax_quoted and not name.endswith("#"):
-        return ctx.resolve(symbol.symbol(name, ns))
-    return symbol.symbol(name, ns=ns)
+        return ctx.resolve(sym.symbol(name, ns))
+    return sym.symbol(name, ns=ns)
 
 
-def _read_kw(ctx: ReaderContext) -> keyword.Keyword:
+def _read_kw(ctx: ReaderContext) -> kw.Keyword:
     """Return a keyword from the input stream."""
     start = ctx.reader.advance()
     assert start == ":"
@@ -899,15 +899,15 @@ def _read_kw(ctx: ReaderContext) -> keyword.Keyword:
     if should_autoresolve:
         current_ns = get_current_ns()
         if ns is not None:
-            aliased_ns = current_ns.aliases.get(symbol.symbol(ns))
+            aliased_ns = current_ns.aliases.get(sym.symbol(ns))
             if aliased_ns is None:
                 raise ctx.syntax_error(f"Cannot resolve namespace alias '{ns}'")
             ns = aliased_ns.name
         else:
             ns = current_ns.name
-        return keyword.keyword(name, ns=ns)
+        return kw.keyword(name, ns=ns)
 
-    return keyword.keyword(name, ns=ns)
+    return kw.keyword(name, ns=ns)
 
 
 def _read_meta(ctx: ReaderContext) -> IMeta:
@@ -918,9 +918,9 @@ def _read_meta(ctx: ReaderContext) -> IMeta:
     meta = _read_next_consuming_comment(ctx)
 
     meta_map: Optional[lmap.Map[LispForm, LispForm]]
-    if isinstance(meta, symbol.Symbol):
-        meta_map = lmap.map({keyword.keyword("tag"): meta})
-    elif isinstance(meta, keyword.Keyword):
+    if isinstance(meta, sym.Symbol):
+        meta_map = lmap.map({kw.keyword("tag"): meta})
+    elif isinstance(meta, kw.Keyword):
         meta_map = lmap.map({meta: True})
     elif isinstance(meta, lmap.Map):
         meta_map = meta
@@ -949,7 +949,7 @@ def _walk(inner_f, outer_f, form):
     if isinstance(form, IPersistentList):
         return outer_f(llist.list(map(inner_f, form)))
     elif isinstance(form, IPersistentVector):
-        return outer_f(vector.vector(map(inner_f, form)))
+        return outer_f(vec.vector(map(inner_f, form)))
     elif isinstance(form, IPersistentMap):
         return outer_f(lmap.hash_map(*chain.from_iterable(map(inner_f, form.seq()))))
     elif isinstance(form, IPersistentSet):
@@ -985,10 +985,10 @@ def _read_function(ctx: ReaderContext) -> llist.List:
 
     def sym_replacement(arg_num):
         suffix = arg_suffix(arg_num)
-        return symbol.symbol(f"arg-{suffix}")
+        return sym.symbol(f"arg-{suffix}")
 
     def identify_and_replace(f):
-        if isinstance(f, symbol.Symbol):
+        if isinstance(f, sym.Symbol):
             if f.ns is None:
                 match = fn_macro_args.match(f.name)
                 if match is not None:
@@ -1000,7 +1000,7 @@ def _read_function(ctx: ReaderContext) -> llist.List:
 
     body = _postwalk(identify_and_replace, form) if len(form) > 0 else None
 
-    arg_list: List[symbol.Symbol] = []
+    arg_list: List[sym.Symbol] = []
     numbered_args = sorted(map(int, filter(lambda k: k != "rest", arg_set)))
     if len(numbered_args) > 0:
         max_arg = max(numbered_args)
@@ -1009,7 +1009,7 @@ def _read_function(ctx: ReaderContext) -> llist.List:
             arg_list.append(_AMPERSAND)
             arg_list.append(sym_replacement("rest"))
 
-    return llist.l(_FN, vector.vector(arg_list), body)
+    return llist.l(_FN, vec.vector(arg_list), body)
 
 
 @_with_loc
@@ -1099,19 +1099,19 @@ def _process_syntax_quoted_form(
         raise ctx.syntax_error("Cannot splice outside collection")
     elif isinstance(form, llist.List):
         return llist.l(_SEQ, lconcat(_expand_syntax_quote(ctx, form)))
-    elif isinstance(form, vector.Vector):
+    elif isinstance(form, vec.Vector):
         return llist.l(_APPLY, _VECTOR, lconcat(_expand_syntax_quote(ctx, form)))
     elif isinstance(form, lset.Set):
         return llist.l(_APPLY, _HASH_SET, lconcat(_expand_syntax_quote(ctx, form)))
     elif isinstance(form, lmap.Map):
         flat_kvs = list(chain.from_iterable(form.items()))
         return llist.l(_APPLY, _HASH_MAP, lconcat(_expand_syntax_quote(ctx, flat_kvs)))  # type: ignore
-    elif isinstance(form, symbol.Symbol):
+    elif isinstance(form, sym.Symbol):
         if form.ns is None and form.name.endswith("#"):
             try:
                 return llist.l(_QUOTE, ctx.gensym_env[form.name])
             except KeyError:
-                genned = symbol.symbol(langutil.genname(form.name[:-1])).with_meta(
+                genned = sym.symbol(langutil.genname(form.name[:-1])).with_meta(
                     form.meta
                 )
                 ctx.gensym_env[form.name] = genned
@@ -1312,7 +1312,7 @@ def _read_reader_conditional(ctx: ReaderContext) -> LispReaderForm:
 
 
 def _load_record_or_type(
-    ctx: ReaderContext, s: symbol.Symbol, v: LispReaderForm
+    ctx: ReaderContext, s: sym.Symbol, v: LispReaderForm
 ) -> Union[IRecord, IType]:
     """Attempt to load the constructor named by `s` and construct a new
     record or type instance from the vector or map following name."""
@@ -1320,7 +1320,7 @@ def _load_record_or_type(
     assert "." in s.name, "Record names must appear fully qualified"
 
     ns_name, rec = s.name.rsplit(".", maxsplit=1)
-    ns_sym = symbol.symbol(ns_name)
+    ns_sym = sym.symbol(ns_name)
     ns = Namespace.get(ns_sym)
     if ns is None:
         raise ctx.syntax_error(f"Namespace {ns_name} does not exist")
@@ -1329,9 +1329,9 @@ def _load_record_or_type(
     if rectype is None:
         raise ctx.syntax_error(f"Record or type {s} does not exist")
 
-    if isinstance(v, vector.Vector):
+    if isinstance(v, vec.Vector):
         if issubclass(rectype, (IRecord, IType)):
-            posfactory = Var.find_in_ns(ns_sym, symbol.symbol(f"->{rec}"))
+            posfactory = Var.find_in_ns(ns_sym, sym.symbol(f"->{rec}"))
             assert (
                 posfactory is not None
             ), "Record and Type must have positional factories"
@@ -1340,7 +1340,7 @@ def _load_record_or_type(
             raise ctx.syntax_error(f"Var {s} is not a Record or Type")
     elif isinstance(v, lmap.Map):
         if issubclass(rectype, IRecord):
-            mapfactory = Var.find_in_ns(ns_sym, symbol.symbol(f"map->{rec}"))
+            mapfactory = Var.find_in_ns(ns_sym, sym.symbol(f"map->{rec}"))
             assert mapfactory is not None, "Record must have map factory"
             return mapfactory.value(v)
         else:
@@ -1379,7 +1379,7 @@ def _read_reader_macro(ctx: ReaderContext) -> LispReaderForm:
         return _read_numeric_constant(ctx)
     elif ns_name_chars.match(token):
         s = _read_sym(ctx)
-        assert isinstance(s, symbol.Symbol)
+        assert isinstance(s, sym.Symbol)
         v = _read_next_consuming_comment(ctx)
         if s in ctx.data_readers:
             f = ctx.data_readers[s]
@@ -1480,7 +1480,7 @@ def read(  # pylint: disable=too-many-arguments
     data_readers: DataReaders = None,
     eof: Any = EOF,
     is_eof_error: bool = False,
-    features: Optional[IPersistentSet[keyword.Keyword]] = None,
+    features: Optional[IPersistentSet[kw.Keyword]] = None,
     process_reader_cond: bool = True,
 ) -> Iterable[RawReaderForm]:
     """Read the contents of a stream as a Lisp expression.
@@ -1534,7 +1534,7 @@ def read_str(  # pylint: disable=too-many-arguments
     data_readers: DataReaders = None,
     eof: Any = EOF,
     is_eof_error: bool = False,
-    features: Optional[IPersistentSet[keyword.Keyword]] = None,
+    features: Optional[IPersistentSet[kw.Keyword]] = None,
     process_reader_cond: bool = True,
 ) -> Iterable[RawReaderForm]:
     """Read the contents of a string as a Lisp expression.
@@ -1559,7 +1559,7 @@ def read_file(  # pylint: disable=too-many-arguments
     data_readers: DataReaders = None,
     eof: Any = EOF,
     is_eof_error: bool = False,
-    features: Optional[IPersistentSet[keyword.Keyword]] = None,
+    features: Optional[IPersistentSet[kw.Keyword]] = None,
     process_reader_cond: bool = True,
 ) -> Iterable[RawReaderForm]:
     """Read the contents of a file as a Lisp expression.

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -29,13 +29,13 @@ from typing import (
 
 import attr
 
-import basilisp.lang.keyword as keyword
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as symbol
-import basilisp.lang.util as langutil
-import basilisp.lang.vector as vector
+from basilisp.lang import keyword as keyword
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as symbol
+from basilisp.lang import util as langutil
+from basilisp.lang import vector as vector
 from basilisp.lang.interfaces import (
     ILispObject,
     ILookup,

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -30,14 +30,14 @@ from typing import (
     cast,
 )
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.obj as lobj
-import basilisp.lang.seq as lseq
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import obj as lobj
+from basilisp.lang import seq as lseq
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.atom import Atom
 from basilisp.lang.interfaces import (
     IAssociative,

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -4,12 +4,12 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import Pattern, Union
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.interfaces import IPersistentMap, IRecord, ISeq, IType
 
 CompilerOpts = IPersistentMap[kw.Keyword, bool]

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -8,9 +8,9 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import Iterable, Match, Pattern, Type
 
-import dateutil.parser as dateparser
+from dateutil import parser as dateparser
 
-import basilisp.lang.atom as atom
+from basilisp.lang import atom as atom
 
 _DOUBLE_DOT = ".."
 _DOUBLE_DOT_REPLACEMENT = "__DOT_DOT__"

--- a/src/basilisp/main.py
+++ b/src/basilisp/main.py
@@ -1,8 +1,8 @@
 import importlib
 import logging
 
-import basilisp.importer as importer
-import basilisp.lang.runtime as runtime
+from basilisp import importer as importer
+from basilisp.lang import runtime as runtime
 from basilisp.lang.typing import CompilerOpts
 from basilisp.logconfig import DEFAULT_HANDLER, DEFAULT_LEVEL
 

--- a/src/basilisp/prompt.py
+++ b/src/basilisp/prompt.py
@@ -14,8 +14,8 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
 
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
 
 _USER_DATA_HOME = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
 BASILISP_USER_DATA = os.path.abspath(os.path.join(_USER_DATA_HOME, "basilisp"))

--- a/src/basilisp/testrunner.py
+++ b/src/basilisp/testrunner.py
@@ -4,13 +4,13 @@ from typing import Callable, Iterable, Optional
 
 import pytest
 
-import basilisp.lang.compiler as compiler
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
-import basilisp.main as basilisp
+from basilisp import main as basilisp
+from basilisp.lang import compiler as compiler
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.obj import lrepr
 from basilisp.util import Maybe
 

--- a/tests/basilisp/atom_test.py
+++ b/tests/basilisp/atom_test.py
@@ -1,10 +1,10 @@
-import basilisp.lang.atom as atom
 import basilisp.lang.interfaces
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import atom as atom
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 
 
 def test_atom_deref_interface():

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -10,19 +10,19 @@ from fractions import Fraction
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 
-import dateutil.parser as dateparser
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
+from dateutil import parser as dateparser
 
-import basilisp.lang.compiler as compiler
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import compiler as compiler
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.compiler.constants import SYM_PRIVATE_META_KEY
 from basilisp.lang.interfaces import IType, IWithMeta
 from basilisp.lang.runtime import Var

--- a/tests/basilisp/conftest.py
+++ b/tests/basilisp/conftest.py
@@ -3,10 +3,10 @@ from typing import Dict, Optional
 
 import pytest
 
-import basilisp.lang.compiler as compiler
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
+from basilisp.lang import compiler as compiler
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from tests.basilisp.helpers import CompileFn, get_or_create_ns
 
 

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -7,13 +7,13 @@ from uuid import UUID
 
 import pytest
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.exception import ExceptionInfo
 from basilisp.lang.interfaces import IExceptionInfo
 

--- a/tests/basilisp/delay_test.py
+++ b/tests/basilisp/delay_test.py
@@ -1,5 +1,5 @@
-import basilisp.lang.delay as delay
-import basilisp.lang.vector as vec
+from basilisp.lang import delay as delay
+from basilisp.lang import vector as vec
 
 
 def test_delay(capsys):

--- a/tests/basilisp/helpers.py
+++ b/tests/basilisp/helpers.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Tuple
 
-import basilisp.lang.symbol as sym
+from basilisp.lang import symbol as sym
 from basilisp.lang.runtime import CORE_NS_SYM, Namespace
 
 CompileFn = Callable[[str], Any]

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -10,9 +10,9 @@ import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from _pytest.pytester import Testdir
 
-import basilisp.importer as importer
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
+from basilisp import importer as importer
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from basilisp.lang.util import demunge, munge
 
 

--- a/tests/basilisp/keyword_test.py
+++ b/tests/basilisp/keyword_test.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-import basilisp.lang.map as lmap
+from basilisp.lang import map as lmap
 from basilisp.lang.keyword import Keyword, complete, keyword
 
 

--- a/tests/basilisp/list_test.py
+++ b/tests/basilisp/list_test.py
@@ -2,8 +2,8 @@ import pickle
 
 import pytest
 
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
 from basilisp.lang.interfaces import (
     ILispObject,
     IPersistentCollection,

--- a/tests/basilisp/lrepr_test.py
+++ b/tests/basilisp/lrepr_test.py
@@ -3,10 +3,10 @@ import re
 import uuid
 from fractions import Fraction
 
-import dateutil.parser as dateparser
 import pytest
+from dateutil import parser as dateparser
 
-import basilisp.lang.keyword as kw
+from basilisp.lang import keyword as kw
 from tests.basilisp.helpers import CompileFn
 
 

--- a/tests/basilisp/map_test.py
+++ b/tests/basilisp/map_test.py
@@ -3,7 +3,7 @@ from typing import Mapping
 
 import pytest
 
-import basilisp.lang.map as lmap
+from basilisp.lang import map as lmap
 from basilisp.lang.interfaces import (
     IAssociative,
     ICounted,

--- a/tests/basilisp/multifn_test.py
+++ b/tests/basilisp/multifn_test.py
@@ -1,9 +1,9 @@
 import pytest
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.multifn as multifn
-import basilisp.lang.symbol as sym
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import multifn as multifn
+from basilisp.lang import symbol as sym
 
 
 def test_multi_function():

--- a/tests/basilisp/namespace_test.py
+++ b/tests/basilisp/namespace_test.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-import basilisp.lang.atom as atom
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
-import basilisp.lang.symbol as sym
+from basilisp.lang import atom as atom
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from basilisp.lang.runtime import Namespace, NamespaceMap, Var
 from tests.basilisp.helpers import get_or_create_ns
 

--- a/tests/basilisp/promise_test.py
+++ b/tests/basilisp/promise_test.py
@@ -1,6 +1,6 @@
 import threading
 
-import basilisp.lang.vector as vec
+from basilisp.lang import vector as vec
 from basilisp.lang.promise import Promise
 
 

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -4,15 +4,15 @@ from typing import Optional
 
 import pytest
 
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.reader as reader
-import basilisp.lang.runtime as runtime
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.util as langutil
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import reader as reader
+from basilisp.lang import runtime as runtime
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import util as langutil
+from basilisp.lang import vector as vec
 from basilisp.lang.interfaces import IPersistentSet
 
 

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -4,15 +4,15 @@ from fractions import Fraction
 
 import pytest
 
-import basilisp.lang.atom as atom
-import basilisp.lang.keyword as keyword
-import basilisp.lang.list as llist
-import basilisp.lang.map as lmap
-import basilisp.lang.runtime as runtime
-import basilisp.lang.seq as lseq
-import basilisp.lang.set as lset
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import atom as atom
+from basilisp.lang import keyword as keyword
+from basilisp.lang import list as llist
+from basilisp.lang import map as lmap
+from basilisp.lang import runtime as runtime
+from basilisp.lang import seq as lseq
+from basilisp.lang import set as lset
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.compiler.constants import SpecialForm
 from basilisp.lang.interfaces import ISeq
 from tests.basilisp.helpers import get_or_create_ns

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -5,7 +5,7 @@ from fractions import Fraction
 import pytest
 
 from basilisp.lang import atom as atom
-from basilisp.lang import keyword as keyword
+from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
 from basilisp.lang import map as lmap
 from basilisp.lang import runtime as runtime
@@ -28,19 +28,19 @@ def test_is_supported_python_version():
     {
         (3, 6): frozenset(
             map(
-                keyword.keyword,
+                kw.keyword,
                 ["lpy36", "default", "lpy", "lpy36-", "lpy36+", "lpy37-", "lpy38-"],
             )
         ),
         (3, 7): frozenset(
             map(
-                keyword.keyword,
+                kw.keyword,
                 ["lpy37", "default", "lpy", "lpy37-", "lpy37+", "lpy36+", "lpy38-"],
             )
         ),
         (3, 8): frozenset(
             map(
-                keyword.keyword,
+                kw.keyword,
                 ["lpy38", "default", "lpy", "lpy38-", "lpy38+", "lpy37+", "lpy36+"],
             )
         ),
@@ -145,13 +145,13 @@ def test_to_seq():
     assert None is not runtime.to_seq(lset.s(1))
     assert None is not runtime.to_seq("string")
 
-    one_elem = llist.l(keyword.keyword("kw"))
+    one_elem = llist.l(kw.keyword("kw"))
     assert one_elem == runtime.to_seq(one_elem)
 
-    seqable = vec.v(keyword.keyword("kw"))
+    seqable = vec.v(kw.keyword("kw"))
     assert seqable == runtime.to_seq(seqable)
 
-    v1 = vec.v(keyword.keyword("kw"), 1, llist.l("something"), 3)
+    v1 = vec.v(kw.keyword("kw"), 1, llist.l("something"), 3)
     s1 = runtime.to_seq(v1)
     assert isinstance(s1, ISeq)
     for v, s in zip(v1, s1):
@@ -230,9 +230,9 @@ def test_nth():
 
 def test_get():
     assert None is runtime.get(None, "a")
-    assert keyword.keyword("nada") is runtime.get(None, "a", keyword.keyword("nada"))
+    assert kw.keyword("nada") is runtime.get(None, "a", kw.keyword("nada"))
     assert None is runtime.get(3, "a")
-    assert keyword.keyword("nada") is runtime.get(3, "a", keyword.keyword("nada"))
+    assert kw.keyword("nada") is runtime.get(3, "a", kw.keyword("nada"))
     assert 1 == runtime.get(lmap.map({"a": 1}), "a")
     assert None is runtime.get(lmap.map({"a": 1}), "b")
     assert 2 == runtime.get(lmap.map({"a": 1}), "b", 2)
@@ -456,14 +456,14 @@ class TestToPython:
         assert "string" == runtime.to_py("string")
         assert sym.symbol("sym") == runtime.to_py(sym.symbol("sym"))
         assert sym.symbol("sym", ns="ns") == runtime.to_py(sym.symbol("sym", ns="ns"))
-        assert "kw" == runtime.to_py(keyword.keyword("kw"))
-        assert "kw" == runtime.to_py(keyword.keyword("kw", ns="kw"))
+        assert "kw" == runtime.to_py(kw.keyword("kw"))
+        assert "kw" == runtime.to_py(kw.keyword("kw", ns="kw"))
 
     def test_to_dict(self):
         assert {} == runtime.to_py(lmap.Map.empty())
         assert {"a": 2} == runtime.to_py(lmap.map({"a": 2}))
         assert {"a": 2, "b": "string"} == runtime.to_py(
-            lmap.map({"a": 2, keyword.keyword("b"): "string"})
+            lmap.map({"a": 2, kw.keyword("b"): "string"})
         )
 
     def test_to_list(self):
@@ -482,7 +482,7 @@ class TestToPython:
     def test_to_set(self):
         assert set() == runtime.to_py(lset.Set.empty())
         assert {"a", 2} == runtime.to_py(lset.set({"a", 2}))
-        assert {"a", 2, "b"} == runtime.to_py(lset.set({"a", 2, keyword.keyword("b")}))
+        assert {"a", 2, "b"} == runtime.to_py(lset.set({"a", 2, kw.keyword("b")}))
 
 
 class TestToLisp:
@@ -493,16 +493,14 @@ class TestToLisp:
         assert "string" == runtime.to_lisp("string")
         assert sym.symbol("sym") == runtime.to_lisp(sym.symbol("sym"))
         assert sym.symbol("sym", ns="ns") == runtime.to_lisp(sym.symbol("sym", ns="ns"))
-        assert keyword.keyword("kw") == runtime.to_lisp(keyword.keyword("kw"))
-        assert keyword.keyword("kw", ns="ns") == runtime.to_lisp(
-            keyword.keyword("kw", ns="ns")
-        )
+        assert kw.keyword("kw") == runtime.to_lisp(kw.keyword("kw"))
+        assert kw.keyword("kw", ns="ns") == runtime.to_lisp(kw.keyword("kw", ns="ns"))
 
     def test_to_map(self):
         assert lmap.Map.empty() == runtime.to_lisp({})
-        assert lmap.map({keyword.keyword("a"): 2}) == runtime.to_lisp({"a": 2})
+        assert lmap.map({kw.keyword("a"): 2}) == runtime.to_lisp({"a": 2})
         assert lmap.map(
-            {keyword.keyword("a"): 2, keyword.keyword("b"): "string"}
+            {kw.keyword("a"): 2, kw.keyword("b"): "string"}
         ) == runtime.to_lisp({"a": 2, "b": "string"})
 
     def test_to_map_no_keywordize(self):
@@ -515,8 +513,8 @@ class TestToLisp:
     def test_to_set(self):
         assert lset.Set.empty() == runtime.to_lisp(set())
         assert lset.set({"a", 2}) == runtime.to_lisp({"a", 2})
-        assert lset.set({"a", 2, keyword.keyword("b")}) == runtime.to_lisp(
-            {"a", 2, keyword.keyword("b")}
+        assert lset.set({"a", 2, kw.keyword("b")}) == runtime.to_lisp(
+            {"a", 2, kw.keyword("b")}
         )
 
     def test_to_vec(self):

--- a/tests/basilisp/seq_test.py
+++ b/tests/basilisp/seq_test.py
@@ -1,8 +1,8 @@
-import basilisp.lang.keyword as kw
-import basilisp.lang.list as llist
-import basilisp.lang.runtime as runtime
-import basilisp.lang.seq as lseq
-import basilisp.lang.vector as vec
+from basilisp.lang import keyword as kw
+from basilisp.lang import list as llist
+from basilisp.lang import runtime as runtime
+from basilisp.lang import seq as lseq
+from basilisp.lang import vector as vec
 
 
 def test_to_sequence():

--- a/tests/basilisp/set_test.py
+++ b/tests/basilisp/set_test.py
@@ -3,8 +3,8 @@ import typing
 
 import pytest
 
-import basilisp.lang.map as lmap
-import basilisp.lang.set as lset
+from basilisp.lang import map as lmap
+from basilisp.lang import set as lset
 from basilisp.lang.interfaces import (
     ICounted,
     ILispObject,

--- a/tests/basilisp/symbol_test.py
+++ b/tests/basilisp/symbol_test.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-import basilisp.lang.map as lmap
+from basilisp.lang import map as lmap
 from basilisp.lang.keyword import keyword
 from basilisp.lang.symbol import Symbol, symbol
 

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -1,4 +1,4 @@
-import _pytest.pytester as pytester
+from _pytest import pytester as pytester
 
 
 def test_testrunner(testdir: pytester.Testdir, capsys):

--- a/tests/basilisp/var_test.py
+++ b/tests/basilisp/var_test.py
@@ -2,11 +2,11 @@ from unittest.mock import patch
 
 import pytest
 
-import basilisp.lang.atom as atom
-import basilisp.lang.keyword as kw
-import basilisp.lang.map as lmap
-import basilisp.lang.symbol as sym
-import basilisp.lang.vector as vec
+from basilisp.lang import atom as atom
+from basilisp.lang import keyword as kw
+from basilisp.lang import map as lmap
+from basilisp.lang import symbol as sym
+from basilisp.lang import vector as vec
 from basilisp.lang.runtime import (
     Namespace,
     NamespaceMap,

--- a/tests/basilisp/vector_test.py
+++ b/tests/basilisp/vector_test.py
@@ -2,8 +2,8 @@ import pickle
 
 import pytest
 
-import basilisp.lang.map as lmap
-import basilisp.lang.vector as vector
+from basilisp.lang import map as lmap
+from basilisp.lang import vector as vector
 from basilisp.lang.interfaces import (
     IAssociative,
     ICounted,

--- a/tests/basilisp/vector_test.py
+++ b/tests/basilisp/vector_test.py
@@ -3,7 +3,7 @@ import pickle
 import pytest
 
 from basilisp.lang import map as lmap
-from basilisp.lang import vector as vector
+from basilisp.lang import vector as vec
 from basilisp.lang.interfaces import (
     IAssociative,
     ICounted,
@@ -38,51 +38,51 @@ from basilisp.lang.symbol import symbol
     ],
 )
 def test_vector_interface_membership(interface):
-    assert isinstance(vector.v(), interface)
-    assert issubclass(vector.Vector, interface)
+    assert isinstance(vec.v(), interface)
+    assert issubclass(vec.Vector, interface)
 
 
 def test_vector_slice():
-    assert isinstance(vector.v(1, 2, 3)[1:], vector.Vector)
+    assert isinstance(vec.v(1, 2, 3)[1:], vec.Vector)
 
 
 def test_assoc():
-    v = vector.Vector.empty()
-    assert vector.v("a") == v.assoc(0, "a")
-    assert vector.Vector.empty() == v
-    assert vector.vector(["a", "b"]) == v.assoc(0, "a", 1, "b")
+    v = vec.Vector.empty()
+    assert vec.v("a") == v.assoc(0, "a")
+    assert vec.Vector.empty() == v
+    assert vec.vector(["a", "b"]) == v.assoc(0, "a", 1, "b")
 
-    v1 = vector.v("a")
-    assert vector.v("c", "b") == v1.assoc(0, "c", 1, "b")
-    assert vector.v("a", "b") == v1.assoc(1, "b")
+    v1 = vec.v("a")
+    assert vec.v("c", "b") == v1.assoc(0, "c", 1, "b")
+    assert vec.v("a", "b") == v1.assoc(1, "b")
 
 
 def test_vector_bool():
-    assert True is bool(vector.Vector.empty())
+    assert True is bool(vec.Vector.empty())
 
 
 def test_contains():
-    assert True is vector.v("a").contains(0)
-    assert True is vector.v("a", "b").contains(1)
-    assert False is vector.v("a", "b").contains(2)
-    assert False is vector.v("a", "b").contains(-1)
-    assert False is vector.Vector.empty().contains(0)
-    assert False is vector.Vector.empty().contains(1)
-    assert False is vector.Vector.empty().contains(-1)
+    assert True is vec.v("a").contains(0)
+    assert True is vec.v("a", "b").contains(1)
+    assert False is vec.v("a", "b").contains(2)
+    assert False is vec.v("a", "b").contains(-1)
+    assert False is vec.Vector.empty().contains(0)
+    assert False is vec.Vector.empty().contains(1)
+    assert False is vec.Vector.empty().contains(-1)
 
 
 def test_py_contains():
-    assert "a" in vector.v("a")
-    assert "a" in vector.v("a", "b")
-    assert "b" in vector.v("a", "b")
-    assert "c" not in vector.Vector.empty()
-    assert "c" not in vector.v("a")
-    assert "c" not in vector.v("a", "b")
+    assert "a" in vec.v("a")
+    assert "a" in vec.v("a", "b")
+    assert "b" in vec.v("a", "b")
+    assert "c" not in vec.Vector.empty()
+    assert "c" not in vec.v("a")
+    assert "c" not in vec.v("a", "b")
 
 
 def test_vector_cons():
     meta = lmap.m(tag="async")
-    v1 = vector.v(keyword("kw1"), meta=meta)
+    v1 = vec.v(keyword("kw1"), meta=meta)
     v2 = v1.cons(keyword("kw2"))
     assert v1 is not v2
     assert v1 != v2
@@ -92,54 +92,54 @@ def test_vector_cons():
 
 
 def test_entry():
-    assert vector.MapEntry.of(0, "a") == vector.v("a").entry(0)
-    assert vector.MapEntry.of(1, "b") == vector.v("a", "b").entry(1)
-    assert None is vector.v("a", "b").entry(2)
-    assert vector.MapEntry.of(-1, "b") == vector.v("a", "b").entry(-1)
-    assert None is vector.Vector.empty().entry(0)
-    assert None is vector.Vector.empty().entry(1)
-    assert None is vector.Vector.empty().entry(-1)
+    assert vec.MapEntry.of(0, "a") == vec.v("a").entry(0)
+    assert vec.MapEntry.of(1, "b") == vec.v("a", "b").entry(1)
+    assert None is vec.v("a", "b").entry(2)
+    assert vec.MapEntry.of(-1, "b") == vec.v("a", "b").entry(-1)
+    assert None is vec.Vector.empty().entry(0)
+    assert None is vec.Vector.empty().entry(1)
+    assert None is vec.Vector.empty().entry(-1)
 
 
 def test_val_at():
-    assert "a" == vector.v("a").val_at(0)
-    assert "b" == vector.v("a", "b").val_at(1)
-    assert None is vector.v("a", "b").val_at(2)
-    assert "b" == vector.v("a", "b").val_at(-1)
-    assert None is vector.Vector.empty().val_at(0)
-    assert None is vector.Vector.empty().val_at(1)
-    assert None is vector.Vector.empty().val_at(-1)
+    assert "a" == vec.v("a").val_at(0)
+    assert "b" == vec.v("a", "b").val_at(1)
+    assert None is vec.v("a", "b").val_at(2)
+    assert "b" == vec.v("a", "b").val_at(-1)
+    assert None is vec.Vector.empty().val_at(0)
+    assert None is vec.Vector.empty().val_at(1)
+    assert None is vec.Vector.empty().val_at(-1)
 
 
 def test_peek():
-    assert None is vector.v().peek()
+    assert None is vec.v().peek()
 
-    assert 1 == vector.v(1).peek()
-    assert 2 == vector.v(1, 2).peek()
-    assert 3 == vector.v(1, 2, 3).peek()
+    assert 1 == vec.v(1).peek()
+    assert 2 == vec.v(1, 2).peek()
+    assert 3 == vec.v(1, 2, 3).peek()
 
 
 def test_pop():
     with pytest.raises(IndexError):
-        vector.v().pop()
+        vec.v().pop()
 
-    assert vector.Vector.empty() == vector.v(1).pop()
-    assert vector.v(1) == vector.v(1, 2).pop()
-    assert vector.v(1, 2) == vector.v(1, 2, 3).pop()
+    assert vec.Vector.empty() == vec.v(1).pop()
+    assert vec.v(1) == vec.v(1, 2).pop()
+    assert vec.v(1, 2) == vec.v(1, 2, 3).pop()
 
 
 def test_vector_meta():
-    assert vector.v("vec").meta is None
+    assert vec.v("vec").meta is None
     meta = lmap.m(type=symbol("str"))
-    assert vector.v("vec", meta=meta).meta == meta
+    assert vec.v("vec", meta=meta).meta == meta
 
 
 def test_vector_with_meta():
-    vec = vector.v("vec")
+    vec = vec.v("vec")
     assert vec.meta is None
 
     meta1 = lmap.m(type=symbol("str"))
-    vec1 = vector.v("vec", meta=meta1)
+    vec1 = vec.v("vec", meta=meta1)
     assert vec1.meta == meta1
 
     meta2 = lmap.m(tag=keyword("async"))
@@ -158,24 +158,24 @@ def test_vector_with_meta():
 @pytest.mark.parametrize(
     "o",
     [
-        vector.v(),
-        vector.v(keyword("kw1")),
-        vector.v(keyword("kw1"), 2),
-        vector.v(keyword("kw1"), 2, None, "nothingness"),
-        vector.v(keyword("kw1"), vector.v("string", 4)),
+        vec.v(),
+        vec.v(keyword("kw1")),
+        vec.v(keyword("kw1"), 2),
+        vec.v(keyword("kw1"), 2, None, "nothingness"),
+        vec.v(keyword("kw1"), vec.v("string", 4)),
     ],
 )
-def test_vector_pickleability(pickle_protocol: int, o: vector.Vector):
+def test_vector_pickleability(pickle_protocol: int, o: vec.Vector):
     assert o == pickle.loads(pickle.dumps(o, protocol=pickle_protocol))
 
 
 @pytest.mark.parametrize(
     "l,str_repr",
     [
-        (vector.v(), "[]"),
-        (vector.v(keyword("kw1")), "[:kw1]"),
-        (vector.v(keyword("kw1"), keyword("kw2")), "[:kw1 :kw2]"),
+        (vec.v(), "[]"),
+        (vec.v(keyword("kw1")), "[:kw1]"),
+        (vec.v(keyword("kw1"), keyword("kw2")), "[:kw1 :kw2]"),
     ],
 )
-def test_vector_repr(l: vector.Vector, str_repr: str):
+def test_vector_repr(l: vec.Vector, str_repr: str):
     assert repr(l) == str_repr

--- a/tests/basilisp/vector_test.py
+++ b/tests/basilisp/vector_test.py
@@ -135,8 +135,8 @@ def test_vector_meta():
 
 
 def test_vector_with_meta():
-    vec = vec.v("vec")
-    assert vec.meta is None
+    vec0 = vec.v("vec")
+    assert vec0.meta is None
 
     meta1 = lmap.m(type=symbol("str"))
     vec1 = vec.v("vec", meta=meta1)

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ deps =
     black
     isort
 commands =
-    isort --check-only
+    isort --check --profile black .
     black --check .
 
 [testenv:py{36,37,38}-mypy]


### PR DESCRIPTION
Update a few things related to the dev environment:
 * Set the default development interpreter version to Python 3.8. This should help improve startup times a bit to help iteration during development.
 * Lock dev dependencies again for Python 3.8. This resulted in updating isort to version 5.0, which produced a pretty significant diff (and made me break this PR out from #601). 
    * In so doing, I also took this opportunity to update a few places where I'd used `as keyword`, `as symbol`, and `as vector` import aliases rather than `as kw`, `as sym`, and `as vec` respectively. Should make it easier to contribute new code anywhere and not be surprised about the alias in use.