### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,12 @@ commands:
   setup_cpython_tests:
     description: "Check out code, install Tox, and prepare the test environment."
     parameters:
-      python_version:
-        description: "Required. Python version as `major.minor`."
-        type: string
       cache_key_prefix:
         description: "Required. Prefix used for the CircleCI cache key."
         type: string
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      # Fetch the site-packages location with the following command:
-      #   docker run -it cimg/python:3.6 python -m site --user-site
-      # - run: sudo chown -R circleci:circleci /home/circleci/.local/lib/python<< parameters.python_version >>/site-packages
       - restore_cache:
           key: << parameters.cache_key_prefix >>2-{{ checksum "tox.ini" }}-{{ checksum "pyproject.toml" }}
       - run:
@@ -28,9 +22,6 @@ commands:
   teardown_cpython_tests:
     description: "Store the cache for the current run."
     parameters:
-      python_version:
-        description: "Required. Python version as `major.minor`."
-        type: string
       cache_key_prefix:
         description: "Required. Prefix used for the CircleCI cache key."
         type: string
@@ -40,7 +31,6 @@ commands:
           paths:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
-            - "/home/circleci/.local/lib/python<< parameters.python_version >>/site-packages"
 
   run_cpython_tests:
     description: "Install Tox and run tests."
@@ -57,7 +47,6 @@ commands:
         default: 2
     steps:
       - setup_cpython_tests:
-          python_version: << parameters.python_version >>
           cache_key_prefix: py<< parameters.python_version >>-deps
       - run:
           name: Run Tests
@@ -70,7 +59,6 @@ commands:
             mkdir coverage
             mv .coverage.* "coverage/.coverage.py<< parameters.python_version >>"
       - teardown_cpython_tests:
-          python_version: << parameters.python_version >>
           cache_key_prefix: py<< parameters.python_version >>-deps
       - store_artifacts:
           path: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 commands:
-  setup_tests:
+  setup_cpython_tests:
     description: "Check out code, install Tox, and prepare the test environment."
     parameters:
       python_version:
@@ -13,18 +13,19 @@ commands:
     steps:
       - checkout
       - run: sudo chown -R circleci:circleci /usr/local/bin
-      - run: sudo chown -R circleci:circleci /usr/local/lib/python<< parameters.python_version >>/site-packages
+      # Fetch the site-packages location with the following command:
+      #   docker run -it cimg/python:3.6 python -m site --user-site
+      - run: sudo chown -R circleci:circleci /home/circleci/.local/lib/python<< parameters.python_version >>/site-packages
       - restore_cache:
           key: << parameters.cache_key_prefix >>2-{{ checksum "tox.ini" }}-{{ checksum "pyproject.toml" }}
       - run:
-          name: Install Poetry and Tox
+          name: Install Tox
           shell: /bin/bash -leo pipefail
           command: |
             pip install -U pip
             pip install tox
-            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
 
-  teardown_tests:
+  teardown_cpython_tests:
     description: "Store the cache for the current run."
     parameters:
       python_version:
@@ -39,7 +40,7 @@ commands:
           paths:
             - "/home/circleci/project/.tox"
             - "/usr/local/bin"
-            - "/usr/local/lib/python<< parameters.python_version >>/site-packages"
+            - "/home/circleci/.local/lib/python<< parameters.python_version >>/site-packages"
 
   run_cpython_tests:
     description: "Install Tox and run tests."
@@ -55,7 +56,7 @@ commands:
         type: integer
         default: 2
     steps:
-      - setup_tests:
+      - setup_cpython_tests:
           python_version: << parameters.python_version >>
           cache_key_prefix: py<< parameters.python_version >>-deps
       - run:
@@ -68,7 +69,7 @@ commands:
             tox -p << parameters.tox_parallel >> -e << parameters.tox_envs >>
             mkdir coverage
             mv .coverage.* "coverage/.coverage.py<< parameters.python_version >>"
-      - teardown_tests:
+      - teardown_cpython_tests:
           python_version: << parameters.python_version >>
           cache_key_prefix: py<< parameters.python_version >>-deps
       - store_artifacts:
@@ -156,7 +157,7 @@ jobs:
     docker:
       - image: circleci/python:3.10-buster
     steps:
-      - setup_tests:
+      - setup_cpython_tests:
           python_version: "3.10"
           cache_key_prefix: report-coverage-deps
       - run:
