### PR TITLE
Delete generated utility functions from REPL namespace after execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Set tighter bounds on dependency version ranges (#657)
  * Improved on and completed several different sections of the documentation (#661, #669)
+ * Delete unused utility functions after they are generated and executed by the REPL to save memory (#674) 
 
 ### Fixed
  * Fixed the `with` macro definition to match the Python language spec (#656)

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -155,9 +155,10 @@ def compile_and_exec_form(  # pylint: disable= too-many-arguments
     if collect_bytecode:
         collect_bytecode(bytecode)
     exec(bytecode, ns.module.__dict__)
-    ret = getattr(ns.module, final_wrapped_name)()
-    del ns.module.__dict__[final_wrapped_name]
-    return ret
+    try:
+        return getattr(ns.module, final_wrapped_name)()
+    finally:
+        del ns.module.__dict__[final_wrapped_name]
 
 
 def _incremental_compile_module(

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -155,7 +155,9 @@ def compile_and_exec_form(  # pylint: disable= too-many-arguments
     if collect_bytecode:
         collect_bytecode(bytecode)
     exec(bytecode, ns.module.__dict__)
-    return getattr(ns.module, final_wrapped_name)()
+    ret = getattr(ns.module, final_wrapped_name)()
+    del ns.module.__dict__[final_wrapped_name]
+    return ret
 
 
 def _incremental_compile_module(


### PR DESCRIPTION
Fixes #675 

In order to fetch the expression from an expression, the Basilisp REPL generates a simple function in the current REPL module which returns the expression. Afterwards, the function definition hangs around indefinitely even though the function will never be used or called again. This PR adds code to simply `del` that function from the module so it doesn't hang around eating up memory.