### PR TITLE
Fix the `with` macro to match the Python language spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Fixed the `with` macro definition to match the Python language spec (#656)
 
 ## [v0.1.0a1]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3642,20 +3642,23 @@
   [bindings & body]
   (let [binding (first bindings)
         expr    (second bindings)]
-    `(let [obj#     ~expr
-           ~binding (. obj# ~'__enter__)]
+    `(let [obj#        ~expr
+           ~binding    (. obj# ~'__enter__)
+           hit-except# (volatile! false)]
        (try
          (let [res# ~@(if (nthnext bindings 2)
                         [(concat
                           (list 'with (vec (nthrest bindings 2)))
                           body)]
                         body)]
-           (. ~binding (~'__exit__ nil nil nil))
            res#)
          (catch python/Exception e#
-           (if (. ~binding (~'__exit__ (python/type e#) e# (. e# ~'__traceback__)))
-             nil
-             (throw e#)))))))
+           (vreset! hit-except# true)
+           (when-not (. obj# (~'__exit__ (python/type e#) e# (. e# ~'__traceback__)))
+             (throw e#)))
+         (finally
+           (when-not @hit-except#
+             (. obj# (~'__exit__ nil nil nil))))))))
 
 (def ^{:doc   "Evaluate body within a try/except expression, binding the named expressions
                as per Python's context manager protocol spec (Python's with blocks)."


### PR DESCRIPTION
Fixes #655 