### PR TITLE
Refactor compiler with singledispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * The compiler now uses the pre-computed hash to lookup keywords directly, which should improve lookup time for repeated invocations (#592)
  * Symbol hashes are now pre-computed when they are created (#592)
  * Moved `basilisp.core.template` to `basilisp.template` to match Clojure (#599)
+ * Refactor compiler to use `functools.singledispatch` for type based dispatch (#605)
+ * Rename `List`, `Map`, `Set`, and `Vector` to `PersistentList`, `PersistentMap`, `PersistentSet`, and `PersistentVector` respectively (#605)
 
 ### Fixed
  * Fixed a bug where `def` forms did not permit recursive references to the `def`'ed Vars (#578)

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ pypy-shell:
 	@docker run -it \
 		--mount src=`pwd`,target=/usr/src/app,type=bind \
 		--workdir /usr/src/app \
-		pypy:3.6-7.0-slim-jessie \
+		pypy:3.6-7.3-slim-buster \
 		/bin/sh -c 'pip install -e . && basilisp repl'
 
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -124,13 +124,7 @@ from basilisp.lang.compiler.nodes import Set as SetNode
 from basilisp.lang.compiler.nodes import SetBang, SpecialFormNode, Throw, Try, VarRef
 from basilisp.lang.compiler.nodes import Vector as VectorNode
 from basilisp.lang.compiler.nodes import WithMeta, deftype_or_reify_python_member_names
-from basilisp.lang.interfaces import (
-    IMeta,
-    IRecord,
-    ISeq,
-    IType,
-    IWithMeta,
-)
+from basilisp.lang.interfaces import IMeta, IRecord, ISeq, IType, IWithMeta
 from basilisp.lang.runtime import Var
 from basilisp.lang.typing import CompilerOpts, LispForm, ReaderForm
 from basilisp.lang.util import OBJECT_DUNDER_METHODS, count, genname, is_abstract, munge

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1,5 +1,6 @@
 import collections
 import contextlib
+import functools
 import logging
 import re
 import uuid
@@ -20,7 +21,6 @@ from typing import (
     Optional,
     Pattern,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -49,7 +49,6 @@ from basilisp.lang.compiler.nodes import (
     Binding,
     Catch,
     Const,
-    ConstType,
     Def,
     DefType,
     DefTypeBase,
@@ -3109,11 +3108,33 @@ def _with_meta_to_py_ast(
 #################
 
 
+@functools.singledispatch
+def _const_val_to_py_ast(form: LispForm, _: GeneratorContext) -> GeneratedPyAST:
+    """Generate Python AST nodes for constant Lisp forms.
+
+    Nested values in collections for :const nodes are not analyzed, so recursive
+    structures need to call into this function to generate Python AST nodes for
+    nested elements. For top-level :const Lisp AST nodes, see
+    `_const_node_to_py_ast`."""
+    raise GeneratorException(f"No constant handler is defined for type {type(form)}")
+
+
+def _collection_literal_to_py_ast(
+    ctx: GeneratorContext, form: Iterable[LispForm]
+) -> Iterable[GeneratedPyAST]:
+    """Turn a quoted collection literal of Lisp forms into Python AST nodes.
+
+    This function can only handle constant values. It does not call back into
+    the generic AST generators, so only constant values will be generated down
+    this path."""
+    yield from map(lambda form: _const_val_to_py_ast(form, ctx), form)
+
+
 def _const_meta_kwargs_ast(  # pylint:disable=inconsistent-return-statements
     ctx: GeneratorContext, form: IMeta
 ) -> Optional[GeneratedPyAST]:
     if hasattr(form, "meta") and form.meta is not None:
-        genned = _const_val_to_py_ast(ctx, _clean_meta(form))
+        genned = _const_val_to_py_ast(_clean_meta(form), ctx)
         return GeneratedPyAST(
             node=ast.keyword(arg="meta", value=genned.node),
             dependencies=genned.dependencies,
@@ -3122,22 +3143,19 @@ def _const_meta_kwargs_ast(  # pylint:disable=inconsistent-return-statements
         return None
 
 
+@_const_val_to_py_ast.register(bool)
+@_const_val_to_py_ast.register(type(None))
+@_const_val_to_py_ast.register(complex)
+@_const_val_to_py_ast.register(float)
+@_const_val_to_py_ast.register(int)
+@_const_val_to_py_ast.register(str)
 @_simple_ast_generator
-def _name_const_to_py_ast(_: GeneratorContext, form: Union[bool, None]) -> ast.AST:
+def _py_const_to_py_ast(form: Union[bool, None], _: GeneratorContext) -> ast.AST:
     return ast.Constant(form)
 
 
-@_simple_ast_generator
-def _num_to_py_ast(_: GeneratorContext, form: Union[complex, float, int]) -> ast.AST:
-    return ast.Constant(form)
-
-
-@_simple_ast_generator
-def _str_to_py_ast(_: GeneratorContext, form: str) -> ast.AST:
-    return ast.Constant(form)
-
-
-def _const_sym_to_py_ast(ctx: GeneratorContext, form: sym.Symbol) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(sym.Symbol)
+def _const_sym_to_py_ast(form: sym.Symbol, ctx: GeneratorContext) -> GeneratedPyAST:
     meta = _const_meta_kwargs_ast(ctx, form)
 
     sym_kwarg = (
@@ -3158,8 +3176,9 @@ def _const_sym_to_py_ast(ctx: GeneratorContext, form: sym.Symbol) -> GeneratedPy
     )
 
 
+@_const_val_to_py_ast.register(kw.Keyword)
 @_simple_ast_generator
-def _kw_to_py_ast(_: GeneratorContext, form: kw.Keyword) -> ast.AST:
+def _kw_to_py_ast(form: kw.Keyword, _: GeneratorContext) -> ast.AST:
     kwarg = (
         Maybe(form.ns)
         .map(lambda ns: [ast.keyword(arg="ns", value=ast.Constant(form.ns))])
@@ -3172,15 +3191,17 @@ def _kw_to_py_ast(_: GeneratorContext, form: kw.Keyword) -> ast.AST:
     )
 
 
+@_const_val_to_py_ast.register(Decimal)
 @_simple_ast_generator
-def _decimal_to_py_ast(_: GeneratorContext, form: Decimal) -> ast.AST:
+def _decimal_to_py_ast(form: Decimal, _: GeneratorContext) -> ast.AST:
     return ast.Call(
         func=_NEW_DECIMAL_FN_NAME, args=[ast.Constant(str(form))], keywords=[]
     )
 
 
+@_const_val_to_py_ast.register(Fraction)
 @_simple_ast_generator
-def _fraction_to_py_ast(_: GeneratorContext, form: Fraction) -> ast.AST:
+def _fraction_to_py_ast(form: Fraction, _: GeneratorContext) -> ast.AST:
     return ast.Call(
         func=_NEW_FRACTION_FN_NAME,
         args=[ast.Constant(form.numerator), ast.Constant(form.denominator)],
@@ -3188,26 +3209,30 @@ def _fraction_to_py_ast(_: GeneratorContext, form: Fraction) -> ast.AST:
     )
 
 
+@_const_val_to_py_ast.register(datetime)
 @_simple_ast_generator
-def _inst_to_py_ast(_: GeneratorContext, form: datetime) -> ast.AST:
+def _inst_to_py_ast(form: datetime, _: GeneratorContext) -> ast.AST:
     return ast.Call(
         func=_NEW_INST_FN_NAME, args=[ast.Constant(form.isoformat())], keywords=[]
     )
 
 
+@_const_val_to_py_ast.register(type(re.compile(r"")))
 @_simple_ast_generator
-def _regex_to_py_ast(_: GeneratorContext, form: Pattern) -> ast.AST:
+def _regex_to_py_ast(form: Pattern, _: GeneratorContext) -> ast.AST:
     return ast.Call(
         func=_NEW_REGEX_FN_NAME, args=[ast.Constant(form.pattern)], keywords=[]
     )
 
 
+@_const_val_to_py_ast.register(uuid.UUID)
 @_simple_ast_generator
-def _uuid_to_py_ast(_: GeneratorContext, form: uuid.UUID) -> ast.AST:
+def _uuid_to_py_ast(form: uuid.UUID, _: GeneratorContext) -> ast.AST:
     return ast.Call(func=_NEW_UUID_FN_NAME, args=[ast.Constant(str(form))], keywords=[])
 
 
-def _const_py_dict_to_py_ast(ctx: GeneratorContext, node: dict) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(dict)
+def _const_py_dict_to_py_ast(node: dict, ctx: GeneratorContext) -> GeneratedPyAST:
     key_deps, keys = _chain_py_ast(*_collection_literal_to_py_ast(ctx, node.keys()))
     val_deps, vals = _chain_py_ast(*_collection_literal_to_py_ast(ctx, node.values()))
     return GeneratedPyAST(
@@ -3216,26 +3241,30 @@ def _const_py_dict_to_py_ast(ctx: GeneratorContext, node: dict) -> GeneratedPyAS
     )
 
 
-def _const_py_list_to_py_ast(ctx: GeneratorContext, node: list) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(list)
+def _const_py_list_to_py_ast(node: list, ctx: GeneratorContext) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, node))
     return GeneratedPyAST(
         node=ast.List(elts=list(elems), ctx=ast.Load()), dependencies=list(elem_deps)
     )
 
 
-def _const_py_set_to_py_ast(ctx: GeneratorContext, node: set) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(set)
+def _const_py_set_to_py_ast(node: set, ctx: GeneratorContext) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, node))
     return GeneratedPyAST(node=ast.Set(elts=list(elems)), dependencies=list(elem_deps))
 
 
-def _const_py_tuple_to_py_ast(ctx: GeneratorContext, node: tuple) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(tuple)
+def _const_py_tuple_to_py_ast(node: tuple, ctx: GeneratorContext) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, node))
     return GeneratedPyAST(
         node=ast.Tuple(elts=list(elems), ctx=ast.Load()), dependencies=list(elem_deps)
     )
 
 
-def _const_map_to_py_ast(ctx: GeneratorContext, form: lmap.Map) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(lmap.Map)
+def _const_map_to_py_ast(form: lmap.Map, ctx: GeneratorContext) -> GeneratedPyAST:
     key_deps, keys = _chain_py_ast(*_collection_literal_to_py_ast(ctx, form.keys()))
     val_deps, vals = _chain_py_ast(*_collection_literal_to_py_ast(ctx, form.values()))
     meta = _const_meta_kwargs_ast(ctx, form)
@@ -3255,7 +3284,8 @@ def _const_map_to_py_ast(ctx: GeneratorContext, form: lmap.Map) -> GeneratedPyAS
     )
 
 
-def _const_set_to_py_ast(ctx: GeneratorContext, form: lset.Set) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(lset.Set)
+def _const_set_to_py_ast(form: lset.Set, ctx: GeneratorContext) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, form))
     meta = _const_meta_kwargs_ast(ctx, form)
     return GeneratedPyAST(
@@ -3270,7 +3300,8 @@ def _const_set_to_py_ast(ctx: GeneratorContext, form: lset.Set) -> GeneratedPyAS
     )
 
 
-def _const_record_to_py_ast(ctx: GeneratorContext, form: IRecord) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(IRecord)
+def _const_record_to_py_ast(form: IRecord, ctx: GeneratorContext) -> GeneratedPyAST:
     assert isinstance(form, IRecord) and isinstance(
         form, ISeqable
     ), "IRecord types should also be ISeq"
@@ -3287,13 +3318,13 @@ def _const_record_to_py_ast(ctx: GeneratorContext, form: IRecord) -> GeneratedPy
     vals_deps: List[ast.AST] = []
     for k, v in form_seq:
         assert isinstance(k, kw.Keyword), "Record key in seq must be keyword"
-        key_nodes = _kw_to_py_ast(ctx, k)
+        key_nodes = _kw_to_py_ast(k, ctx)
         keys.append(key_nodes.node)
         assert (
-            len(key_nodes.dependencies) == 0
+            len(key_nodes.dependencies) == 0  # type: ignore[arg-type]
         ), "Simple AST generators must emit no dependencies"
 
-        val_nodes = _const_val_to_py_ast(ctx, v)
+        val_nodes = _const_val_to_py_ast(v, ctx)
         vals.append(val_nodes.node)
         vals_deps.extend(val_nodes.dependencies)
 
@@ -3313,8 +3344,10 @@ def _const_record_to_py_ast(ctx: GeneratorContext, form: IRecord) -> GeneratedPy
     )
 
 
+@_const_val_to_py_ast.register(llist.List)
+@_const_val_to_py_ast.register(ISeq)
 def _const_seq_to_py_ast(
-    ctx: GeneratorContext, form: Union[llist.List, ISeq]
+    form: Union[llist.List, ISeq], ctx: GeneratorContext
 ) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, form))
 
@@ -3335,13 +3368,14 @@ def _const_seq_to_py_ast(
     )
 
 
-def _const_type_to_py_ast(ctx: GeneratorContext, form: IType) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(IType)
+def _const_type_to_py_ast(form: IType, ctx: GeneratorContext) -> GeneratedPyAST:
     tp = type(form)
 
     ctor_args = []
     ctor_arg_deps: List[ast.AST] = []
     for field in attr.fields(tp):
-        field_nodes = _const_val_to_py_ast(ctx, getattr(form, field.name, None))
+        field_nodes = _const_val_to_py_ast(getattr(form, field.name, None), ctx)
         ctor_args.append(field_nodes.node)
         ctor_args.extend(field_nodes.dependencies)
 
@@ -3351,7 +3385,8 @@ def _const_type_to_py_ast(ctx: GeneratorContext, form: IType) -> GeneratedPyAST:
     )
 
 
-def _const_vec_to_py_ast(ctx: GeneratorContext, form: vec.Vector) -> GeneratedPyAST:
+@_const_val_to_py_ast.register(vec.Vector)
+def _const_vec_to_py_ast(form: vec.Vector, ctx: GeneratorContext) -> GeneratedPyAST:
     elem_deps, elems = _chain_py_ast(*_collection_literal_to_py_ast(ctx, form))
     meta = _const_meta_kwargs_ast(ctx, form)
     return GeneratedPyAST(
@@ -3369,89 +3404,6 @@ def _const_vec_to_py_ast(ctx: GeneratorContext, form: vec.Vector) -> GeneratedPy
     )
 
 