@@ -181,7 +182,7 @@ jobs:
               fi
             done
             tox -v -e coverage
-      - teardown_tests:
+      - teardown_cpython_tests:
           python_version: "3.8"
           cache_key_prefix: report-coverage-deps
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,13 +188,16 @@ jobs:
       - run_pypy_tests:
           python_version: "3.7"
 
-  test-pypy-38:
-    docker:
-      - image: pypy:3.8-slim-buster
-    parallelism: 8
-    steps:
-      - run_pypy_tests:
-          python_version: "3.8"
+# This will not work until the following Poetry bug is fixed:
+#   https://github.com/python-poetry/poetry/issues/4655
+#
+#  test-pypy-38:
+#    docker:
+#      - image: pypy:3.8-slim-buster
+#    parallelism: 8
+#    steps:
+#      - run_pypy_tests:
+#          python_version: "3.8"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,6 @@ jobs:
       - image: circleci/python:3.10-buster
     steps:
       - setup_cpython_tests:
-          python_version: "3.10"
           cache_key_prefix: report-coverage-deps
       - run:
           name: Report Coverage
@@ -171,7 +170,6 @@ jobs:
             done
             tox -v -e coverage
       - teardown_cpython_tests:
-          python_version: "3.8"
           cache_key_prefix: report-coverage-deps
 
   test-pypy-36:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       # Fetch the site-packages location with the following command:
       #   docker run -it cimg/python:3.6 python -m site --user-site
