### PR TITLE
py->lisp recursively creates lisp objects in maps now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fixed the `with` macro definition to match the Python language spec (#656)
+ * Fixed a bug where `py->lisp` did not convert map keys or values into Basilisp objects (#679)
 
 ## [v0.1.0a1]
 ### Added

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -586,12 +586,59 @@ class TestToLisp:
         assert lmap.map(
             {kw.keyword("a"): 2, kw.keyword("b"): "string"}
         ) == runtime.to_lisp({"a": 2, "b": "string"})
+        assert lmap.map(
+            {
+                kw.keyword("a"): 2,
+                kw.keyword("b"): lmap.map(
+                    {
+                        kw.keyword("c"): "string",
+                        kw.keyword("d"): vec.v("list"),
+                        kw.keyword("e"): lset.s("a", "set"),
+                        kw.keyword("f"): vec.v("tuple", "not", "list"),
+                    }
+                ),
+            }
+        ) == runtime.to_lisp(
+            {
+                "a": 2,
+                "b": {
+                    "c": "string",
+                    "d": ["list"],
+                    "e": {"a", "set"},
+                    kw.keyword("f"): ("tuple", "not", "list"),
+                },
+            }
+        )
 
     def test_to_map_no_keywordize(self):
         assert lmap.PersistentMap.empty() == runtime.to_lisp({})
         assert lmap.map({"a": 2}) == runtime.to_lisp({"a": 2}, keywordize_keys=False)
         assert lmap.map({"a": 2, "b": "string"}) == runtime.to_lisp(
             {"a": 2, "b": "string"}, keywordize_keys=False
+        )
+        assert lmap.map(
+            {
+                "a": 2,
+                "b": lmap.map(
+                    {
+                        "c": "string",
+                        "d": vec.v("list"),
+                        "e": lset.s("a", "set"),
+                        kw.keyword("f"): vec.v("tuple", "not", "list"),
+                    }
+                ),
+            }
+        ) == runtime.to_lisp(
+            {
+                "a": 2,
+                "b": {
+                    "c": "string",
+                    "d": ["list"],
+                    "e": {"a", "set"},
+                    kw.keyword("f"): ("tuple", "not", "list"),
+                },
+            },
+            keywordize_keys=False,
         )
 
     def test_to_set(self):


### PR DESCRIPTION
Fixes #678 