-_CONST_VALUE_HANDLERS: Mapping[Type, SimplePyASTGenerator] = {
-    bool: _name_const_to_py_ast,
-    complex: _num_to_py_ast,
-    datetime: _inst_to_py_ast,
-    Decimal: _decimal_to_py_ast,
-    dict: _const_py_dict_to_py_ast,  # type: ignore
-    float: _num_to_py_ast,
-    Fraction: _fraction_to_py_ast,
-    int: _num_to_py_ast,
-    kw.Keyword: _kw_to_py_ast,
-    list: _const_py_list_to_py_ast,  # type: ignore
-    llist.List: _const_seq_to_py_ast,  # type: ignore
-    lmap.Map: _const_map_to_py_ast,  # type: ignore
-    lset.Set: _const_set_to_py_ast,  # type: ignore
-    IRecord: _const_record_to_py_ast,  # type: ignore
-    ISeq: _const_seq_to_py_ast,  # type: ignore
-    IType: _const_type_to_py_ast,  # type: ignore
-    type(re.compile("")): _regex_to_py_ast,
-    set: _const_py_set_to_py_ast,  # type: ignore
-    sym.Symbol: _const_sym_to_py_ast,  # type: ignore
-    str: _str_to_py_ast,
-    tuple: _const_py_tuple_to_py_ast,  # type: ignore
-    type(None): _name_const_to_py_ast,
-    uuid.UUID: _uuid_to_py_ast,
-    vec.Vector: _const_vec_to_py_ast,  # type: ignore
-}
-
-
-def _const_val_to_py_ast(ctx: GeneratorContext, form: LispForm) -> GeneratedPyAST:
-    """Generate Python AST nodes for constant Lisp forms.
-
-    Nested values in collections for :const nodes are not analyzed, so recursive
-    structures need to call into this function to generate Python AST nodes for
-    nested elements. For top-level :const Lisp AST nodes, see
-    `_const_node_to_py_ast`."""
-    handle_value = _CONST_VALUE_HANDLERS.get(type(form))
-    if handle_value is None:
-        if isinstance(form, ISeq):
-            handle_value = _const_seq_to_py_ast  # type: ignore
-        elif isinstance(form, IRecord):
-            handle_value = _const_record_to_py_ast
-        elif isinstance(form, IType):
-            handle_value = _const_type_to_py_ast
-    assert handle_value is not None, "A type handler must be defined for constants"
-    return handle_value(ctx, form)
-
-
-def _collection_literal_to_py_ast(
-    ctx: GeneratorContext, form: Iterable[LispForm]
-) -> Iterable[GeneratedPyAST]:
-    """Turn a quoted collection literal of Lisp forms into Python AST nodes.
-
-    This function can only handle constant values. It does not call back into
-    the generic AST generators, so only constant values will be generated down
-    this path."""
-    yield from map(partial(_const_val_to_py_ast, ctx), form)
-
-
-_CONSTANT_HANDLER: Mapping[ConstType, SimplePyASTGenerator] = {
-    ConstType.BOOL: _name_const_to_py_ast,
-    ConstType.INST: _inst_to_py_ast,
-    ConstType.NUMBER: _num_to_py_ast,
-    ConstType.DECIMAL: _decimal_to_py_ast,
-    ConstType.FRACTION: _fraction_to_py_ast,
-    ConstType.KEYWORD: _kw_to_py_ast,
-    ConstType.MAP: _const_map_to_py_ast,  # type: ignore
-    ConstType.SET: _const_set_to_py_ast,  # type: ignore
-    ConstType.RECORD: _const_record_to_py_ast,  # type: ignore
-    ConstType.SEQ: _const_seq_to_py_ast,  # type: ignore
-    ConstType.TYPE: _const_type_to_py_ast,  # type: ignore
-    ConstType.REGEX: _regex_to_py_ast,
-    ConstType.SYMBOL: _const_sym_to_py_ast,  # type: ignore
-    ConstType.STRING: _str_to_py_ast,
-    ConstType.NIL: _name_const_to_py_ast,
-    ConstType.UUID: _uuid_to_py_ast,
-    ConstType.PY_DICT: _const_py_dict_to_py_ast,  # type: ignore
-    ConstType.PY_LIST: _const_py_list_to_py_ast,  # type: ignore
-    ConstType.PY_SET: _const_py_set_to_py_ast,  # type: ignore
-    ConstType.PY_TUPLE: _const_py_tuple_to_py_ast,  # type: ignore
-    ConstType.VECTOR: _const_vec_to_py_ast,  # type: ignore
-}
-
-
 @_with_ast_loc
 def _const_node_to_py_ast(ctx: GeneratorContext, lisp_ast: Const) -> GeneratedPyAST:
     """Generate Python AST nodes for a :const Lisp AST node.
@@ -3460,11 +3412,7 @@ def _const_node_to_py_ast(ctx: GeneratorContext, lisp_ast: Const) -> GeneratedPy
     this function cannot be called recursively for those nested values. Instead,
     call `_const_val_to_py_ast` on nested values."""
     assert lisp_ast.op == NodeOp.CONST