-      - run: sudo chown -R circleci:circleci /home/circleci/.local/lib/python<< parameters.python_version >>/site-packages
+      # - run: sudo chown -R circleci:circleci /home/circleci/.local/lib/python<< parameters.python_version >>/site-packages
       - restore_cache:
           key: << parameters.cache_key_prefix >>2-{{ checksum "tox.ini" }}-{{ checksum "pyproject.toml" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
 jobs:
   test-cpython-36:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
     steps:
       - run_cpython_tests:
           python_version: "3.6"
@@ -122,7 +122,7 @@ jobs:
 
   test-cpython-37:
     docker:
-      - image: circleci/python:3.7-buster
+      - image: cimg/python:3.7
     steps:
       - run_cpython_tests:
           python_version: "3.7"
@@ -130,7 +130,7 @@ jobs:
 
   test-cpython-38:
     docker:
-      - image: circleci/python:3.8-buster
+      - image: cimg/python:3.8
     steps:
       - run_cpython_tests:
           python_version: "3.8"
@@ -138,18 +138,26 @@ jobs:
 
   test-cpython-39:
     docker:
-      - image: circleci/python:3.9-buster
+      - image: cimg/python:3.9
     steps:
       - run_cpython_tests:
           python_version: "3.9"
           tox_envs: py39,py39-mypy,py39-lint,format,safety
 
+  test-cpython-310:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - run_cpython_tests:
+          python_version: "3.10"
+          tox_envs: py310,py310-mypy,py310-lint,format,safety
+
   report-coverage:
     docker:
-      - image: circleci/python:3.9-buster
+      - image: circleci/python:3.10-buster
     steps:
       - setup_tests:
-          python_version: "3.9"
+          python_version: "3.10"
           cache_key_prefix: report-coverage-deps
       - run:
           name: Report Coverage
@@ -193,6 +201,14 @@ jobs:
       - run_pypy_tests:
           python_version: "3.7"
 
+  test-pypy-38:
+    docker:
+      - image: pypy:3.8-slim-buster
+    parallelism: 8
+    steps:
+      - run_pypy_tests:
+          python_version: "3.8"
+
 workflows:
   version: 2
   test:
@@ -201,11 +217,14 @@ workflows:
       - test-cpython-37
       - test-cpython-38
       - test-cpython-39
+      - test-cpython-310
       - test-pypy-36
       - test-pypy-37
+      - test-pypy-38
       - report-coverage:
           requires:
             - test-cpython-36
             - test-cpython-37
             - test-cpython-38
             - test-cpython-39
+            - test-cpython-310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ workflows:
       - test-cpython-310
       - test-pypy-36
       - test-pypy-37
-      - test-pypy-38
+      # - test-pypy-38
       - report-coverage:
           requires:
             - test-cpython-36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added support for fixtures in `basilisp.test` (#654)
- * Added support for Python 3.10 (#???)
+ * Added support for Python 3.10 (#659)
 
 ### Changed
  * Set tighter bounds on dependency version ranges (#657)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added support for fixtures in `basilisp.test` (#654)
+ * Added support for Python 3.10 (#???)
 
 ### Changed
  * Set tighter bounds on dependency version ranges (#657)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ pytest = { version = ">=6.2.4", optional = true }
 pygments = { version = "^2.9.0", optional = true }
 
 [tool.poetry.dev-dependencies]
-black = "*"
+black = [
+    {version = "==20.8b1", python = ">=3.6.0,<3.6.2"},
+    {version = "^21.12b0", python = "^3.6.2"}
+]
 docutils = "==0.15"
 isort = "*"
 pygments = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Compilers",

--- a/src/basilisp/_pyast.py
+++ b/src/basilisp/_pyast.py
@@ -144,7 +144,6 @@ if sys.version_info >= (3, 8):
             kwargs["posonlyargs"] = []
             super().__init__(*args, **kwargs)
 
-
 else:
     Module = _Module
     arguments = _arguments

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -281,20 +281,20 @@ def repl(
                 if result is eof:  # pragma: no cover
                     continue
                 prompter.print(runtime.lrepr(result))
-                repl_module.mark_repl_result(result)  # type: ignore
+                repl_module.mark_repl_result(result)
             except reader.SyntaxError as e:
                 traceback.print_exception(reader.SyntaxError, e, e.__traceback__)
-                repl_module.mark_exception(e)  # type: ignore
+                repl_module.mark_exception(e)
                 continue
             except compiler.CompilerException as e:
                 traceback.print_exception(
                     compiler.CompilerException, e, e.__traceback__
                 )
-                repl_module.mark_exception(e)  # type: ignore
+                repl_module.mark_exception(e)
                 continue
             except Exception as e:
                 traceback.print_exception(Exception, e, e.__traceback__)
-                repl_module.mark_exception(e)  # type: ignore
+                repl_module.mark_exception(e)
                 continue
 
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1436,10 +1436,10 @@ def _wrap_override_var_indirection(f: PyASTGenerator) -> PyASTGenerator:
     ) -> GeneratedPyAST:
         if isinstance(node, Do) and node.top_level:
             with ctx.with_var_indirection_override():
-                return f(ctx, node, *args, **kwargs)  # type: ignore[call-arg]
+                return f(ctx, node, *args, **kwargs)
         else:
             with ctx.with_var_indirection_override(False):
-                return f(ctx, node, *args, **kwargs)  # type: ignore[call-arg]
+                return f(ctx, node, *args, **kwargs)
 
     return _wrapped_do
 
@@ -3238,7 +3238,7 @@ def _with_meta_to_py_ast(
 
 
 @functools.singledispatch
-def _const_val_to_py_ast(form: LispForm, _: GeneratorContext) -> GeneratedPyAST:
+def _const_val_to_py_ast(form: object, _: GeneratorContext) -> GeneratedPyAST:
     """Generate Python AST nodes for constant Lisp forms.
 
     Nested values in collections for :const nodes are not analyzed, so recursive
@@ -3472,7 +3472,7 @@ def _const_record_to_py_ast(form: IRecord, ctx: GeneratorContext) -> GeneratedPy
         key_nodes = _kw_to_py_ast(k, ctx)
         keys.append(key_nodes.node)
         assert (
-            len(key_nodes.dependencies) == 0  # type: ignore[arg-type]
+            len(key_nodes.dependencies) == 0
         ), "Simple AST generators must emit no dependencies"
 
         val_nodes = _const_val_to_py_ast(v, ctx)

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -167,7 +167,7 @@ class StreamReader:
             self._update_loc(c)
 
     @property
-    def name(self) -> Optional[None]:
+    def name(self) -> Optional[str]:
         return getattr(self._stream, "name", None)
 
     @property
@@ -226,14 +226,7 @@ class StreamReader:
 
 
 @functools.singledispatch
-def _py_from_lisp(
-    form: Union[
-        llist.PersistentList,
-        lmap.PersistentMap,
-        lset.PersistentSet,
-        vec.PersistentVector,
-    ]
-) -> ReaderForm:
+def _py_from_lisp(form: object) -> ReaderForm:
     raise SyntaxError(f"Unrecognized Python type: {type(form)}")
 
 
@@ -479,7 +472,7 @@ def _with_loc(f: W) -> W:
     @functools.wraps(f)
     def with_lineno_and_col(ctx, **kwargs):
         line, col = ctx.reader.line, ctx.reader.col
-        v = f(ctx, **kwargs)  # type: ignore[call-arg]
+        v = f(ctx, **kwargs)
         if isinstance(v, IWithMeta):
             new_meta = lmap.map({READER_LINE_KW: line, READER_COL_KW: col})
             old_meta = v.meta

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -70,7 +70,7 @@ NS_VAR_NAME = "*ns*"
 NS_VAR_SYM = sym.symbol(NS_VAR_NAME, ns=CORE_NS)
 NS_VAR_NS = CORE_NS
 REPL_DEFAULT_NS = "basilisp.user"
-SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 6), (3, 7), (3, 8), (3, 9)})
+SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)})
 
 # Public basilisp.core symbol names
 COMPILER_OPTIONS_VAR_NAME = "*compiler-options*"

--- a/src/basilisp/prompt.py
+++ b/src/basilisp/prompt.py
@@ -155,7 +155,9 @@ else:
 
         def print(self, msg: str) -> None:
             tokens = list(pygments.lex(msg, lexer=self._pygments_lexer))
-            print_formatted_text(PygmentsTokens(tokens), **self._style_settings)
+            print_formatted_text(
+                PygmentsTokens(tokens), **self._style_settings  # type: ignore[arg-type]
+            )
 
     _DEFAULT_PROMPTER = StyledPromptToolkitPrompter
 

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -39,6 +39,7 @@ def test_is_supported_python_version():
                     "lpy37-",
                     "lpy38-",
                     "lpy39-",
+                    "lpy310-",
                 ],
             )
         ),
@@ -54,6 +55,7 @@ def test_is_supported_python_version():
                     "lpy36+",
                     "lpy38-",
                     "lpy39-",
+                    "lpy310-",
                 ],
             )
         ),
@@ -69,6 +71,7 @@ def test_is_supported_python_version():
                     "lpy37+",
                     "lpy36+",
                     "lpy39-",
+                    "lpy310-",
                 ],
             )
         ),
@@ -80,6 +83,23 @@ def test_is_supported_python_version():
                     "default",
                     "lpy",
                     "lpy39-",
+                    "lpy39+",
+                    "lpy38+",
+                    "lpy37+",
+                    "lpy36+",
+                    "lpy310-",
+                ],
+            )
+        ),
+        (3, 10): frozenset(
+            map(
+                kw.keyword,
+                [
+                    "lpy310",
+                    "default",
+                    "lpy",
+                    "lpy310+",
+                    "lpy310-",
                     "lpy39+",
                     "lpy38+",
                     "lpy37+",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py36,py37,py38,py39,pypy3,coverage,py{36,37,38,39}-mypy,py{36,37,38,39}-lint,format,safety
+envlist = py36,py37,py38,py39,py310,pypy3,coverage,py{36,37,38,39,310}-mypy,py{36,37,38,39,310}-lint,format,safety
 
 [testenv]
 whitelist_externals = poetry
@@ -40,14 +40,14 @@ commands =
     isort --check --profile black .
     black --check .
 
-[testenv:py{36,37,38,39}-mypy]
+[testenv:py{36,37,38,39,310}-mypy]
 deps =
     mypy
     types-python-dateutil
 commands =
     mypy --config-file={toxinidir}/pyproject.toml --show-error-codes src/basilisp
 
-[testenv:py{36,37,38,39}-lint]
+[testenv:py{36,37,38,39,310}-lint]
 deps =
     prospector==1.3.1
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 
 [testenv:format]
 deps =
-    black
+    black==21.12b0
     isort
 commands =
     isort --check --profile black .

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
              {posargs}
 
 [testenv:coverage]
-depends = py36, py37, py38, py39
+depends = py36, py37, py38, py39, py310
 deps =
     coveralls
     coverage[toml]


### PR DESCRIPTION
Add formal support for Python 3.10 and fix a few other issues:
 * Minor typing issues from updating MyPy
 * Minor formatting issues from updating Black. Support for Black is limited to versions 20.8b1 and older for Python 3.6.0 and 3.6.1 due to those versions not including the `NoReturn` annotation. Basilisp does not use that annotation though, so it should be fine to allow earlier versions of Python for now. We may eventually drop Python 3.6 support anyway, but there's no strong reason to do so right now.
 * Update CircleCI Docker images to use the new `cimg` based images provided by Circle. This simplified some of our build steps, which is nice.