-    node_type = lisp_ast.type
-    handle_const_node = _CONSTANT_HANDLER.get(node_type)
-    assert handle_const_node is not None, f"No :const AST type handler for {node_type}"
-    node_val = lisp_ast.val
-    return handle_const_node(ctx, node_val)
+    return _const_val_to_py_ast(lisp_ast.val, ctx)
 
 
 _NODE_HANDLERS: Mapping[NodeOp, PyASTGenerator] = {

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -96,13 +96,7 @@ from basilisp.lang.compiler.nodes import Set as SetNode
 from basilisp.lang.compiler.nodes import SetBang, Throw, Try, VarRef
 from basilisp.lang.compiler.nodes import Vector as VectorNode
 from basilisp.lang.compiler.nodes import WithMeta
-from basilisp.lang.interfaces import (
-    IMeta,
-    IRecord,
-    ISeq,
-    ISeqable,
-    IType,
-)
+from basilisp.lang.interfaces import IMeta, IRecord, ISeq, ISeqable, IType
 from basilisp.lang.runtime import CORE_NS
 from basilisp.lang.runtime import NS_VAR_NAME as LISP_NS_VAR
 from basilisp.lang.runtime import BasilispModule, Var

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -167,7 +167,7 @@ class Node(ABC, Generic[T]):
         """Details about the environment of the original form such as line and
         column numbers."""
 
-    def to_map(self) -> lmap.Map:
+    def to_map(self) -> lmap.PersistentMap:
         return to_lisp(attr.asdict(self))
 
     def assoc(self, **kwargs):
@@ -333,7 +333,7 @@ class Await(Node[ReaderLispForm]):
     children: Sequence[kw.Keyword] = vec.v(EXPR)
     op: NodeOp = NodeOp.AWAIT
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -347,10 +347,10 @@ class Binding(Node[sym.Symbol], Assignable):
     is_assignable: bool = False
     init: Optional[Node] = None
     meta: NodeMeta = None
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.BINDING
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -363,7 +363,7 @@ class Catch(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(CLASS, LOCAL, BODY)
     op: NodeOp = NodeOp.CATCH
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -374,10 +374,10 @@ class Const(Node[ReaderLispForm]):
     is_literal: bool
     env: NodeEnv
     meta: NodeMeta = None
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.CONST
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -389,10 +389,10 @@ class Def(Node[SpecialForm]):
     doc: Optional[str]
     env: NodeEnv
     meta: NodeMeta = None
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.DEF
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 DefTypeBase = Union["MaybeClass", "MaybeHostForm", "VarRef"]
@@ -407,13 +407,13 @@ class DefType(Node[SpecialForm]):
     members: Iterable["DefTypeMember"]
     env: NodeEnv
     verified_abstract: bool = False
-    artificially_abstract: IPersistentSet[DefTypeBase] = lset.Set.empty()
+    artificially_abstract: IPersistentSet[DefTypeBase] = lset.PersistentSet.empty()
     is_frozen: bool = True
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(FIELDS, MEMBERS)
     op: NodeOp = NodeOp.DEFTYPE
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
     @property
     def python_member_names(self) -> Iterable[str]:
@@ -442,7 +442,7 @@ class DefTypeClassMethod(DefTypeMember):
     children: Sequence[kw.Keyword] = vec.v(CLASS_LOCAL, PARAMS, BODY)
     op: NodeOp = NodeOp.DEFTYPE_CLASSMETHOD
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -453,7 +453,7 @@ class DefTypeMethod(DefTypeMember):
     children: Sequence[kw.Keyword] = vec.v(ARITIES)
     op: NodeOp = NodeOp.DEFTYPE_METHOD
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -471,7 +471,7 @@ class DefTypeMethodArity(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(THIS_LOCAL, PARAMS, BODY)
     op: NodeOp = NodeOp.DEFTYPE_METHOD_ARITY
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
     @property
     def python_name(self) -> str:
@@ -486,7 +486,7 @@ class DefTypeProperty(DefTypeMember):
     children: Sequence[kw.Keyword] = vec.v(THIS_LOCAL, PARAMS, BODY)
     op: NodeOp = NodeOp.DEFTYPE_PROPERTY
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -499,7 +499,7 @@ class DefTypeStaticMethod(DefTypeMember):
     children: Sequence[kw.Keyword] = vec.v(PARAMS, BODY)
     op: NodeOp = NodeOp.DEFTYPE_STATICMETHOD
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 DefTypePythonMember = Union[DefTypeClassMethod, DefTypeProperty, DefTypeStaticMethod]
@@ -515,7 +515,7 @@ class Do(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(STATEMENTS, RET)
     op: NodeOp = NodeOp.DO
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -531,7 +531,7 @@ class Fn(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(ARITIES)
     op: NodeOp = NodeOp.FN
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -546,7 +546,7 @@ class FnArity(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(PARAMS, BODY)
     op: NodeOp = NodeOp.FN_ARITY
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -560,7 +560,7 @@ class HostCall(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(TARGET, ARGS)
     op: NodeOp = NodeOp.HOST_CALL
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -573,7 +573,7 @@ class HostField(Node[Union[SpecialForm, sym.Symbol]], Assignable):
     children: Sequence[kw.Keyword] = vec.v(TARGET)
     op: NodeOp = NodeOp.HOST_FIELD
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -586,7 +586,7 @@ class If(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(TEST, THEN, ELSE)
     op: NodeOp = NodeOp.IF
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -594,22 +594,22 @@ class Import(Node[SpecialForm]):
     form: SpecialForm
     aliases: Iterable["ImportAlias"]
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.IMPORT
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
-class ImportAlias(Node[Union[sym.Symbol, vec.Vector]]):
-    form: Union[sym.Symbol, vec.Vector]
+class ImportAlias(Node[Union[sym.Symbol, vec.PersistentVector]]):
+    form: Union[sym.Symbol, vec.PersistentVector]
     name: str
     alias: Optional[str]
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.IMPORT_ALIAS
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -622,7 +622,7 @@ class Invoke(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(FN, ARGS)
     op: NodeOp = NodeOp.INVOKE
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -634,7 +634,7 @@ class Let(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(BINDINGS, BODY)
     op: NodeOp = NodeOp.LET
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -646,7 +646,7 @@ class LetFn(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(BINDINGS, BODY)
     op: NodeOp = NodeOp.LETFN
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -658,10 +658,10 @@ class Local(Node[sym.Symbol], Assignable):
     is_assignable: bool = False
     arg_id: Optional[int] = None
     is_variadic: bool = False
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.LOCAL
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -674,19 +674,19 @@ class Loop(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(BINDINGS, BODY)
     op: NodeOp = NodeOp.LOOP
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
-class Map(Node[lmap.Map]):
-    form: lmap.Map
+class Map(Node[IPersistentMap]):
+    form: IPersistentMap
     keys: Iterable[Node]
     vals: Iterable[Node]
     env: NodeEnv
     children: Sequence[kw.Keyword] = vec.v(KEYS, VALS)
     op: NodeOp = NodeOp.MAP
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -695,10 +695,10 @@ class MaybeClass(Node[sym.Symbol]):
     class_: str
     target: Any
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.MAYBE_CLASS
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -708,10 +708,10 @@ class MaybeHostForm(Node[sym.Symbol]):
     field: str
     target: Any
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.MAYBE_HOST_FORM
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(  # type: ignore
@@ -728,7 +728,7 @@ class PyDict(Node[dict]):
     children: Sequence[kw.Keyword] = vec.v(KEYS, VALS)
     op: NodeOp = NodeOp.PY_DICT
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(  # type: ignore
@@ -744,7 +744,7 @@ class PyList(Node[list]):
     children: Sequence[kw.Keyword] = vec.v(ITEMS)
     op: NodeOp = NodeOp.PY_LIST
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(  # type: ignore
@@ -760,7 +760,7 @@ class PySet(Node[Union[frozenset, set]]):
     children: Sequence[kw.Keyword] = vec.v(ITEMS)
     op: NodeOp = NodeOp.PY_SET
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -771,7 +771,7 @@ class PyTuple(Node[tuple]):
     children: Sequence[kw.Keyword] = vec.v(ITEMS)
     op: NodeOp = NodeOp.PY_TUPLE
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -783,7 +783,7 @@ class Quote(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(EXPR)
     op: NodeOp = NodeOp.QUOTE
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -795,7 +795,7 @@ class Recur(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(EXPRS)
     op: NodeOp = NodeOp.RECUR
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -805,12 +805,12 @@ class Reify(Node[SpecialForm]):
     members: Iterable["DefTypeMember"]
     env: NodeEnv
     verified_abstract: bool = False
-    artificially_abstract: IPersistentSet[DefTypeBase] = lset.Set.empty()
+    artificially_abstract: IPersistentSet[DefTypeBase] = lset.PersistentSet.empty()
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(MEMBERS)
     op: NodeOp = NodeOp.REIFY
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
     @property
     def python_member_names(self) -> Iterable[str]:
@@ -818,15 +818,15 @@ class Reify(Node[SpecialForm]):
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
-class RequireAlias(Node[Union[sym.Symbol, vec.Vector]]):
-    form: Union[sym.Symbol, vec.Vector]
+class RequireAlias(Node[Union[sym.Symbol, vec.PersistentVector]]):
+    form: Union[sym.Symbol, vec.PersistentVector]
     name: str
     alias: Optional[str]
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.REQUIRE_ALIAS
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -834,21 +834,21 @@ class Require(Node[SpecialForm]):
     form: SpecialForm
     aliases: Iterable[RequireAlias]
     env: NodeEnv
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.REQUIRE
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
-class Set(Node[lset.Set]):
-    form: lset.Set
+class Set(Node[IPersistentSet]):
+    form: IPersistentSet
     items: Iterable[Node]
     env: NodeEnv
     children: Sequence[kw.Keyword] = vec.v(ITEMS)
     op: NodeOp = NodeOp.SET
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -860,7 +860,7 @@ class SetBang(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(TARGET, VAL)
     op: NodeOp = NodeOp.SET_BANG
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -871,7 +871,7 @@ class Throw(Node[SpecialForm]):
     children: Sequence[kw.Keyword] = vec.v(EXCEPTION)
     op: NodeOp = NodeOp.THROW
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -884,7 +884,7 @@ class Try(Node[SpecialForm]):
     finally_: Optional[Do] = None
     op: NodeOp = NodeOp.TRY
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -893,10 +893,10 @@ class VarRef(Node[sym.Symbol], Assignable):
     var: Var
     env: NodeEnv
     return_var: bool = False
-    children: Sequence[kw.Keyword] = vec.Vector.empty()
+    children: Sequence[kw.Keyword] = vec.PersistentVector.empty()
     op: NodeOp = NodeOp.VAR
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
     @property
     def is_assignable(self) -> bool:
@@ -904,14 +904,14 @@ class VarRef(Node[sym.Symbol], Assignable):
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
-class Vector(Node[vec.Vector]):
-    form: vec.Vector
+class Vector(Node[IPersistentVector]):
+    form: IPersistentVector
     items: Iterable[Node]
     env: NodeEnv
     children: Sequence[kw.Keyword] = vec.v(ITEMS)
     op: NodeOp = NodeOp.VECTOR
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -923,7 +923,7 @@ class WithMeta(Node[LispForm]):
     children: Sequence[kw.Keyword] = vec.v(META, EXPR)
     op: NodeOp = NodeOp.WITH_META
     top_level: bool = False
-    raw_forms: IPersistentVector[LispForm] = vec.Vector.empty()
+    raw_forms: IPersistentVector[LispForm] = vec.PersistentVector.empty()
 
 
 SpecialFormNode = Union[

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -2,10 +2,10 @@ import threading
 from typing import Iterable, Optional
 
 from basilisp.lang import map as lmap
-from basilisp.lang.interfaces import IAssociative, ILispObject
+from basilisp.lang.interfaces import IAssociative, ILispObject, IPersistentMap
 
 _LOCK = threading.Lock()
-_INTERN: lmap.Map[int, "Keyword"] = lmap.Map.empty()
+_INTERN: IPersistentMap[int, "Keyword"] = lmap.PersistentMap.empty()
 
 
 class Keyword(ILispObject):
@@ -49,7 +49,7 @@ class Keyword(ILispObject):
 
 
 def complete(
-    text: str, kw_cache: Optional[lmap.Map[int, Keyword]] = None,
+    text: str, kw_cache: Optional[IPersistentMap[int, Keyword]] = None,
 ) -> Iterable[str]:
     """Return an iterable of possible completions for the given text."""
     assert text.startswith(":")

--- a/src/basilisp/lang/list.py
+++ b/src/basilisp/lang/list.py
@@ -10,7 +10,7 @@ from basilisp.lang.seq import EMPTY
 T = TypeVar("T")
 
 
-class List(IPersistentList[T], ISeq[T], IWithMeta):
+class PersistentList(IPersistentList[T], ISeq[T], IWithMeta):
     """Basilisp List. Delegates internally to a pyrsistent.PList object.
 
     Do not instantiate directly. Instead use the l() and list() factory
@@ -27,7 +27,7 @@ class List(IPersistentList[T], ISeq[T], IWithMeta):
 
     def __getitem__(self, item):
         if isinstance(item, slice):
-            return List(self._inner[item])
+            return PersistentList(self._inner[item])
         return self._inner[item]
 
     def __hash__(self):
@@ -43,7 +43,7 @@ class List(IPersistentList[T], ISeq[T], IWithMeta):
     def meta(self) -> Optional[IPersistentMap]:
         return self._meta
 
-    def with_meta(self, meta: Optional[IPersistentMap]) -> "List":
+    def with_meta(self, meta: Optional[IPersistentMap]) -> "PersistentList":
         return list(self._inner, meta=meta)
 
     @property
@@ -61,36 +61,36 @@ class List(IPersistentList[T], ISeq[T], IWithMeta):
     def rest(self) -> ISeq[T]:
         if self._inner.rest is _EMPTY_PLIST:
             return EMPTY
-        return List(self._inner.rest)
+        return PersistentList(self._inner.rest)
 
-    def cons(self, *elems: T) -> "List[T]":
+    def cons(self, *elems: T) -> "PersistentList[T]":
         l = self._inner
         for elem in elems:
             l = l.cons(elem)
-        return List(l)
+        return PersistentList(l)
 
     @staticmethod
-    def empty(meta=None) -> "List":  # pylint:disable=arguments-differ
+    def empty(meta=None) -> "PersistentList":  # pylint:disable=arguments-differ
         return l(meta=meta)
 
     def peek(self):
         return self.first
 
-    def pop(self) -> "List[T]":
+    def pop(self) -> "PersistentList[T]":
         if self.is_empty:
             raise IndexError("Cannot pop an empty list")
-        return cast(List, self.rest)
+        return cast(PersistentList, self.rest)
 
 
-def list(members, meta=None) -> List:  # pylint:disable=redefined-builtin
+def list(members, meta=None) -> PersistentList:  # pylint:disable=redefined-builtin
     """Creates a new list."""
-    return List(  # pylint: disable=abstract-class-instantiated
+    return PersistentList(  # pylint: disable=abstract-class-instantiated
         plist(iterable=members), meta=meta
     )
 
 
-def l(*members, meta=None) -> List:  # noqa
+def l(*members, meta=None) -> PersistentList:  # noqa
     """Creates a new list from members."""
-    return List(  # pylint: disable=abstract-class-instantiated
+    return PersistentList(  # pylint: disable=abstract-class-instantiated
         plist(iterable=members), meta=meta
     )

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -258,9 +258,10 @@ def map(  # pylint:disable=redefined-builtin
 ) -> PersistentMap[K, V]:
     """Creates a new map."""
     # For some reason, creating a new `immutables.Map` instance from an existing
-    # `basilisp.lang.map.Map` instance causes issues because the `__iter__` returns
-    # only the keys rather than tuple of key/value pairs, even though it adheres to
-    # the `Mapping` protocol. Passing the `.items()` directly bypasses this problem.
+    # `basilisp.lang.map.PersistentMap` instance causes issues because the `__iter__`
+    # returns only the keys rather than tuple of key/value pairs, even though it
+    # adheres to the `Mapping` protocol. Passing the `.items()` directly bypasses
+    # this problem.
     return PersistentMap.from_coll(kvs.items(), meta=meta)
 
 

--- a/src/basilisp/lang/multifn.py
+++ b/src/basilisp/lang/multifn.py
@@ -22,7 +22,7 @@ class MultiFunction(Generic[T]):
         self._default = default
         self._dispatch = dispatch
         self._lock = threading.Lock()
-        self._methods: IPersistentMap[T, Method] = lmap.Map.empty()
+        self._methods: IPersistentMap[T, Method] = lmap.PersistentMap.empty()
 
     def __call__(self, *args, **kwargs):
         key = self._dispatch(*args, **kwargs)
@@ -58,7 +58,7 @@ class MultiFunction(Generic[T]):
     def remove_all_methods(self) -> None:
         """Remove all methods defined for this multi-function."""
         with self._lock:
-            self._methods = lmap.Map.empty()
+            self._methods = lmap.PersistentMap.empty()
 
     @property
     def default(self) -> T:

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -69,7 +69,7 @@ newline_chars = re.compile("(\r\n|\r|\n)")
 fn_macro_args = re.compile("(%)(&|[0-9])?")
 unicode_char = re.compile(r"u(\w+)")
 
-DataReaders = Optional[lmap.Map]
+DataReaders = Optional[lmap.PersistentMap]
 GenSymEnvironment = MutableMapping[str, sym.Symbol]
 Resolver = Callable[[sym.Symbol], sym.Symbol]
 LispReaderFn = Callable[["ReaderContext"], LispForm]
@@ -226,28 +226,33 @@ class StreamReader:
 
 @functools.singledispatch
 def _py_from_lisp(
-    form: Union[llist.List, lmap.Map, lset.Set, vec.Vector]
+    form: Union[
+        llist.PersistentList,
+        lmap.PersistentMap,
+        lset.PersistentSet,
+        vec.PersistentVector,
+    ]
 ) -> ReaderForm:
     raise SyntaxError(f"Unrecognized Python type: {type(form)}")
 
 
 @_py_from_lisp.register(IPersistentList)
-def _py_tuple_from_list(form: llist.List) -> tuple:
+def _py_tuple_from_list(form: llist.PersistentList) -> tuple:
     return tuple(form)
 
 
 @_py_from_lisp.register(IPersistentMap)
-def _py_dict_from_map(form: lmap.Map) -> dict:
+def _py_dict_from_map(form: lmap.PersistentMap) -> dict:
     return dict(form)
 
 
 @_py_from_lisp.register(IPersistentSet)
-def _py_set_from_set(form: lset.Set) -> set:
+def _py_set_from_set(form: lset.PersistentSet) -> set:
     return set(form)
 
 
 @_py_from_lisp.register(IPersistentVector)
-def _py_list_from_vec(form: vec.Vector) -> list:
+def _py_list_from_vec(form: vec.PersistentVector) -> list:
     return list(form)
 
 
@@ -295,7 +300,7 @@ class ReaderContext:
         features: Optional[IPersistentSet[kw.Keyword]] = None,
         process_reader_cond: bool = True,
     ) -> None:
-        data_readers = Maybe(data_readers).or_else_get(lmap.Map.empty())
+        data_readers = Maybe(data_readers).or_else_get(lmap.PersistentMap.empty())
         for reader_sym in data_readers.keys():
             if not isinstance(reader_sym, sym.Symbol):
                 raise TypeError("Expected symbol for data reader tag")
@@ -318,7 +323,7 @@ class ReaderContext:
         self._eof = eof
 
     @property
-    def data_readers(self) -> lmap.Map:
+    def data_readers(self) -> lmap.PersistentMap:
         return self._data_readers
 
     @property
@@ -400,7 +405,7 @@ class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
 
     def __init__(
         self,
-        form: llist.List[Tuple[kw.Keyword, ReaderForm]],
+        form: llist.PersistentList[Tuple[kw.Keyword, ReaderForm]],
         is_splicing: bool = False,
     ):
         self._form = form
@@ -531,7 +536,10 @@ def _read_namespaced(
 
 def _read_coll(
     ctx: ReaderContext,
-    f: Callable[[Collection[Any]], Union[llist.List, lset.Set, vec.Vector]],
+    f: Callable[
+        [Collection[Any]],
+        Union[llist.PersistentList, lset.PersistentSet, vec.PersistentVector],
+    ],
     end_token: str,
     coll_name: str,
 ):
@@ -557,7 +565,7 @@ def _read_coll(
             selected_feature = elem.select_feature(ctx.reader_features)
             if selected_feature is ReaderConditional.FEATURE_NOT_PRESENT:
                 continue
-            elif isinstance(selected_feature, vec.Vector):
+            elif isinstance(selected_feature, vec.PersistentVector):
                 coll.extend(selected_feature)
             else:
                 raise ctx.syntax_error(
@@ -573,7 +581,7 @@ def _read_coll(
 
 
 @_with_loc
-def _read_list(ctx: ReaderContext) -> llist.List:
+def _read_list(ctx: ReaderContext) -> llist.PersistentList:
     """Read a list element from the input stream."""
     start = ctx.reader.advance()
     assert start == "("
@@ -581,7 +589,7 @@ def _read_list(ctx: ReaderContext) -> llist.List:
 
 
 @_with_loc
-def _read_vector(ctx: ReaderContext) -> vec.Vector:
+def _read_vector(ctx: ReaderContext) -> vec.PersistentVector:
     """Read a vector element from the input stream."""
     start = ctx.reader.advance()
     assert start == "["
@@ -589,12 +597,12 @@ def _read_vector(ctx: ReaderContext) -> vec.Vector:
 
 
 @_with_loc
-def _read_set(ctx: ReaderContext) -> lset.Set:
+def _read_set(ctx: ReaderContext) -> lset.PersistentSet:
     """Return a set from the input stream."""
     start = ctx.reader.advance()
     assert start == "{"
 
-    def set_if_valid(s: Collection) -> lset.Set:
+    def set_if_valid(s: Collection) -> lset.PersistentSet:
         coll_set = set(s)
         if len(s) != len(coll_set):
             dupes = ", ".join(
@@ -628,7 +636,7 @@ def __read_map_elems(ctx: ReaderContext) -> Iterable[RawReaderForm]:
             selected_feature = v.select_feature(ctx.reader_features)
             if selected_feature is ReaderConditional.FEATURE_NOT_PRESENT:
                 continue
-            elif isinstance(selected_feature, vec.Vector):
+            elif isinstance(selected_feature, vec.PersistentVector):
                 yield from selected_feature
             else:
                 raise ctx.syntax_error(
@@ -669,7 +677,9 @@ def _map_key_processor(namespace: Optional[str],) -> Callable[[Hashable], Hashab
 
 
 @_with_loc
-def _read_map(ctx: ReaderContext, namespace: Optional[str] = None) -> lmap.Map:
+def _read_map(
+    ctx: ReaderContext, namespace: Optional[str] = None
+) -> lmap.PersistentMap:
     """Return a map from the input stream."""
     reader = ctx.reader
     start = reader.advance()
@@ -688,7 +698,7 @@ def _read_map(ctx: ReaderContext, namespace: Optional[str] = None) -> lmap.Map:
         return lmap.map(d)
 
 
-def _read_namespaced_map(ctx: ReaderContext) -> lmap.Map:
+def _read_namespaced_map(ctx: ReaderContext) -> lmap.PersistentMap:
     """Read a namespaced map from the input stream."""
     start = ctx.reader.peek()
     assert start == ":"
@@ -917,12 +927,12 @@ def _read_meta(ctx: ReaderContext) -> IMeta:
     assert start == "^"
     meta = _read_next_consuming_comment(ctx)
 
-    meta_map: Optional[lmap.Map[LispForm, LispForm]]
+    meta_map: Optional[lmap.PersistentMap[LispForm, LispForm]]
     if isinstance(meta, sym.Symbol):
         meta_map = lmap.map({kw.keyword("tag"): meta})
     elif isinstance(meta, kw.Keyword):
         meta_map = lmap.map({meta: True})
-    elif isinstance(meta, lmap.Map):
+    elif isinstance(meta, lmap.PersistentMap):
         meta_map = meta
     else:
         raise ctx.syntax_error(
@@ -966,7 +976,7 @@ def _postwalk(f, form):
 
 
 @_with_loc
-def _read_function(ctx: ReaderContext) -> llist.List:
+def _read_function(ctx: ReaderContext) -> llist.PersistentList:
     """Read a function reader macro from the input stream."""
     if ctx.is_in_anon_fn:
         raise ctx.syntax_error("Nested #() definitions not allowed")
@@ -1013,7 +1023,7 @@ def _read_function(ctx: ReaderContext) -> llist.List:
 
 
 @_with_loc
-def _read_quoted(ctx: ReaderContext) -> llist.List:
+def _read_quoted(ctx: ReaderContext) -> llist.PersistentList:
     """Read a quoted form from the input stream."""
     start = ctx.reader.advance()
     assert start == "'"
@@ -1097,13 +1107,13 @@ def _process_syntax_quoted_form(
         return form[1]  # type: ignore
     elif _is_unquote_splicing(form):
         raise ctx.syntax_error("Cannot splice outside collection")
-    elif isinstance(form, llist.List):
+    elif isinstance(form, llist.PersistentList):
         return llist.l(_SEQ, lconcat(_expand_syntax_quote(ctx, form)))
-    elif isinstance(form, vec.Vector):
+    elif isinstance(form, vec.PersistentVector):
         return llist.l(_APPLY, _VECTOR, lconcat(_expand_syntax_quote(ctx, form)))
-    elif isinstance(form, lset.Set):
+    elif isinstance(form, lset.PersistentSet):
         return llist.l(_APPLY, _HASH_SET, lconcat(_expand_syntax_quote(ctx, form)))
-    elif isinstance(form, lmap.Map):
+    elif isinstance(form, lmap.PersistentMap):
         flat_kvs = list(chain.from_iterable(form.items()))
         return llist.l(_APPLY, _HASH_MAP, lconcat(_expand_syntax_quote(ctx, flat_kvs)))  # type: ignore
     elif isinstance(form, sym.Symbol):
@@ -1283,7 +1293,7 @@ def _read_reader_conditional_preserving(ctx: ReaderContext) -> ReaderConditional
         )
 
     feature_list = _read_coll(ctx, llist.list, ")", "reader conditional")
-    assert isinstance(feature_list, llist.List)
+    assert isinstance(feature_list, llist.PersistentList)
     return ReaderConditional(feature_list, is_splicing=is_splicing)
 
 
@@ -1329,7 +1339,7 @@ def _load_record_or_type(
     if rectype is None:
         raise ctx.syntax_error(f"Record or type {s} does not exist")
 
-    if isinstance(v, vec.Vector):
+    if isinstance(v, vec.PersistentVector):
         if issubclass(rectype, (IRecord, IType)):
             posfactory = Var.find_in_ns(ns_sym, sym.symbol(f"->{rec}"))
             assert (
@@ -1338,7 +1348,7 @@ def _load_record_or_type(
             return posfactory.value(*v)
         else:
             raise ctx.syntax_error(f"Var {s} is not a Record or Type")
-    elif isinstance(v, lmap.Map):
+    elif isinstance(v, lmap.PersistentMap):
         if issubclass(rectype, IRecord):
             mapfactory = Var.find_in_ns(ns_sym, sym.symbol(f"map->{rec}"))
             assert mapfactory is not None, "Record must have map factory"

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -60,11 +60,11 @@ class TransientSet(ITransientSet[T]):
                 pass
         return self
 
-    def to_persistent(self) -> "Set[T]":
-        return Set(self._inner.finish())
+    def to_persistent(self) -> "PersistentSet[T]":
+        return PersistentSet(self._inner.finish())
 
 
-class Set(
+class PersistentSet(
     IPersistentSet[T], IEvolveableCollection[TransientSet], ILispObject, IWithMeta,
 ):
     """Basilisp Set. Delegates internally to a immutables.Map object.
@@ -81,8 +81,8 @@ class Set(
     @classmethod
     def from_iterable(
         cls, members: Optional[Iterable[T]], meta: Optional[IPersistentMap] = None
-    ) -> "Set":
-        return Set(_Map((m, m) for m in (members or ())), meta=meta)
+    ) -> "PersistentSet":
+        return PersistentSet(_Map((m, m) for m in (members or ())), meta=meta)
 
     _from_iterable = from_iterable
 
@@ -147,26 +147,26 @@ class Set(
     def meta(self) -> Optional[IPersistentMap]:
         return self._meta
 
-    def with_meta(self, meta: Optional[IPersistentMap]) -> "Set[T]":
+    def with_meta(self, meta: Optional[IPersistentMap]) -> "PersistentSet[T]":
         return set(self._inner, meta=meta)
 
-    def cons(self, *elems: T) -> "Set[T]":
+    def cons(self, *elems: T) -> "PersistentSet[T]":
         with self._inner.mutate() as m:
             for elem in elems:
                 m.set(elem, elem)
-            return Set(m.finish(), meta=self.meta)
+            return PersistentSet(m.finish(), meta=self.meta)
 
-    def disj(self, *elems: T) -> "Set[T]":
+    def disj(self, *elems: T) -> "PersistentSet[T]":
         with self._inner.mutate() as m:
             for elem in elems:
                 try:
                     del m[elem]
                 except KeyError:
                     pass
-            return Set(m.finish(), meta=self.meta)
+            return PersistentSet(m.finish(), meta=self.meta)
 
     @staticmethod
-    def empty() -> "Set":
+    def empty() -> "PersistentSet":
         return s()
 
     def seq(self) -> ISeq[T]:
@@ -178,11 +178,11 @@ class Set(
 
 def set(  # pylint:disable=redefined-builtin
     members: Iterable[T], meta: Optional[IPersistentMap] = None
-) -> Set[T]:
+) -> PersistentSet[T]:
     """Creates a new set."""
-    return Set.from_iterable(members, meta=meta)
+    return PersistentSet.from_iterable(members, meta=meta)
 
 
-def s(*members: T, meta: Optional[IPersistentMap] = None) -> Set[T]:
+def s(*members: T, meta: Optional[IPersistentMap] = None) -> PersistentSet[T]:
     """Creates a new set from members."""
-    return Set.from_iterable(members, meta=meta)
+    return PersistentSet.from_iterable(members, meta=meta)

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -14,7 +14,9 @@ from basilisp.lang.interfaces import IPersistentMap, IRecord, ISeq, IType
 
 CompilerOpts = IPersistentMap[kw.Keyword, bool]
 
-IterableLispForm = Union[llist.List, lmap.Map, lset.Set, vec.Vector]
+IterableLispForm = Union[
+    llist.PersistentList, lmap.PersistentMap, lset.PersistentSet, vec.PersistentVector
+]
 LispNumber = Union[int, float, Fraction]
 LispForm = Union[
     bool,
@@ -25,16 +27,16 @@ LispForm = Union[
     float,
     Fraction,
     kw.Keyword,
-    llist.List,
-    lmap.Map,
+    llist.PersistentList,
+    lmap.PersistentMap,
     None,
     Pattern,
-    lset.Set,
+    lset.PersistentSet,
     str,
     sym.Symbol,
-    vec.Vector,
+    vec.PersistentVector,
     uuid.UUID,
 ]
 PyCollectionForm = Union[dict, list, set, tuple]
 ReaderForm = Union[LispForm, IRecord, ISeq, IType, PyCollectionForm]
-SpecialForm = Union[llist.List, ISeq]
+SpecialForm = Union[llist.PersistentList, ISeq]

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -70,11 +70,11 @@ class TransientVector(ITransientVector[T]):
         del self._inner[-1]
         return self
 
-    def to_persistent(self) -> "Vector[T]":
-        return Vector(self._inner.persistent())
+    def to_persistent(self) -> "PersistentVector[T]":
+        return PersistentVector(self._inner.persistent())
 
 
-class Vector(
+class PersistentVector(
     IPersistentVector[T], IEvolveableCollection[TransientVector], ILispObject, IWithMeta
 ):
     """Basilisp Vector. Delegates internally to a pyrsistent.PVector object.
@@ -104,7 +104,7 @@ class Vector(
 
     def __getitem__(self, item):
         if isinstance(item, slice):
-            return Vector(self._inner[item])
+            return PersistentVector(self._inner[item])
         return self._inner[item]
 
     def __hash__(self):
@@ -123,17 +123,17 @@ class Vector(
     def meta(self) -> Optional[IPersistentMap]:
         return self._meta
 
-    def with_meta(self, meta: Optional[IPersistentMap]) -> "Vector[T]":
+    def with_meta(self, meta: Optional[IPersistentMap]) -> "PersistentVector[T]":
         return vector(self._inner, meta=meta)
 
-    def cons(self, *elems: T) -> "Vector[T]":  # type: ignore[override]
+    def cons(self, *elems: T) -> "PersistentVector[T]":  # type: ignore[override]
         e = self._inner.evolver()
         for elem in elems:
             e.append(elem)
-        return Vector(e.persistent(), meta=self.meta)
+        return PersistentVector(e.persistent(), meta=self.meta)
 
-    def assoc(self, *kvs: T) -> "Vector[T]":  # type: ignore[override]
-        return Vector(self._inner.mset(*kvs))  # type: ignore[arg-type]
+    def assoc(self, *kvs: T) -> "PersistentVector[T]":  # type: ignore[override]
+        return PersistentVector(self._inner.mset(*kvs))  # type: ignore[arg-type]
 
     def contains(self, k):
         return 0 <= k < len(self._inner)
@@ -151,7 +151,7 @@ class Vector(
             return default
 
     @staticmethod
-    def empty() -> "Vector[T]":
+    def empty() -> "PersistentVector[T]":
         return v()
 
     def seq(self) -> ISeq[T]:  # type: ignore[override]
@@ -162,7 +162,7 @@ class Vector(
             return None
         return self[-1]
 
-    def pop(self) -> "Vector[T]":
+    def pop(self) -> "PersistentVector[T]":
         if len(self) == 0:
             raise IndexError("Cannot pop an empty vector")
         return self[:-1]
@@ -178,7 +178,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 
 
-class MapEntry(IMapEntry[K, V], Vector[Union[K, V]]):
+class MapEntry(IMapEntry[K, V], PersistentVector[Union[K, V]]):
     __slots__ = ()
 
     def __init__(self, wrapped: "PVector[Union[K, V]]") -> None:
@@ -207,11 +207,13 @@ class MapEntry(IMapEntry[K, V], Vector[Union[K, V]]):
         return MapEntry(pvector(v))
 
 
-def vector(members: Iterable[T], meta: Optional[IPersistentMap] = None) -> Vector[T]:
+def vector(
+    members: Iterable[T], meta: Optional[IPersistentMap] = None
+) -> PersistentVector[T]:
     """Creates a new vector."""
-    return Vector(pvector(members), meta=meta)
+    return PersistentVector(pvector(members), meta=meta)
 
 
-def v(*members: T, meta: Optional[IPersistentMap] = None) -> Vector[T]:
+def v(*members: T, meta: Optional[IPersistentMap] = None) -> PersistentVector[T]:
     """Creates a new vector from members."""
-    return Vector(pvector(members), meta=meta)
+    return PersistentVector(pvector(members), meta=meta)

--- a/src/basilisp/testrunner.py
+++ b/src/basilisp/testrunner.py
@@ -40,7 +40,7 @@ def pytest_collect_file(parent, path):
 class TestFailuresInfo(Exception):
     __slots__ = ("_msg", "_data")
 
-    def __init__(self, message: str, data: lmap.Map) -> None:
+    def __init__(self, message: str, data: lmap.PersistentMap) -> None:
         super().__init__()
         self._msg = message
         self._data = data
@@ -52,7 +52,7 @@ class TestFailuresInfo(Exception):
         return f"{self._msg} {lrepr(self._data)}"
 
     @property
-    def data(self) -> lmap.Map:
+    def data(self) -> lmap.PersistentMap:
         return self._data
 
     @property
@@ -60,7 +60,7 @@ class TestFailuresInfo(Exception):
         return self._msg
 
 
-TestFunction = Callable[[], lmap.Map]
+TestFunction = Callable[[], lmap.PersistentMap]
 
 
 class BasilispFile(pytest.File):
@@ -165,8 +165,8 @@ class BasilispTestItem(pytest.Item):
         If any tests fail, raise an ExceptionInfo exception with the
         test failures. PyTest will invoke self.repr_failure to display
         the failures to the user."""
-        results: lmap.Map = self._run_test()
-        failures: Optional[vec.Vector] = results.val_at(_FAILURES_KW)
+        results: lmap.PersistentMap = self._run_test()
+        failures: Optional[vec.PersistentVector] = results.val_at(_FAILURES_KW)
         if runtime.to_seq(failures):
             raise TestFailuresInfo("Test failures", lmap.map(results))
 
@@ -204,7 +204,7 @@ class BasilispTestItem(pytest.Item):
         messages.extend(traceback.format_exception(Exception, exc, exc.__traceback__))
         return "".join(messages)
 
-    def _failure_msg(self, details: lmap.Map) -> str:
+    def _failure_msg(self, details: lmap.PersistentMap) -> str:
         assert details.val_at(_TYPE_KW) == _FAILURE_KW
         msg: str = details.val_at(_MESSAGE_KW)
 

--- a/tests/basilisp/atom_test.py
+++ b/tests/basilisp/atom_test.py
@@ -13,8 +13,8 @@ def test_atom_deref_interface():
 
 
 def test_atom():
-    a = atom.Atom(vec.Vector.empty())
-    assert vec.Vector.empty() == a.deref()
+    a = atom.Atom(vec.PersistentVector.empty())
+    assert vec.PersistentVector.empty() == a.deref()
 
     assert vec.v(1) == a.swap(lambda v, e: v.cons(e), 1)
     assert vec.v(1) == a.deref()
@@ -22,8 +22,8 @@ def test_atom():
     assert vec.v(1, 2) == a.swap(lambda v, e: v.cons(e), 2)
     assert vec.v(1, 2) == a.deref()
 
-    assert vec.v(1, 2) == a.reset(lmap.Map.empty())
-    assert lmap.Map.empty() == a.deref()
+    assert vec.v(1, 2) == a.reset(lmap.PersistentMap.empty())
+    assert lmap.PersistentMap.empty() == a.deref()
 
 
 def test_alter_atom_meta():

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -2545,8 +2545,8 @@ class TestMacroexpandFunctions:
         assert llist.l(
             sym.symbol("defmacro", ns="basilisp.core"),
             sym.symbol("child"),
-            vec.Vector.empty(),
-            llist.l(sym.symbol("fn", ns="basilisp.core"), vec.Vector.empty()),
+            vec.PersistentVector.empty(),
+            llist.l(sym.symbol("fn", ns="basilisp.core"), vec.PersistentVector.empty()),
         ) == compiler.macroexpand_1(llist.l(sym.symbol("parent")))
 
         assert llist.l(
@@ -2556,7 +2556,9 @@ class TestMacroexpandFunctions:
         assert llist.l(sym.symbol("map")) == compiler.macroexpand_1(
             llist.l(sym.symbol("map"))
         )
-        assert vec.Vector.empty() == compiler.macroexpand_1(vec.Vector.empty())
+        assert vec.PersistentVector.empty() == compiler.macroexpand_1(
+            vec.PersistentVector.empty()
+        )
 
         assert sym.symbol("non-existent-symbol") == compiler.macroexpand_1(
             sym.symbol("non-existent-symbol")
@@ -2572,7 +2574,9 @@ class TestMacroexpandFunctions:
                 sym.symbol("fn", ns="basilisp.core"),
                 sym.symbol("child"),
                 vec.v(sym.symbol("&env"), sym.symbol("&form")),
-                llist.l(sym.symbol("fn", ns="basilisp.core"), vec.Vector.empty()),
+                llist.l(
+                    sym.symbol("fn", ns="basilisp.core"), vec.PersistentVector.empty()
+                ),
             ),
         ) == compiler.macroexpand(llist.l(sym.symbol("parent"), meta=meta))
 
@@ -2583,8 +2587,8 @@ class TestMacroexpandFunctions:
         assert llist.l(sym.symbol("map")) == compiler.macroexpand(
             llist.l(sym.symbol("map"), meta=meta)
         )
-        assert vec.Vector.empty() == compiler.macroexpand(
-            vec.Vector.empty().with_meta(meta)
+        assert vec.PersistentVector.empty() == compiler.macroexpand(
+            vec.PersistentVector.empty().with_meta(meta)
         )
 
         assert sym.symbol("non-existent-symbol") == compiler.macroexpand(
@@ -3399,14 +3403,14 @@ class TestQuote:
         )
 
     def test_quoted_map(self, lcompile: CompileFn):
-        assert lcompile("'{}") == lmap.Map.empty()
+        assert lcompile("'{}") == lmap.PersistentMap.empty()
         assert lcompile("'{:a 2}") == lmap.map({kw.keyword("a"): 2})
         assert lcompile('\'{:a 2 "str" s}') == lmap.map(
             {kw.keyword("a"): 2, "str": sym.symbol("s")}
         )
 
     def test_quoted_set(self, lcompile: CompileFn):
-        assert lcompile("'#{}") == lset.Set.empty()
+        assert lcompile("'#{}") == lset.PersistentSet.empty()
         assert lcompile("'#{:a 2}") == lset.s(kw.keyword("a"), 2)
         assert lcompile('\'#{:a 2 "str"}') == lset.s(kw.keyword("a"), 2, "str")
 

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -44,19 +44,19 @@ TRUTHY_VALUES = [
     kw.keyword("name", ns="ns"),
     "",
     "not empty",
-    llist.List.empty(),
+    llist.PersistentList.empty(),
     llist.l(0),
     llist.l(False),
     llist.l(True),
-    lmap.Map.empty(),
+    lmap.PersistentMap.empty(),
     lmap.map({0: 0}),
     lmap.map({False: False}),
     lmap.map({True: True}),
-    lset.Set.empty(),
+    lset.PersistentSet.empty(),
     lset.s(0),
     lset.s(False),
     lset.s(True),
-    vec.Vector.empty(),
+    vec.PersistentVector.empty(),
     vec.v(0),
     vec.v(False),
     vec.v(True),
@@ -79,19 +79,19 @@ NON_NIL_VALUES = [
     kw.keyword("name", ns="ns"),
     "",
     "not empty",
-    llist.List.empty(),
+    llist.PersistentList.empty(),
     llist.l(0),
     llist.l(False),
     llist.l(True),
-    lmap.Map.empty(),
+    lmap.PersistentMap.empty(),
     lmap.map({0: 0}),
     lmap.map({False: False}),
     lmap.map({True: True}),
-    lset.Set.empty(),
+    lset.PersistentSet.empty(),
     lset.s(0),
     lset.s(False),
     lset.s(True),
-    vec.Vector.empty(),
+    vec.PersistentVector.empty(),
     vec.v(0),
     vec.v(False),
     vec.v(True),
@@ -196,12 +196,12 @@ def test_ex_info():
 
 
 def test_last():
-    assert None is core.last(llist.List.empty())
+    assert None is core.last(llist.PersistentList.empty())
     assert 1 == core.last(llist.l(1))
     assert 2 == core.last(llist.l(1, 2))
     assert 3 == core.last(llist.l(1, 2, 3))
 
-    assert None is core.last(vec.Vector.empty())
+    assert None is core.last(vec.PersistentVector.empty())
     assert 1 == core.last(vec.v(1))
     assert 2 == core.last(vec.v(1, 2))
     assert 3 == core.last(vec.v(1, 2, 3))
@@ -477,18 +477,29 @@ class TestIsAny:
 
 
 class TestIsAssociative:
-    @pytest.mark.parametrize("v", [lmap.Map.empty(), vec.Vector.empty()])
+    @pytest.mark.parametrize(
+        "v", [lmap.PersistentMap.empty(), vec.PersistentVector.empty()]
+    )
     def test_is_associative(self, v):
         assert True is core.associative__Q__(v)
 
-    @pytest.mark.parametrize("v", [llist.List.empty(), lset.Set.empty()])
+    @pytest.mark.parametrize(
+        "v", [llist.PersistentList.empty(), lset.PersistentSet.empty()]
+    )
     def test_is_not_associative(self, v):
         assert False is core.associative__Q__(v)
 
 
 class TestIsClass:
     @pytest.mark.parametrize(
-        "tp", [kw.Keyword, llist.List, lmap.Map, sym.Symbol, vec.Vector]
+        "tp",
+        [
+            kw.Keyword,
+            llist.PersistentList,
+            lmap.PersistentMap,
+            sym.Symbol,
+            vec.PersistentVector,
+        ],
     )
     def test_is_class(self, tp):
         assert True is core.class__Q__(tp)
@@ -501,7 +512,12 @@ class TestIsClass:
 class TestIsColl:
     @pytest.mark.parametrize(
         "v",
-        [llist.List.empty(), lmap.Map.empty(), lset.Set.empty(), vec.Vector.empty()],
+        [
+            llist.PersistentList.empty(),
+            lmap.PersistentMap.empty(),
+            lset.PersistentSet.empty(),
+            vec.PersistentVector.empty(),
+        ],
     )
     def test_is_coll(self, v):
         assert True is core.coll__Q__(v)
@@ -547,10 +563,10 @@ class TestIsFn:
             1,
             1.6,
             kw.keyword("a"),
-            lmap.Map.empty(),
-            lset.Set.empty(),
+            lmap.PersistentMap.empty(),
+            lset.PersistentSet.empty(),
             sym.symbol("a"),
-            vec.Vector.empty(),
+            vec.PersistentVector.empty(),
         ],
     )
     def test_is_not_fn(self, v):
@@ -560,7 +576,9 @@ class TestIsFn:
         assert True is core.ifn__Q__(basilisp_fn)
         assert True is core.ifn__Q__(py_fn)
 
-    @pytest.mark.parametrize("v", [kw.keyword("a"), lmap.Map.empty(), lset.Set.empty()])
+    @pytest.mark.parametrize(
+        "v", [kw.keyword("a"), lmap.PersistentMap.empty(), lset.PersistentSet.empty()]
+    )
     def test_other_is_ifn(self, v):
         assert True is core.ifn__Q__(v)
 
@@ -623,7 +641,7 @@ class TestIsIdent:
 
 def test_is_map_entry():
     assert True is core.map_entry__Q__(lmap.MapEntry.of("a", "b"))
-    assert False is core.map_entry__Q__(vec.Vector.empty())
+    assert False is core.map_entry__Q__(vec.PersistentVector.empty())
     assert False is core.map_entry__Q__(vec.v("a", "b"))
     assert False is core.map_entry__Q__(vec.v("a", "b", "c"))
 
@@ -814,7 +832,7 @@ class TestIsPy:
     def test_is_py_dict(self, v):
         assert True is core.py_dict__Q__(v)
 
-    @pytest.mark.parametrize("v", [lmap.Map.empty(), lmap.map({"a": "b"})])
+    @pytest.mark.parametrize("v", [lmap.PersistentMap.empty(), lmap.map({"a": "b"})])
     def test_is_not_py_dict(self, v):
         assert False is core.py_dict__Q__(v)
 
@@ -822,7 +840,7 @@ class TestIsPy:
     def test_is_py_frozenset(self, v):
         assert True is core.py_frozenset__Q__(v)
 
-    @pytest.mark.parametrize("v", [lset.Set.empty(), lset.s("a", "b")])
+    @pytest.mark.parametrize("v", [lset.PersistentSet.empty(), lset.s("a", "b")])
     def test_is_not_py_frozenset(self, v):
         assert False is core.py_frozenset__Q__(v)
 
@@ -830,7 +848,7 @@ class TestIsPy:
     def test_is_py_list(self, v):
         assert True is core.py_list__Q__(v)
 
-    @pytest.mark.parametrize("v", [vec.Vector.empty(), vec.v("a", "b")])
+    @pytest.mark.parametrize("v", [vec.PersistentVector.empty(), vec.v("a", "b")])
     def test_is_not_py_list(self, v):
         assert False is core.py_list__Q__(v)
 
@@ -838,7 +856,7 @@ class TestIsPy:
     def test_is_py_set(self, v):
         assert True is core.py_set__Q__(v)
 
-    @pytest.mark.parametrize("v", [lset.Set.empty(), lset.s("a", "b")])
+    @pytest.mark.parametrize("v", [lset.PersistentSet.empty(), lset.s("a", "b")])
     def test_is_not_py_set(self, v):
         assert False is core.py_set__Q__(v)
 
@@ -846,7 +864,7 @@ class TestIsPy:
     def test_is_py_tuple(self, v):
         assert True is core.py_tuple__Q__(v)
 
-    @pytest.mark.parametrize("v", [llist.List.empty(), llist.l("a", "b")])
+    @pytest.mark.parametrize("v", [llist.PersistentList.empty(), llist.l("a", "b")])
     def test_is_not_py_tuple(self, v):
         assert False is core.py_tuple__Q__(v)
 
@@ -1038,12 +1056,12 @@ class TestAssociativeFunctions:
         assert False is core.contains__Q__(vec.v(1, 2, 3), -1)
 
     def test_disj(self):
-        assert lset.Set.empty() == core.disj(lset.Set.empty(), "a")
-        assert lset.Set.empty() == core.disj(lset.s("a"), "a")
+        assert lset.PersistentSet.empty() == core.disj(lset.PersistentSet.empty(), "a")
+        assert lset.PersistentSet.empty() == core.disj(lset.s("a"), "a")
         assert lset.s("b", "d") == core.disj(lset.s("a", "b", "c", "d"), "a", "c", "e")
 
     def test_dissoc(self):
-        assert lmap.Map.empty() == core.dissoc(lmap.map({"a": 1}), "a", "c")
+        assert lmap.PersistentMap.empty() == core.dissoc(lmap.map({"a": 1}), "a", "c")
         assert lmap.map({"a": 1}) == core.dissoc(lmap.map({"a": 1}), "b", "c")
 
     def test_get(self):
@@ -1100,7 +1118,7 @@ class TestAssociativeFunctions:
             lmap.map({"f": 6}),
         )
 
-        assert vec.v("a") == core.assoc_in(vec.Vector.empty(), vec.v(0), "a")
+        assert vec.v("a") == core.assoc_in(vec.PersistentVector.empty(), vec.v(0), "a")
         assert vec.v("c", "b") == core.assoc_in(vec.v("a", "b"), vec.v(0), "c")
         assert vec.v("a", "c") == core.assoc_in(vec.v("a", "b"), vec.v(1), "c")
         assert vec.v("a", "d", "c") == core.assoc_in(
@@ -1237,11 +1255,11 @@ class TestAssociativeFunctions:
         assert lset.s(1, 2) == lset.set(core.vals(lmap.map({"a": 1, "b": 2})))
 
     def test_select_keys(self):
-        assert lmap.Map.empty() == core.select_keys(
-            lmap.Map.empty(), vec.Vector.empty()
+        assert lmap.PersistentMap.empty() == core.select_keys(
+            lmap.PersistentMap.empty(), vec.PersistentVector.empty()
         )
-        assert lmap.Map.empty() == core.select_keys(
-            lmap.Map.empty(), vec.v(kw.keyword("a"), kw.keyword("b"))
+        assert lmap.PersistentMap.empty() == core.select_keys(
+            lmap.PersistentMap.empty(), vec.v(kw.keyword("a"), kw.keyword("b"))
         )
         assert lmap.map(
             {kw.keyword("a"): "a", kw.keyword("b"): "b"}
@@ -1341,7 +1359,7 @@ def test_partial_kw():
 
 class TestIsEvery:
     @pytest.mark.parametrize(
-        "coll", [vec.Vector.empty(), vec.v(3), vec.v(3, 5, 7, 9, 11)]
+        "coll", [vec.PersistentVector.empty(), vec.v(3), vec.v(3, 5, 7, 9, 11)]
     )
     def test_is_every(self, coll):
         assert True is core.every__Q__(core.odd__Q__, coll)
@@ -1356,7 +1374,7 @@ class TestIsEvery:
 
 class TestIsNotEvery:
     @pytest.mark.parametrize(
-        "coll", [vec.Vector.empty(), vec.v(3), vec.v(3, 5, 7, 9, 11)]
+        "coll", [vec.PersistentVector.empty(), vec.v(3), vec.v(3, 5, 7, 9, 11)]
     )
     def test_is_not_every(self, coll):
         assert False is core.not_every__Q__(core.odd__Q__, coll)
@@ -1384,7 +1402,7 @@ class TestSome:
         assert True is core.some(core.odd__Q__, coll)
 
     @pytest.mark.parametrize(
-        "coll", [vec.Vector.empty(), vec.v(2), vec.v(2, 4, 6, 8, 10)]
+        "coll", [vec.PersistentVector.empty(), vec.v(2), vec.v(2, 4, 6, 8, 10)]
     )
     def test_is_not_some(self, coll):
         assert None is core.some(core.odd__Q__, coll)
@@ -1405,7 +1423,7 @@ class TestNotAny:
         assert False is core.not_any__Q__(core.odd__Q__, coll)
 
     @pytest.mark.parametrize(
-        "coll", [vec.Vector.empty(), vec.v(2), vec.v(2, 4, 6, 8, 10)]
+        "coll", [vec.PersistentVector.empty(), vec.v(2), vec.v(2, 4, 6, 8, 10)]
     )
     def test_not_is_not_any(self, coll):
         assert True is core.not_any__Q__(core.odd__Q__, coll)
@@ -1472,7 +1490,7 @@ def test_string_format():
 
 def test_merge():
     assert None is core.merge()
-    assert lmap.Map.empty() == core.merge(lmap.Map.empty())
+    assert lmap.PersistentMap.empty() == core.merge(lmap.PersistentMap.empty())
     assert lmap.map({kw.keyword("a"): 1}) == core.merge(lmap.map({kw.keyword("a"): 1}))
     assert lmap.map({kw.keyword("a"): 53, kw.keyword("b"): "hi"}) == core.merge(
         lmap.map({kw.keyword("a"): 1, kw.keyword("b"): "hi"}),
@@ -1481,7 +1499,9 @@ def test_merge():
 
 
 def test_map():
-    assert llist.List.empty() == core.map_(core.identity, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.map_(
+        core.identity, vec.PersistentVector.empty()
+    )
     assert llist.l(1, 2, 3) == core.map_(core.identity, vec.v(1, 2, 3))
     assert llist.l(2, 3, 4) == core.map_(core.inc, vec.v(1, 2, 3))
 
@@ -1498,8 +1518,8 @@ def test_map_indexed():
 
 
 def test_mapcat():
-    assert llist.List.empty() == core.mapcat(
-        lambda x: vec.v(x, x + 1), vec.Vector.empty()
+    assert llist.PersistentList.empty() == core.mapcat(
+        lambda x: vec.v(x, x + 1), vec.PersistentVector.empty()
     )
     assert llist.l(1, 2, 2, 3, 3, 4) == core.mapcat(
         lambda x: vec.v(x, x + 1), vec.v(1, 2, 3)
@@ -1510,36 +1530,48 @@ def test_mapcat():
 
 
 def test_filter():
-    assert llist.List.empty() == core.filter_(core.identity, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.filter_(
+        core.identity, vec.PersistentVector.empty()
+    )
     assert llist.l(1, 3) == core.filter_(core.odd__Q__, vec.v(1, 2, 3, 4))
     assert llist.l(1, 2, 3, 4) == core.filter_(core.identity, vec.v(1, 2, 3, 4))
 
 
 def test_remove():
-    assert llist.List.empty() == core.remove(core.identity, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.remove(
+        core.identity, vec.PersistentVector.empty()
+    )
     assert llist.l(2, 4) == core.remove(core.odd__Q__, vec.v(1, 2, 3, 4))
-    assert llist.List.empty() == core.remove(core.identity, vec.v(1, 2, 3, 4))
+    assert llist.PersistentList.empty() == core.remove(core.identity, vec.v(1, 2, 3, 4))
 
 
 def test_take():
-    assert llist.List.empty() == core.take(3, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.take(3, vec.PersistentVector.empty())
     assert llist.l(1, 2, 3) == core.take(3, vec.v(1, 2, 3))
     assert llist.l(1, 2) == core.take(2, vec.v(1, 2, 3))
     assert llist.l(1) == core.take(1, vec.v(1, 2, 3))
-    assert llist.List.empty() == core.take(0, vec.v(1, 2, 3))
+    assert llist.PersistentList.empty() == core.take(0, vec.v(1, 2, 3))
 
 
 def test_take_while():
-    assert llist.List.empty() == core.take_while(core.odd__Q__, vec.Vector.empty())
-    assert llist.List.empty() == core.take_while(core.even__Q__, vec.v(1, 3, 5, 7))
-    assert llist.List.empty() == core.take_while(core.odd__Q__, vec.v(2, 3, 5, 7))
+    assert llist.PersistentList.empty() == core.take_while(
+        core.odd__Q__, vec.PersistentVector.empty()
+    )
+    assert llist.PersistentList.empty() == core.take_while(
+        core.even__Q__, vec.v(1, 3, 5, 7)
+    )
+    assert llist.PersistentList.empty() == core.take_while(
+        core.odd__Q__, vec.v(2, 3, 5, 7)
+    )
     assert llist.l(1, 3, 5) == core.take_while(core.odd__Q__, vec.v(1, 3, 5, 2))
     assert llist.l(1, 3, 5, 7) == core.take_while(core.odd__Q__, vec.v(1, 3, 5, 7))
     assert llist.l(1) == core.take_while(core.odd__Q__, vec.v(1, 2, 3, 4))
 
 
 def test_take_nth():
-    assert llist.List.empty() == core.take_nth(0, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.take_nth(
+        0, vec.PersistentVector.empty()
+    )
     assert llist.l(1, 1, 1) == core.take(3, core.take_nth(0, vec.v(1)))
     assert llist.l(1, 1, 1) == core.take(3, core.take_nth(0, vec.v(1, 1, 1)))
     assert llist.l(1, 2, 3, 4, 5) == core.take_nth(1, vec.v(1, 2, 3, 4, 5))
@@ -1547,8 +1579,8 @@ def test_take_nth():
 
 
 def test_drop():
-    assert llist.List.empty() == core.drop(3, vec.Vector.empty())
-    assert llist.List.empty() == core.drop(3, vec.v(1, 2, 3))
+    assert llist.PersistentList.empty() == core.drop(3, vec.PersistentVector.empty())
+    assert llist.PersistentList.empty() == core.drop(3, vec.v(1, 2, 3))
     assert llist.l(1, 2, 3) == core.drop(0, vec.v(1, 2, 3))
     assert llist.l(2, 3) == core.drop(1, vec.v(1, 2, 3))
     assert llist.l(3) == core.drop(2, vec.v(1, 2, 3))
@@ -1556,8 +1588,12 @@ def test_drop():
 
 
 def test_drop_while():
-    assert llist.List.empty() == core.drop_while(core.odd__Q__, vec.Vector.empty())
-    assert llist.List.empty() == core.drop_while(core.odd__Q__, vec.v(1, 3, 5, 7))
+    assert llist.PersistentList.empty() == core.drop_while(
+        core.odd__Q__, vec.PersistentVector.empty()
+    )
+    assert llist.PersistentList.empty() == core.drop_while(
+        core.odd__Q__, vec.v(1, 3, 5, 7)
+    )
     assert llist.l(2) == core.drop_while(core.odd__Q__, vec.v(1, 3, 5, 2))
     assert llist.l(2, 3, 4) == core.drop_while(core.odd__Q__, vec.v(1, 2, 3, 4))
     assert llist.l(2, 4, 6, 8) == core.drop_while(core.odd__Q__, vec.v(2, 4, 6, 8))
@@ -1568,54 +1604,58 @@ def test_drop_last():
     assert llist.l(1, 2, 3) == core.drop_last(2, vec.v(1, 2, 3, 4, 5))
     assert llist.l(1, 2) == core.drop_last(3, vec.v(1, 2, 3, 4, 5))
     assert llist.l(1) == core.drop_last(4, vec.v(1, 2, 3, 4, 5))
-    assert llist.List.empty() == core.drop_last(5, vec.v(1, 2, 3, 4, 5))
-    assert llist.List.empty() == core.drop_last(6, vec.v(1, 2, 3, 4, 5))
+    assert llist.PersistentList.empty() == core.drop_last(5, vec.v(1, 2, 3, 4, 5))
+    assert llist.PersistentList.empty() == core.drop_last(6, vec.v(1, 2, 3, 4, 5))
     assert llist.l(1, 2, 3, 4, 5) == core.drop_last(0, vec.v(1, 2, 3, 4, 5))
     assert llist.l(1, 2, 3, 4, 5) == core.drop_last(-1, vec.v(1, 2, 3, 4, 5))
 
 
 def test_split_at():
-    assert vec.v(llist.List.empty(), llist.List.empty()) == core.split_at(
-        3, vec.Vector.empty()
-    )
-    assert vec.v(llist.List.empty(), llist.l(1, 2, 3)) == core.split_at(
+    assert vec.v(
+        llist.PersistentList.empty(), llist.PersistentList.empty()
+    ) == core.split_at(3, vec.PersistentVector.empty())
+    assert vec.v(llist.PersistentList.empty(), llist.l(1, 2, 3)) == core.split_at(
         0, vec.v(1, 2, 3)
     )
     assert vec.v(llist.l(1), llist.l(2, 3)) == core.split_at(1, vec.v(1, 2, 3))
     assert vec.v(llist.l(1, 2), llist.l(3)) == core.split_at(2, vec.v(1, 2, 3))
-    assert vec.v(llist.l(1, 2, 3), llist.List.empty()) == core.split_at(
+    assert vec.v(llist.l(1, 2, 3), llist.PersistentList.empty()) == core.split_at(
         3, vec.v(1, 2, 3)
     )
-    assert vec.v(llist.l(1, 2, 3), llist.List.empty()) == core.split_at(
+    assert vec.v(llist.l(1, 2, 3), llist.PersistentList.empty()) == core.split_at(
         4, vec.v(1, 2, 3)
     )
     assert vec.v(llist.l(1, 2, 3), llist.l(4)) == core.split_at(3, vec.v(1, 2, 3, 4))
 
 
 def test_split_with():
-    assert vec.v(llist.List.empty(), llist.List.empty()) == core.split_with(
-        core.odd__Q__, vec.Vector.empty()
-    )
+    assert vec.v(
+        llist.PersistentList.empty(), llist.PersistentList.empty()
+    ) == core.split_with(core.odd__Q__, vec.PersistentVector.empty())
     assert vec.v(llist.l(1), llist.l(2, 3)) == core.split_with(
         core.odd__Q__, vec.v(1, 2, 3)
     )
-    assert vec.v(llist.l(1, 3, 5, 7), llist.List.empty()) == core.split_with(
+    assert vec.v(llist.l(1, 3, 5, 7), llist.PersistentList.empty()) == core.split_with(
         core.odd__Q__, vec.v(1, 3, 5, 7)
     )
-    assert vec.v(llist.List.empty(), llist.l(2, 4, 6, 8)) == core.split_with(
+    assert vec.v(llist.PersistentList.empty(), llist.l(2, 4, 6, 8)) == core.split_with(
         core.odd__Q__, vec.v(2, 4, 6, 8)
     )
 
 
 def test_group_by():
-    assert lmap.Map.empty() == core.group_by(core.inc, vec.Vector.empty())
+    assert lmap.PersistentMap.empty() == core.group_by(
+        core.inc, vec.PersistentVector.empty()
+    )
     assert lmap.map({True: vec.v(1, 3), False: vec.v(2, 4)}) == core.group_by(
         core.odd__Q__, vec.v(1, 2, 3, 4)
     )
 
 
 def test_interpose():
-    assert llist.List.empty() == core.interpose(",", vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.interpose(
+        ",", vec.PersistentVector.empty()
+    )
     assert llist.l("hi") == core.interpose(",", vec.v("hi"))
     assert llist.l("hi", ",", "there") == core.interpose(",", vec.v("hi", "there"))
 
@@ -1680,7 +1720,9 @@ def test_partition_all():
 
 
 def test_partition_by():
-    assert llist.List.empty() == core.partition_by(core.odd__Q__, vec.Vector.empty())
+    assert llist.PersistentList.empty() == core.partition_by(
+        core.odd__Q__, vec.PersistentVector.empty()
+    )
     assert llist.l(llist.l(1, 1, 1), llist.l(2, 2), llist.l(3, 3)) == core.partition_by(
         core.odd__Q__, vec.v(1, 1, 1, 2, 2, 3, 3)
     )

--- a/tests/basilisp/keyword_test.py
+++ b/tests/basilisp/keyword_test.py
@@ -62,25 +62,27 @@ def test_keyword_pickleability(pickle_protocol: int, o: Keyword):
 
 class TestKeywordCompletion:
     @pytest.fixture
-    def empty_cache(self) -> lmap.Map[int, Keyword]:
-        return lmap.Map.empty()
+    def empty_cache(self) -> lmap.PersistentMap[int, Keyword]:
+        return lmap.PersistentMap.empty()
 
-    def test_empty_cache_no_completion(self, empty_cache: lmap.Map[int, Keyword]):
+    def test_empty_cache_no_completion(
+        self, empty_cache: lmap.PersistentMap[int, Keyword]
+    ):
         assert [] == list(complete(":", kw_cache=empty_cache))
 
     @pytest.fixture
-    def cache(self) -> lmap.Map[int, Keyword]:
+    def cache(self) -> lmap.PersistentMap[int, Keyword]:
         values = [Keyword("kw"), Keyword("ns"), Keyword("kw", ns="ns")]
         return lmap.map({hash(v): v for v in values})
 
-    def test_no_ns_completion(self, cache: lmap.Map[int, Keyword]):
+    def test_no_ns_completion(self, cache: lmap.PersistentMap[int, Keyword]):
         assert [] == list(complete(":v", kw_cache=cache))
         assert {":kw", ":ns/kw"} == set(complete(":k", kw_cache=cache))
         assert {":kw", ":ns/kw"} == set(complete(":kw", kw_cache=cache))
         assert {":ns", ":ns/kw"} == set(complete(":n", kw_cache=cache))
         assert {":ns", ":ns/kw"} == set(complete(":ns", kw_cache=cache))
 
-    def test_ns_completion(self, cache: lmap.Map[int, Keyword]):
+    def test_ns_completion(self, cache: lmap.PersistentMap[int, Keyword]):
         assert [] == list(complete(":v/", kw_cache=cache))
         assert [] == list(complete(":k/", kw_cache=cache))
         assert [] == list(complete(":kw/", kw_cache=cache))

--- a/tests/basilisp/list_test.py
+++ b/tests/basilisp/list_test.py
@@ -33,15 +33,15 @@ from basilisp.lang.symbol import symbol
 )
 def test_list_interface_membership(interface):
     assert isinstance(llist.l(), interface)
-    assert issubclass(llist.List, interface)
+    assert issubclass(llist.PersistentList, interface)
 
 
 def test_list_slice():
-    assert isinstance(llist.l(1, 2, 3)[1:], llist.List)
+    assert isinstance(llist.l(1, 2, 3)[1:], llist.PersistentList)
 
 
 def test_list_bool():
-    assert True is bool(llist.List.empty())
+    assert True is bool(llist.PersistentList.empty())
 
 
 def test_list_cons():
@@ -67,7 +67,7 @@ def test_pop():
     with pytest.raises(IndexError):
         llist.l().pop()
 
-    assert llist.List.empty() == llist.l(1).pop()
+    assert llist.PersistentList.empty() == llist.l(1).pop()
     assert llist.l(2) == llist.l(1, 2).pop()
     assert llist.l(2, 3) == llist.l(1, 2, 3).pop()
 
@@ -100,7 +100,7 @@ def test_list_with_meta():
 
 
 def test_list_first():
-    assert None is llist.List.empty().first
+    assert None is llist.PersistentList.empty().first
     assert None is llist.l().first
     assert 1 == llist.l(1).first
     assert 1 == llist.l(1, 2).first
@@ -122,7 +122,7 @@ def test_list_rest():
         llist.l(keyword("kw1"), llist.l("string", 4)),
     ],
 )
-def test_list_pickleability(pickle_protocol: int, o: llist.List):
+def test_list_pickleability(pickle_protocol: int, o: llist.PersistentList):
     assert o == pickle.loads(pickle.dumps(o, protocol=pickle_protocol))
 
 
@@ -134,5 +134,5 @@ def test_list_pickleability(pickle_protocol: int, o: llist.List):
         (llist.l(keyword("kw1"), keyword("kw2")), "(:kw1 :kw2)"),
     ],
 )
-def test_list_repr(l: llist.List, str_repr: str):
+def test_list_repr(l: llist.PersistentList, str_repr: str):
     assert repr(l) == str_repr

--- a/tests/basilisp/map_test.py
+++ b/tests/basilisp/map_test.py
@@ -39,13 +39,13 @@ def test_map_entry_interface_membership():
 )
 def test_map_interface_membership(interface):
     assert isinstance(lmap.m(), interface)
-    assert issubclass(lmap.Map, interface)
+    assert issubclass(lmap.PersistentMap, interface)
 
 
 def test_assoc():
     m = lmap.m()
     assert lmap.map({"k": 1}) == m.assoc("k", 1)
-    assert lmap.Map.empty() == m
+    assert lmap.PersistentMap.empty() == m
     assert lmap.map({"a": 1, "b": 2}) == m.assoc("a", 1, "b", 2)
 
     m1 = lmap.map({"a": 3})
@@ -54,7 +54,7 @@ def test_assoc():
 
 
 def test_map_bool():
-    assert True is bool(lmap.Map.empty())
+    assert True is bool(lmap.PersistentMap.empty())
 
 
 def test_map_as_function():
@@ -68,33 +68,35 @@ def test_map_as_function():
 def test_contains():
     assert True is lmap.map({"a": 1}).contains("a")
     assert False is lmap.map({"a": 1}).contains("b")
-    assert False is lmap.Map.empty().contains("a")
+    assert False is lmap.PersistentMap.empty().contains("a")
 
 
 def test_dissoc():
-    assert lmap.Map.empty() == lmap.Map.empty().dissoc("a")
-    assert lmap.Map.empty() == lmap.Map.empty().dissoc("a", "b", "c")
+    assert lmap.PersistentMap.empty() == lmap.PersistentMap.empty().dissoc("a")
+    assert lmap.PersistentMap.empty() == lmap.PersistentMap.empty().dissoc(
+        "a", "b", "c"
+    )
 
     m1 = lmap.map({"a": 3})
     assert m1 == m1.dissoc("b")
-    assert lmap.Map.empty() == m1.dissoc("a")
+    assert lmap.PersistentMap.empty() == m1.dissoc("a")
 
     m2 = lmap.map({"a": 3, "b": 2})
     assert lmap.map({"a": 3}) == m2.dissoc("b")
     assert lmap.map({"b": 2}) == m2.dissoc("a")
-    assert lmap.Map.empty() == m2.dissoc("a", "b")
+    assert lmap.PersistentMap.empty() == m2.dissoc("a", "b")
 
 
 def test_entry():
     assert MapEntry.of("a", 1) == lmap.map({"a": 1}).entry("a")
     assert None is lmap.map({"a": 1}).entry("b")
-    assert None is lmap.Map.empty().entry("a")
+    assert None is lmap.PersistentMap.empty().entry("a")
 
 
 def test_val_at():
     assert 1 == lmap.map({"a": 1}).val_at("a")
     assert None is lmap.map({"a": 1}).val_at("b")
-    assert None is lmap.Map.empty().val_at("a")
+    assert None is lmap.PersistentMap.empty().val_at("a")
 
 
 def test_map_cons():
@@ -213,5 +215,5 @@ def test_hash_map_creator():
         lmap.map({"a": 2, keyword("b"): lmap.map({keyword("c"): "string"})}),
     ],
 )
-def test_map_pickleability(pickle_protocol: int, o: lmap.Map):
+def test_map_pickleability(pickle_protocol: int, o: lmap.PersistentMap):
     assert o == pickle.loads(pickle.dumps(o, protocol=pickle_protocol))

--- a/tests/basilisp/multifn_test.py
+++ b/tests/basilisp/multifn_test.py
@@ -60,7 +60,7 @@ def test_multi_function():
 
     f.remove_all_methods()
 
-    assert lmap.Map.empty() == f.methods
+    assert lmap.PersistentMap.empty() == f.methods
 
     with pytest.raises(NotImplementedError):
         f("blah")

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -381,20 +381,20 @@ def test_vector():
         1.4, kw.keyword("a"), "string"
     )
 
-    assert read_str_first("[\n]") == vec.Vector.empty()
+    assert read_str_first("[\n]") == vec.PersistentVector.empty()
     assert read_str_first("[       :a\n :b\n]") == vec.v(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("[:a :b\n]") == vec.v(kw.keyword("a"), kw.keyword("b"))
     assert read_str_first("[:a :b      ]") == vec.v(kw.keyword("a"), kw.keyword("b"))
-    assert read_str_first("[\n;;comment\n]") == vec.Vector.empty()
+    assert read_str_first("[\n;;comment\n]") == vec.PersistentVector.empty()
     assert read_str_first("[:a :b\n;;comment\n]") == vec.v(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("[:a \n;;comment\n :b]") == vec.v(
         kw.keyword("a"), kw.keyword("b")
     )
-    assert read_str_first("[\n#_[:a :b]\n]") == vec.Vector.empty()
+    assert read_str_first("[\n#_[:a :b]\n]") == vec.PersistentVector.empty()
     assert read_str_first("[:a :b\n#_[:a :b]\n]") == vec.v(
         kw.keyword("a"), kw.keyword("b")
     )
@@ -419,20 +419,20 @@ def test_list():
     )
     assert read_str_first("(- -1 2)") == llist.l(sym.symbol("-"), -1, 2)
 
-    assert read_str_first("(\n)") == llist.List.empty()
+    assert read_str_first("(\n)") == llist.PersistentList.empty()
     assert read_str_first("(       :a\n :b\n)") == llist.l(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("(:a :b\n)") == llist.l(kw.keyword("a"), kw.keyword("b"))
     assert read_str_first("(:a :b      )") == llist.l(kw.keyword("a"), kw.keyword("b"))
-    assert read_str_first("(\n;;comment\n)") == llist.List.empty()
+    assert read_str_first("(\n;;comment\n)") == llist.PersistentList.empty()
     assert read_str_first("(:a :b\n;;comment\n)") == llist.l(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("(:a \n;;comment\n :b)") == llist.l(
         kw.keyword("a"), kw.keyword("b")
     )
-    assert read_str_first("(\n#_[:a :b]\n)") == llist.List.empty()
+    assert read_str_first("(\n#_[:a :b]\n)") == llist.PersistentList.empty()
     assert read_str_first("(:a :b\n#_[:a :b]\n)") == llist.l(
         kw.keyword("a"), kw.keyword("b")
     )
@@ -455,20 +455,20 @@ def test_set():
         kw.keyword("a"), 1, "some string"
     )
 
-    assert read_str_first("#{\n}") == lset.Set.empty()
+    assert read_str_first("#{\n}") == lset.PersistentSet.empty()
     assert read_str_first("#{       :a\n :b\n}") == lset.s(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("#{:a :b\n}") == lset.s(kw.keyword("a"), kw.keyword("b"))
     assert read_str_first("#{:a :b      }") == lset.s(kw.keyword("a"), kw.keyword("b"))
-    assert read_str_first("#{\n;;comment\n}") == lset.Set.empty()
+    assert read_str_first("#{\n;;comment\n}") == lset.PersistentSet.empty()
     assert read_str_first("#{:a :b\n;;comment\n}") == lset.s(
         kw.keyword("a"), kw.keyword("b")
     )
     assert read_str_first("#{:a \n;;comment\n :b}") == lset.s(
         kw.keyword("a"), kw.keyword("b")
     )
-    assert read_str_first("#{\n#_[:a :b]\n}") == lset.Set.empty()
+    assert read_str_first("#{\n#_[:a :b]\n}") == lset.PersistentSet.empty()
     assert read_str_first("#{:a :b\n#_[:a :b]\n}") == lset.s(
         kw.keyword("a"), kw.keyword("b")
     )
@@ -490,7 +490,7 @@ def test_map():
         {kw.keyword("a"): 1, kw.keyword("b"): "string"}
     )
 
-    assert read_str_first("{\n}") == lmap.Map.empty()
+    assert read_str_first("{\n}") == lmap.PersistentMap.empty()
     assert read_str_first("{       :a\n :b\n}") == lmap.map(
         {kw.keyword("a"): kw.keyword("b")}
     )
@@ -498,14 +498,14 @@ def test_map():
     assert read_str_first("{:a :b      }") == lmap.map(
         {kw.keyword("a"): kw.keyword("b")}
     )
-    assert read_str_first("{\n;;comment\n}") == lmap.Map.empty()
+    assert read_str_first("{\n;;comment\n}") == lmap.PersistentMap.empty()
     assert read_str_first("{:a :b\n;;comment\n}") == lmap.map(
         {kw.keyword("a"): kw.keyword("b")}
     )
     assert read_str_first("{:a \n;;comment\n :b}") == lmap.map(
         {kw.keyword("a"): kw.keyword("b")}
     )
-    assert read_str_first("{\n#_[:a :b]\n}") == lmap.Map.empty()
+    assert read_str_first("{\n#_[:a :b]\n}") == lmap.PersistentMap.empty()
     assert read_str_first("{:a :b\n#_[:a :b]\n}") == lmap.map(
         {kw.keyword("a"): kw.keyword("b")}
     )
@@ -689,7 +689,7 @@ def test_syntax_quote_gensym():
     resolver = lambda s: sym.symbol(s.name, ns="test-ns")
 
     gensym = read_str_first("`s#", resolver=resolver)
-    assert isinstance(gensym, llist.List)
+    assert isinstance(gensym, llist.PersistentList)
     assert gensym.first == reader._QUOTE
     genned_sym: sym.Symbol = gensym[1]
     assert genned_sym.name.startswith("s_")
@@ -957,26 +957,26 @@ def test_comment_reader_macro():
 
     assert kw.keyword("kw2") == read_str_first("#_:kw1 :kw2")
 
-    assert llist.List.empty() == read_str_first("(#_sym)")
+    assert llist.PersistentList.empty() == read_str_first("(#_sym)")
     assert llist.l(sym.symbol("inc"), 5) == read_str_first("(inc #_counter 5)")
     assert llist.l(sym.symbol("dec"), 8) == read_str_first("(#_inc dec #_counter 8)")
 
-    assert vec.Vector.empty() == read_str_first("[#_m]")
+    assert vec.PersistentVector.empty() == read_str_first("[#_m]")
     assert vec.v(1) == read_str_first("[#_m 1]")
     assert vec.v(1) == read_str_first("[#_m 1 #_2]")
     assert vec.v(1, 2) == read_str_first("[#_m 1 2]")
     assert vec.v(1, 4) == read_str_first("[#_m 1 #_2 4]")
     assert vec.v(1, 4) == read_str_first("[#_m 1 #_2 4 #_5]")
 
-    assert lset.Set.empty() == read_str_first("#{#_m}")
+    assert lset.PersistentSet.empty() == read_str_first("#{#_m}")
     assert lset.s(1) == read_str_first("#{#_m 1}")
     assert lset.s(1) == read_str_first("#{#_m 1 #_2}")
     assert lset.s(1, 2) == read_str_first("#{#_m 1 2}")
     assert lset.s(1, 4) == read_str_first("#{#_m 1 #_2 4}")
     assert lset.s(1, 4) == read_str_first("#{#_m 1 #_2 4 #_5}")
 
-    assert lmap.Map.empty() == read_str_first("{#_:key}")
-    assert lmap.Map.empty() == read_str_first('{#_:key #_"value"}')
+    assert lmap.PersistentMap.empty() == read_str_first("{#_:key}")
+    assert lmap.PersistentMap.empty() == read_str_first('{#_:key #_"value"}')
     assert lmap.map({kw.keyword("key"): "value"}) == read_str_first(
         '{:key #_"other" "value"}'
     )
@@ -1112,7 +1112,7 @@ class TestReaderConditional:
         assert lset.s(1) == read_str_first("#{1 #?@(:clj [2 4 6])}")
 
     def test_splicing_form_in_maps(self):
-        assert lmap.Map.empty() == read_str_first("{#?@(:clj [:a 1])}")
+        assert lmap.PersistentMap.empty() == read_str_first("{#?@(:clj [:a 1])}")
         assert lmap.map({kw.keyword("b"): 2}) == read_str_first(
             "{#?@(:clj [:a 1] :lpy [:b 2])}"
         )
@@ -1176,7 +1176,7 @@ def test_deref():
     assert read_str_first("@s") == llist.l(reader._DEREF, sym.symbol("s"))
     assert read_str_first("@ns/s") == llist.l(reader._DEREF, sym.symbol("s", ns="ns"))
     assert read_str_first("@(atom {})") == llist.l(
-        reader._DEREF, llist.l(sym.symbol("atom"), lmap.Map.empty())
+        reader._DEREF, llist.l(sym.symbol("atom"), lmap.PersistentMap.empty())
     )
 
 

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -73,7 +73,9 @@ def test_rest():
 def test_nthrest():
     assert None is runtime.nthrest(None, 1)
 
-    assert llist.List.empty() == runtime.nthrest(llist.List.empty(), 0)
+    assert llist.PersistentList.empty() == runtime.nthrest(
+        llist.PersistentList.empty(), 0
+    )
     assert lseq.sequence([2, 3, 4, 5, 6]) == runtime.nthrest(
         llist.l(1, 2, 3, 4, 5, 6), 1
     )
@@ -82,7 +84,9 @@ def test_nthrest():
     assert lseq.sequence([5, 6]) == runtime.nthrest(llist.l(1, 2, 3, 4, 5, 6), 4)
     assert lseq.sequence([6]) == runtime.nthrest(llist.l(1, 2, 3, 4, 5, 6), 5)
 
-    assert vec.Vector.empty() == runtime.nthrest(vec.Vector.empty(), 0)
+    assert vec.PersistentVector.empty() == runtime.nthrest(
+        vec.PersistentVector.empty(), 0
+    )
     assert lseq.sequence([2, 3, 4, 5, 6]) == runtime.nthrest(vec.v(1, 2, 3, 4, 5, 6), 1)
     assert lseq.sequence([3, 4, 5, 6]) == runtime.nthrest(vec.v(1, 2, 3, 4, 5, 6), 2)
     assert lseq.sequence([4, 5, 6]) == runtime.nthrest(vec.v(1, 2, 3, 4, 5, 6), 3)
@@ -103,7 +107,7 @@ def test_next():
 def test_nthnext():
     assert None is runtime.nthnext(None, 1)
 
-    assert None is runtime.nthnext(llist.List.empty(), 0)
+    assert None is runtime.nthnext(llist.PersistentList.empty(), 0)
     assert lseq.sequence([2, 3, 4, 5, 6]) == runtime.nthnext(
         llist.l(1, 2, 3, 4, 5, 6), 1
     )
@@ -112,7 +116,7 @@ def test_nthnext():
     assert lseq.sequence([5, 6]) == runtime.nthnext(llist.l(1, 2, 3, 4, 5, 6), 4)
     assert lseq.sequence([6]) == runtime.nthnext(llist.l(1, 2, 3, 4, 5, 6), 5)
 
-    assert None is runtime.nthnext(vec.Vector.empty(), 0)
+    assert None is runtime.nthnext(vec.PersistentVector.empty(), 0)
     assert lseq.sequence([2, 3, 4, 5, 6]) == runtime.nthnext(vec.v(1, 2, 3, 4, 5, 6), 1)
     assert lseq.sequence([3, 4, 5, 6]) == runtime.nthnext(vec.v(1, 2, 3, 4, 5, 6), 2)
     assert lseq.sequence([4, 5, 6]) == runtime.nthnext(vec.v(1, 2, 3, 4, 5, 6), 3)
@@ -131,10 +135,10 @@ def test_cons():
 
 def test_to_seq():
     assert None is runtime.to_seq(None)
-    assert None is runtime.to_seq(llist.List.empty())
-    assert None is runtime.to_seq(vec.Vector.empty())
-    assert None is runtime.to_seq(lmap.Map.empty())
-    assert None is runtime.to_seq(lset.Set.empty())
+    assert None is runtime.to_seq(llist.PersistentList.empty())
+    assert None is runtime.to_seq(vec.PersistentVector.empty())
+    assert None is runtime.to_seq(lmap.PersistentMap.empty())
+    assert None is runtime.to_seq(lset.PersistentSet.empty())
     assert None is runtime.to_seq("")
 
     assert None is not runtime.to_seq(llist.l(None))
@@ -165,10 +169,10 @@ def test_concat():
     s1 = runtime.concat()
     assert lseq.EMPTY is s1
 
-    s1 = runtime.concat(llist.List.empty(), llist.List.empty())
+    s1 = runtime.concat(llist.PersistentList.empty(), llist.PersistentList.empty())
     assert lseq.EMPTY == s1
 
-    s1 = runtime.concat(llist.List.empty(), llist.l(1, 2, 3))
+    s1 = runtime.concat(llist.PersistentList.empty(), llist.l(1, 2, 3))
     assert s1 == llist.l(1, 2, 3)
 
     s1 = runtime.concat(llist.l(1, 2, 3), vec.v(4, 5, 6))
@@ -210,13 +214,13 @@ def test_nth():
         runtime.nth(vec.v("h", "e", "l", "l", "o"), 7)
 
     with pytest.raises(TypeError):
-        runtime.nth(lmap.Map.empty(), 2)
+        runtime.nth(lmap.PersistentMap.empty(), 2)
 
     with pytest.raises(TypeError):
         runtime.nth(lmap.map({"a": 1, "b": 2, "c": 3}), 2)
 
     with pytest.raises(TypeError):
-        runtime.nth(lset.Set.empty(), 2)
+        runtime.nth(lset.PersistentSet.empty(), 2)
 
     with pytest.raises(TypeError):
         runtime.nth(lset.s(1, 2, 3), 2)
@@ -274,22 +278,22 @@ def test_get():
 
 
 def test_assoc():
-    assert lmap.Map.empty() == runtime.assoc(None)
+    assert lmap.PersistentMap.empty() == runtime.assoc(None)
     assert lmap.map({"a": 1}) == runtime.assoc(None, "a", 1)
     assert lmap.map({"a": 8}) == runtime.assoc(lmap.map({"a": 1}), "a", 8)
     assert lmap.map({"a": 1, "b": "string"}) == runtime.assoc(
         lmap.map({"a": 1}), "b", "string"
     )
 
-    assert vec.v("a") == runtime.assoc(vec.Vector.empty(), 0, "a")
+    assert vec.v("a") == runtime.assoc(vec.PersistentVector.empty(), 0, "a")
     assert vec.v("c", "b") == runtime.assoc(vec.v("a", "b"), 0, "c")
     assert vec.v("a", "c") == runtime.assoc(vec.v("a", "b"), 1, "c")
 
     with pytest.raises(IndexError):
-        runtime.assoc(vec.Vector.empty(), 1, "a")
+        runtime.assoc(vec.PersistentVector.empty(), 1, "a")
 
     with pytest.raises(TypeError):
-        runtime.assoc(llist.List.empty(), 1, "a")
+        runtime.assoc(llist.PersistentList.empty(), 1, "a")
 
 
 def test_update():
@@ -310,14 +314,14 @@ def test_update():
         lmap.map({"a": 1, "b": 583}), "b", lambda _: "string"
     )
 
-    assert vec.v("a") == runtime.update(vec.Vector.empty(), 0, lambda _: "a")
+    assert vec.v("a") == runtime.update(vec.PersistentVector.empty(), 0, lambda _: "a")
     assert vec.v("yay", "b") == runtime.update(vec.v("a", "b"), 0, lambda x: f"y{x}y")
     assert vec.v("a", "boy") == runtime.update(
         vec.v("a", "b"), 1, lambda x, y: f"{x}{y}", "oy"
     )
 
     with pytest.raises(TypeError):
-        runtime.update(llist.List.empty(), 1, lambda _: "y")
+        runtime.update(llist.PersistentList.empty(), 1, lambda _: "y")
 
 
 def test_conj():
@@ -325,24 +329,24 @@ def test_conj():
     assert llist.l(3, 2, 1) == runtime.conj(None, 1, 2, 3)
     assert llist.l(llist.l(1, 2, 3)) == runtime.conj(None, llist.l(1, 2, 3))
 
-    assert llist.l(1) == runtime.conj(llist.List.empty(), 1)
-    assert llist.l(3, 2, 1) == runtime.conj(llist.List.empty(), 1, 2, 3)
+    assert llist.l(1) == runtime.conj(llist.PersistentList.empty(), 1)
+    assert llist.l(3, 2, 1) == runtime.conj(llist.PersistentList.empty(), 1, 2, 3)
     assert llist.l(3, 2, 1, 1) == runtime.conj(llist.l(1), 1, 2, 3)
     assert llist.l(llist.l(1, 2, 3), 1) == runtime.conj(llist.l(1), llist.l(1, 2, 3))
 
-    assert lset.s(1) == runtime.conj(lset.Set.empty(), 1)
-    assert lset.s(1, 2, 3) == runtime.conj(lset.Set.empty(), 1, 2, 3)
+    assert lset.s(1) == runtime.conj(lset.PersistentSet.empty(), 1)
+    assert lset.s(1, 2, 3) == runtime.conj(lset.PersistentSet.empty(), 1, 2, 3)
     assert lset.s(1, 2, 3) == runtime.conj(lset.s(1), 1, 2, 3)
     assert lset.s(1, lset.s(1, 2, 3)) == runtime.conj(lset.s(1), lset.s(1, 2, 3))
 
-    assert vec.v(1) == runtime.conj(vec.Vector.empty(), 1)
-    assert vec.v(1, 2, 3) == runtime.conj(vec.Vector.empty(), 1, 2, 3)
+    assert vec.v(1) == runtime.conj(vec.PersistentVector.empty(), 1)
+    assert vec.v(1, 2, 3) == runtime.conj(vec.PersistentVector.empty(), 1, 2, 3)
     assert vec.v(1, 1, 2, 3) == runtime.conj(vec.v(1), 1, 2, 3)
     assert vec.v(1, vec.v(1, 2, 3)) == runtime.conj(vec.v(1), vec.v(1, 2, 3))
 
-    assert lmap.map({"a": 1}) == runtime.conj(lmap.Map.empty(), ["a", 1])
+    assert lmap.map({"a": 1}) == runtime.conj(lmap.PersistentMap.empty(), ["a", 1])
     assert lmap.map({"a": 1, "b": 93}) == runtime.conj(
-        lmap.Map.empty(), ["a", 1], ["b", 93]
+        lmap.PersistentMap.empty(), ["a", 1], ["b", 93]
     )
     assert lmap.map({"a": 1, "b": 93}) == runtime.conj(
         lmap.map({"a": 8}), ["a", 1], ["b", 93]
@@ -360,13 +364,15 @@ def test_conj():
 
 def test_deref():
     assert 1 == runtime.deref(atom.Atom(1))
-    assert vec.Vector.empty() == runtime.deref(atom.Atom(vec.Vector.empty()))
+    assert vec.PersistentVector.empty() == runtime.deref(
+        atom.Atom(vec.PersistentVector.empty())
+    )
 
     with pytest.raises(TypeError):
         runtime.deref(1)
 
     with pytest.raises(TypeError):
-        runtime.deref(vec.Vector.empty())
+        runtime.deref(vec.PersistentVector.empty())
 
 
 @pytest.mark.parametrize(
@@ -388,22 +394,22 @@ def test_deref():
         ("not empty", "not empty"),
         (Fraction("1/2"), Fraction("1/2")),
         (Decimal("3.14159"), Decimal("3.14159")),
-        (llist.List.empty(), llist.List.empty()),
+        (llist.PersistentList.empty(), llist.PersistentList.empty()),
         (llist.l(1, 2, 3), llist.l(1, 2, 3)),
-        (lmap.Map.empty(), lmap.Map.empty()),
+        (lmap.PersistentMap.empty(), lmap.PersistentMap.empty()),
         (lmap.map({"a": 1, "b": 2}), lmap.map({"a": 1, "b": 2})),
-        (lset.Set.empty(), lset.Set.empty()),
+        (lset.PersistentSet.empty(), lset.PersistentSet.empty()),
         (lset.s(1, 2, 3), lset.s(1, 2, 3)),
-        (vec.Vector.empty(), vec.Vector.empty()),
+        (vec.PersistentVector.empty(), vec.PersistentVector.empty()),
         (vec.v(1, 2, 3), vec.v(1, 2, 3)),
         (lseq.EMPTY, lseq.EMPTY),
         (lseq.EMPTY.cons(3).cons(2).cons(1), lseq.EMPTY.cons(3).cons(2).cons(1)),
         (vec.v(1, 2, 3), lseq.EMPTY.cons(3).cons(2).cons(1)),
-        (llist.List.empty(), vec.Vector.empty()),
+        (llist.PersistentList.empty(), vec.PersistentVector.empty()),
         (llist.l(1, 2, 3), vec.v(1, 2, 3)),
-        (lseq.EMPTY, vec.Vector.empty()),
+        (lseq.EMPTY, vec.PersistentVector.empty()),
         (lseq.EMPTY.cons(3).cons(2).cons(1), vec.v(1, 2, 3)),
-        (llist.List.empty(), lseq.EMPTY),
+        (llist.PersistentList.empty(), lseq.EMPTY),
         (lseq.EMPTY.cons(3).cons(2).cons(1), llist.l(1, 2, 3)),
     ],
 )
@@ -422,18 +428,18 @@ def test_equals(v1, v2):
         (0, 0.00000032),
         (llist.l(1, 2, 3), llist.l(2, 3, 4)),
         (llist.l(1, 2, 3), vec.v(2, 3, 4)),
-        (lmap.Map.empty(), llist.List.empty()),
-        (lmap.Map.empty(), vec.Vector.empty()),
-        (lmap.Map.empty(), lseq.EMPTY),
+        (lmap.PersistentMap.empty(), llist.PersistentList.empty()),
+        (lmap.PersistentMap.empty(), vec.PersistentVector.empty()),
+        (lmap.PersistentMap.empty(), lseq.EMPTY),
         (lmap.map({1: "1", 2: "2", 3: "3"}), llist.l(1, 2, 3)),
         (lmap.map({1: "1", 2: "2", 3: "3"}), vec.v(1, 2, 3)),
         (lmap.map({1: "1", 2: "2", 3: "3"}), lseq.EMPTY.cons(3).cons(2).cons(1)),
-        (lset.Set.empty(), llist.List.empty()),
-        (lset.Set.empty(), lmap.Map.empty()),
-        (lset.Set.empty(), vec.Vector.empty()),
-        (lset.Set.empty(), lseq.EMPTY),
+        (lset.PersistentSet.empty(), llist.PersistentList.empty()),
+        (lset.PersistentSet.empty(), lmap.PersistentMap.empty()),
+        (lset.PersistentSet.empty(), vec.PersistentVector.empty()),
+        (lset.PersistentSet.empty(), lseq.EMPTY),
         (lset.s(1, 2, 3), llist.l(1, 2, 3)),
-        (lset.s(1, 2, 3), lmap.Map.empty()),
+        (lset.s(1, 2, 3), lmap.PersistentMap.empty()),
         (lset.s(1, 2, 3), vec.v(1, 2, 3)),
         (lset.s(1, 2, 3), lseq.EMPTY.cons(3).cons(2).cons(1)),
     ],
@@ -460,27 +466,27 @@ class TestToPython:
         assert "kw" == runtime.to_py(kw.keyword("kw", ns="kw"))
 
     def test_to_dict(self):
-        assert {} == runtime.to_py(lmap.Map.empty())
+        assert {} == runtime.to_py(lmap.PersistentMap.empty())
         assert {"a": 2} == runtime.to_py(lmap.map({"a": 2}))
         assert {"a": 2, "b": "string"} == runtime.to_py(
             lmap.map({"a": 2, kw.keyword("b"): "string"})
         )
 
     def test_to_list(self):
-        assert [] == runtime.to_py(llist.List.empty())
+        assert [] == runtime.to_py(llist.PersistentList.empty())
         assert ["a", 2] == runtime.to_py(llist.l("a", 2))
         assert ["a", 2, None] == runtime.to_py(llist.l("a", 2, None))
 
-        assert [] == runtime.to_py(vec.Vector.empty())
+        assert [] == runtime.to_py(vec.PersistentVector.empty())
         assert ["a", 2] == runtime.to_py(vec.v("a", 2))
         assert ["a", 2, None] == runtime.to_py(vec.v("a", 2, None))
 
-        assert None is runtime.to_py(runtime.to_seq(vec.Vector.empty()))
+        assert None is runtime.to_py(runtime.to_seq(vec.PersistentVector.empty()))
         assert ["a", 2] == runtime.to_py(runtime.to_seq(vec.v("a", 2)))
         assert ["a", 2, None] == runtime.to_py(runtime.to_seq(vec.v("a", 2, None)))
 
     def test_to_set(self):
-        assert set() == runtime.to_py(lset.Set.empty())
+        assert set() == runtime.to_py(lset.PersistentSet.empty())
         assert {"a", 2} == runtime.to_py(lset.set({"a", 2}))
         assert {"a", 2, "b"} == runtime.to_py(lset.set({"a", 2, kw.keyword("b")}))
 
@@ -497,32 +503,34 @@ class TestToLisp:
         assert kw.keyword("kw", ns="ns") == runtime.to_lisp(kw.keyword("kw", ns="ns"))
 
     def test_to_map(self):
-        assert lmap.Map.empty() == runtime.to_lisp({})
+        assert lmap.PersistentMap.empty() == runtime.to_lisp({})
         assert lmap.map({kw.keyword("a"): 2}) == runtime.to_lisp({"a": 2})
         assert lmap.map(
             {kw.keyword("a"): 2, kw.keyword("b"): "string"}
         ) == runtime.to_lisp({"a": 2, "b": "string"})
 
     def test_to_map_no_keywordize(self):
-        assert lmap.Map.empty() == runtime.to_lisp({})
+        assert lmap.PersistentMap.empty() == runtime.to_lisp({})
         assert lmap.map({"a": 2}) == runtime.to_lisp({"a": 2}, keywordize_keys=False)
         assert lmap.map({"a": 2, "b": "string"}) == runtime.to_lisp(
             {"a": 2, "b": "string"}, keywordize_keys=False
         )
 
     def test_to_set(self):
-        assert lset.Set.empty() == runtime.to_lisp(set())
+        assert lset.PersistentSet.empty() == runtime.to_lisp(set())
         assert lset.set({"a", 2}) == runtime.to_lisp({"a", 2})
         assert lset.set({"a", 2, kw.keyword("b")}) == runtime.to_lisp(
             {"a", 2, kw.keyword("b")}
         )
 
     def test_to_vec(self):
-        assert vec.Vector.empty() == runtime.to_lisp([])
+        assert vec.PersistentVector.empty() == runtime.to_lisp([])
         assert vec.v("a", 2) == runtime.to_lisp(["a", 2])
         assert vec.v("a", 2, None) == runtime.to_lisp(["a", 2, None])
 
-        assert vec.Vector.empty() == runtime.to_lisp(vec.Vector.empty())
+        assert vec.PersistentVector.empty() == runtime.to_lisp(
+            vec.PersistentVector.empty()
+        )
         assert vec.v("a", 2) == runtime.to_lisp(("a", 2))
         assert vec.v("a", 2, None) == runtime.to_lisp(("a", 2, None))
 
@@ -554,13 +562,13 @@ def test_is_special_form(form: sym.Symbol):
 
 class TestResolveAlias:
     @pytest.fixture
-    def compiler_special_forms(self) -> lset.Set:
+    def compiler_special_forms(self) -> lset.PersistentSet:
         return lset.set(
             [v for k, v in SpecialForm.__dict__.items() if isinstance(v, sym.Symbol)]
         )
 
     def test_runtime_and_compiler_special_forms_in_sync(
-        self, compiler_special_forms: lset.Set
+        self, compiler_special_forms: lset.PersistentSet
     ):
         assert compiler_special_forms == runtime._SPECIAL_FORMS
 

--- a/tests/basilisp/seq_test.py
+++ b/tests/basilisp/seq_test.py
@@ -101,7 +101,7 @@ def test_sequence():
 
 def test_seq_iterator():
     s = lseq.sequence([])
-    assert vec.Vector.empty() == vec.vector(s)
+    assert vec.PersistentVector.empty() == vec.vector(s)
 
     s = lseq.sequence(range(10000))
     assert 10000 == len(vec.vector(s))

--- a/tests/basilisp/set_test.py
+++ b/tests/basilisp/set_test.py
@@ -31,7 +31,7 @@ from basilisp.lang.symbol import symbol
 )
 def test_set_interface_membership(interface):
     assert isinstance(lset.s(), interface)
-    assert issubclass(lset.Set, interface)
+    assert issubclass(lset.PersistentSet, interface)
 
 
 def test_set_as_function():
@@ -43,7 +43,7 @@ def test_set_as_function():
 
 
 def test_set_bool():
-    assert True is bool(lset.Set.empty())
+    assert True is bool(lset.PersistentSet.empty())
 
 
 def test_set_conj():
@@ -94,7 +94,7 @@ def test_set_with_meta():
         lset.s(keyword("kw1"), lset.s("string", 4)),
     ],
 )
-def test_set_pickleability(pickle_protocol: int, o: lset.Set):
+def test_set_pickleability(pickle_protocol: int, o: lset.PersistentSet):
     assert o == pickle.loads(pickle.dumps(o, protocol=pickle_protocol))
 
 
@@ -106,5 +106,5 @@ def test_set_pickleability(pickle_protocol: int, o: lset.Set):
         (lset.s(keyword("kw1"), keyword("kw2")), {"#{:kw1 :kw2}", "#{:kw2 :kw1}"}),
     ],
 )
-def test_set_repr(l: lset.Set, str_repr: typing.Set[str]):
+def test_set_repr(l: lset.PersistentSet, str_repr: typing.Set[str]):
     assert repr(l) in str_repr

--- a/tests/basilisp/vector_test.py
+++ b/tests/basilisp/vector_test.py
@@ -39,17 +39,17 @@ from basilisp.lang.symbol import symbol
 )
 def test_vector_interface_membership(interface):
     assert isinstance(vec.v(), interface)
-    assert issubclass(vec.Vector, interface)
+    assert issubclass(vec.PersistentVector, interface)
 
 
 def test_vector_slice():
-    assert isinstance(vec.v(1, 2, 3)[1:], vec.Vector)
+    assert isinstance(vec.v(1, 2, 3)[1:], vec.PersistentVector)
 
 
 def test_assoc():
-    v = vec.Vector.empty()
+    v = vec.PersistentVector.empty()
     assert vec.v("a") == v.assoc(0, "a")
-    assert vec.Vector.empty() == v
+    assert vec.PersistentVector.empty() == v
     assert vec.vector(["a", "b"]) == v.assoc(0, "a", 1, "b")
 
     v1 = vec.v("a")
@@ -58,7 +58,7 @@ def test_assoc():
 
 
 def test_vector_bool():
-    assert True is bool(vec.Vector.empty())
+    assert True is bool(vec.PersistentVector.empty())
 
 
 def test_contains():
@@ -66,16 +66,16 @@ def test_contains():
     assert True is vec.v("a", "b").contains(1)
     assert False is vec.v("a", "b").contains(2)
     assert False is vec.v("a", "b").contains(-1)
-    assert False is vec.Vector.empty().contains(0)
-    assert False is vec.Vector.empty().contains(1)
-    assert False is vec.Vector.empty().contains(-1)
+    assert False is vec.PersistentVector.empty().contains(0)
+    assert False is vec.PersistentVector.empty().contains(1)
+    assert False is vec.PersistentVector.empty().contains(-1)
 
 
 def test_py_contains():
     assert "a" in vec.v("a")
     assert "a" in vec.v("a", "b")
     assert "b" in vec.v("a", "b")
-    assert "c" not in vec.Vector.empty()
+    assert "c" not in vec.PersistentVector.empty()
     assert "c" not in vec.v("a")
     assert "c" not in vec.v("a", "b")
 
@@ -96,9 +96,9 @@ def test_entry():
     assert vec.MapEntry.of(1, "b") == vec.v("a", "b").entry(1)
     assert None is vec.v("a", "b").entry(2)
     assert vec.MapEntry.of(-1, "b") == vec.v("a", "b").entry(-1)
-    assert None is vec.Vector.empty().entry(0)
-    assert None is vec.Vector.empty().entry(1)
-    assert None is vec.Vector.empty().entry(-1)
+    assert None is vec.PersistentVector.empty().entry(0)
+    assert None is vec.PersistentVector.empty().entry(1)
+    assert None is vec.PersistentVector.empty().entry(-1)
 
 
 def test_val_at():
@@ -106,9 +106,9 @@ def test_val_at():
     assert "b" == vec.v("a", "b").val_at(1)
     assert None is vec.v("a", "b").val_at(2)
     assert "b" == vec.v("a", "b").val_at(-1)
-    assert None is vec.Vector.empty().val_at(0)
-    assert None is vec.Vector.empty().val_at(1)
-    assert None is vec.Vector.empty().val_at(-1)
+    assert None is vec.PersistentVector.empty().val_at(0)
+    assert None is vec.PersistentVector.empty().val_at(1)
+    assert None is vec.PersistentVector.empty().val_at(-1)
 
 
 def test_peek():
@@ -123,7 +123,7 @@ def test_pop():
     with pytest.raises(IndexError):
         vec.v().pop()
 
-    assert vec.Vector.empty() == vec.v(1).pop()
+    assert vec.PersistentVector.empty() == vec.v(1).pop()
     assert vec.v(1) == vec.v(1, 2).pop()
     assert vec.v(1, 2) == vec.v(1, 2, 3).pop()
 
@@ -165,7 +165,7 @@ def test_vector_with_meta():
         vec.v(keyword("kw1"), vec.v("string", 4)),
     ],
 )
-def test_vector_pickleability(pickle_protocol: int, o: vec.Vector):
+def test_vector_pickleability(pickle_protocol: int, o: vec.PersistentVector):
     assert o == pickle.loads(pickle.dumps(o, protocol=pickle_protocol))
 
 
@@ -177,5 +177,5 @@ def test_vector_pickleability(pickle_protocol: int, o: vec.Vector):
         (vec.v(keyword("kw1"), keyword("kw2")), "[:kw1 :kw2]"),
     ],
 )
-def test_vector_repr(l: vec.Vector, str_repr: str):
+def test_vector_repr(l: vec.PersistentVector, str_repr: str):
     assert repr(l) == str_repr


### PR DESCRIPTION
Some small changes:

 * Refactor the Analyzer and Generator to use `functools.singledispatch` for some type based dispatch rather than a tree of `if isinstance(...)` branches.
 * Rename `List`, `Map`, `Set`, and `Vector` to `PersistentList`, `PersistentMap`, `PersistentSet`, and `PersistentVector` respectively.