### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,12 +8,14 @@ concurrency:
 
 jobs:
   run-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        version: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        os: [ubuntu-latest]
+        version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         include:
-          - version: '3.6'
+          - os: ubuntu-20.04
+            version: '3.6'
             tox-env: py36,py36-mypy,py36-lint,safety
           - version: '3.7'
             tox-env: py37,py37-mypy,py37-lint,safety
@@ -22,8 +24,10 @@ jobs:
           - version: '3.9'
             tox-env: py39,py39-mypy,py39-lint,safety
           - version: '3.10'
-            tox-env: py310,py310-mypy,py310-lint,format,safety
-    steps:
+            tox-env: py310,py310-mypy,py310-lint,safety
+          - version: '3.11'
+            tox-env: py311,py311-mypy,py311-lint,format,safety
+steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,13 +10,14 @@ jobs:
   run-tests:
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         include:
           - os: ubuntu-20.04
             version: '3.6'
-            tox-env: py36,py36-mypy,py36-lint,safety
+            tox-env: py36,py36-mypy
           - version: '3.7'
             tox-env: py37,py37-mypy,py37-lint,safety
           - version: '3.8'
@@ -27,7 +28,7 @@ jobs:
             tox-env: py310,py310-mypy,py310-lint,safety
           - version: '3.11'
             tox-env: py311,py311-mypy,py311-lint,format,safety
-steps:
+    steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
@@ -43,8 +44,9 @@ steps:
             ~/.local/share/pypoetry
           key: ${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
       - name: Install Poetry
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.1.15
       - name: Install Tox
         run: |
           pip install -U pip
@@ -71,7 +73,7 @@ steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v3
@@ -83,8 +85,9 @@ steps:
             ~/.local/share/pypoetry
           key: ${{ runner.os }}-python-coverage-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
       - name: Install Poetry
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: curl -sSL https://install.python-poetry.org | python3 -
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: 1.1.15
       - name: Install Tox
         run: |
           pip install -U pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,9 @@ readerwriterlock = "^1.0.8"
 pytest = { version = "^6.2.5", optional = true }
 pygments = { version = "^2.9.0", optional = true }
 
+
 [tool.poetry.dev-dependencies]
-black = [
-    {version = "==20.8b1", python = ">=3.6.0,<3.6.2"},
-    {version = "*", python = "^3.6.2"}
-]
+black = "^23.7.0"
 docutils = "*"
 isort = "*"
 pygments = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Compilers",

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -6,7 +6,7 @@ from typing import Callable, Iterable, Iterator, Optional, Tuple
 import py
 import pytest
 from _pytest.config import Config
-from _pytest.main import Session  # pylint: disable=unused-import
+from _pytest.main import Session
 
 from basilisp import main as basilisp
 from basilisp.lang import keyword as kw
@@ -102,8 +102,10 @@ class FixtureManager:
                 teardown = cls._run_fixture(fixture)
                 if teardown is not None:
                     teardown_fixtures.append(teardown)
-        except Exception:
-            raise runtime.RuntimeException("Exception occurred during fixture setup")
+        except Exception as exc:
+            raise runtime.RuntimeException(
+                "Exception occurred during fixture setup"
+            ) from exc
         else:
             return teardown_fixtures
 
@@ -115,10 +117,10 @@ class FixtureManager:
                 next(teardown)
             except StopIteration:
                 pass
-            except Exception:
+            except Exception as exc:
                 raise runtime.RuntimeException(
                     "Exception occurred during fixture teardown"
-                )
+                ) from exc
 
     def setup(self) -> None:
         """Setup fixtures and store any teardowns for cleanup later.
@@ -245,7 +247,7 @@ class BasilispTestItem(pytest.Item):
         filename: str,
         fixture_manager: FixtureManager,
     ) -> None:
-        super(BasilispTestItem, self).__init__(name, parent)
+        super().__init__(name, parent)
         self._run_test = run_test
         self._namespace = namespace
         self._filename = filename
@@ -288,7 +290,7 @@ class BasilispTestItem(pytest.Item):
         if runtime.to_seq(failures):
             raise TestFailuresInfo("Test failures", lmap.map(results))
 
-    def repr_failure(self, excinfo, style=None):  # pylint: disable=unused-argument
+    def repr_failure(self, excinfo, style=None):
         """Representation function called when self.runtest() raises an exception."""
         if isinstance(excinfo.value, TestFailuresInfo):
             exc = excinfo.value

--- a/src/basilisp/contrib/sphinx/domain.py
+++ b/src/basilisp/contrib/sphinx/domain.py
@@ -293,7 +293,7 @@ class BasilispNamespaceIndex(Index):
     localname = "Namespace Index"
     shortname = "namespaces"
 
-    def generate(  # pylint: disable=too-many-branches,too-many-locals
+    def generate(  # pylint: disable=too-many-locals
         self, docnames: Iterable[str] = None
     ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         content: Dict[str, List[IndexEntry]] = defaultdict(list)
@@ -369,7 +369,7 @@ class BasilispNamespaceIndex(Index):
 
 
 class BasilispXRefRole(XRefRole):
-    def process_link(  # pylint: disable=too-many-arguments,unused-argument
+    def process_link(  # pylint: disable=too-many-arguments
         self,
         env: BuildEnvironment,
         refnode: Element,
@@ -382,19 +382,19 @@ class BasilispXRefRole(XRefRole):
         return title, target
 
 
-class FormEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class FormEntry(NamedTuple):
     docname: str
     node_id: str
 
 
-class VarEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class VarEntry(NamedTuple):
     docname: str
     node_id: str
     objtype: str
     aliased: bool
 
 
-class NamespaceEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class NamespaceEntry(NamedTuple):
     docname: str
     node_id: str
     synopsis: str
@@ -515,7 +515,7 @@ class BasilispDomain(Domain):
             if ns_entry.docname in docnames:
                 self.namespaces[ns_name] = ns_entry
 
-    def resolve_xref(  # pylint: disable=too-many-arguments,too-many-locals,unused-argument
+    def resolve_xref(  # pylint: disable=too-many-arguments
         self,
         env: BuildEnvironment,
         fromdocname: str,

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -138,7 +138,8 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
     ) -> Optional[ModuleSpec]:
         """Find the ModuleSpec for the specified Basilisp module.
 
-        Returns None if the module is not a Basilisp module to allow import processing to continue."""
+        Returns None if the module is not a Basilisp module to allow import processing to continue.
+        """
         package_components = fullname.split(".")
         if not path:
             path = sys.path
@@ -193,9 +194,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         super().invalidate_caches()
         self._cache = {}
 
-    def _cache_bytecode(
-        self, source_path, cache_path, data
-    ):  # pylint: disable=unused-argument
+    def _cache_bytecode(self, source_path, cache_path, data):
         self.set_data(cache_path, data)
 
     def path_stats(self, path):
@@ -214,8 +213,8 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
     def get_filename(self, fullname: str) -> str:  # pragma: no cover
         try:
             cached = self._cache[fullname]
-        except KeyError:
-            raise ImportError(f"Could not import module '{fullname}'")
+        except KeyError as exc:
+            raise ImportError(f"Could not import module '{fullname}'") from exc
         spec = cached["spec"]
         return spec.loader_state.filename
 
@@ -288,7 +287,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
                 Iterable[ReaderForm],
                 reader.read_file(filename, resolver=runtime.resolve_alias),
             )
-            compiler.compile_module(  # pylint: disable=unexpected-keyword-arg
+            compiler.compile_module(
                 forms,
                 compiler.CompilerContext(
                     filename=filename, opts=runtime.get_compiler_opts()
@@ -348,6 +347,4 @@ def hook_imports():
     using standard `import module.submodule` syntax."""
     if any(isinstance(o, BasilispImporter) for o in sys.meta_path):
         return
-    sys.meta_path.insert(
-        0, BasilispImporter()  # pylint:disable=abstract-class-instantiated
-    )
+    sys.meta_path.insert(0, BasilispImporter())

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -119,7 +119,7 @@ def _emit_ast_string(
         runtime.add_generated_python(to_py_str(module), which_ns=ns)
 
 
-def compile_and_exec_form(  # pylint: disable= too-many-arguments
+def compile_and_exec_form(
     form: ReaderForm,
     ctx: CompilerContext,
     ns: runtime.Namespace,

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -652,8 +652,11 @@ def _loc(form: Union[LispForm, ISeq]) -> Optional[Tuple[int, int]]:
         if meta is not None:
             line = meta.get(reader.READER_LINE_KW)
             col = meta.get(reader.READER_COL_KW)
+            end_line = meta.get(reader.READER_END_LINE_KW)
+            end_col = meta.get(reader.READER_END_COL_KW)
+#            print(f':l {line} :c {col} :el {end_line} :ec {end_col}')
             if isinstance(line, int) and isinstance(col, int):
-                return line, col
+                return line, col, end_line, end_col
     return None
 
 
@@ -677,7 +680,8 @@ def _clean_meta(meta: Optional[lmap.PersistentMap]) -> Optional[lmap.PersistentM
     if meta is None:
         return None
     else:
-        new_meta = meta.dissoc(reader.READER_LINE_KW, reader.READER_COL_KW)
+        new_meta = meta.dissoc(reader.READER_LINE_KW, reader.READER_COL_KW,
+                               reader.READER_END_LINE_KW, reader.READER_END_COL_KW)
         return None if len(new_meta) == 0 else new_meta
 
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -472,7 +472,9 @@ def _kwargs_ast(
 def _clean_meta(form: IMeta) -> LispForm:
     """Remove reader metadata from the form's meta map."""
     assert form.meta is not None, "Form must have non-null 'meta' attribute"
-    meta = form.meta.dissoc(reader.READER_LINE_KW, reader.READER_COL_KW)
+    meta = form.meta.dissoc(reader.READER_LINE_KW, reader.READER_COL_KW,
+                            reader.READER_END_LINE_KW, reader.READER_END_COL_KW)
+#    print(f":meta {meta}")
     if len(meta) == 0:
         return None
     return cast(lmap.PersistentMap, meta)
@@ -485,17 +487,20 @@ def _ast_with_loc(
     if they exist in the node environment."""
     if env.line is not None:
         py_ast.node.lineno = env.line
-
+        py_ast.node.end_lineno = env.end_line
         if include_dependencies:
             for dep in py_ast.dependencies:
                 dep.lineno = env.line
+                dep.end_lineno = env.end_line
 
     if env.col is not None:
-        py_ast.node.col_offset = env.col
+        py_ast.node.col_offset = env.col-1
+        py_ast.node.end_col_offset = env.end_col-1
 
         if include_dependencies:
             for dep in py_ast.dependencies:
-                dep.col_offset = env.col
+                dep.col_offset = env.col-1
+                dep.end_col_offset = env.end_col-1
 
     return py_ast
 

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -140,7 +140,6 @@ class SymbolTableEntry:
     symbol: sym.Symbol
 
 
-# pylint: disable=unsupported-membership-test,unsupported-delete-operation,unsupported-assignment-operation
 @attr.s(auto_attribs=True, slots=True)
 class SymbolTable:
     name: str
@@ -472,9 +471,12 @@ def _kwargs_ast(
 def _clean_meta(form: IMeta) -> LispForm:
     """Remove reader metadata from the form's meta map."""
     assert form.meta is not None, "Form must have non-null 'meta' attribute"
-    meta = form.meta.dissoc(reader.READER_LINE_KW, reader.READER_COL_KW,
-                            reader.READER_END_LINE_KW, reader.READER_END_COL_KW)
-#    print(f":meta {meta}")
+    meta = form.meta.dissoc(
+        reader.READER_LINE_KW,
+        reader.READER_COL_KW,
+        reader.READER_END_LINE_KW,
+        reader.READER_END_COL_KW,
+    )
     if len(meta) == 0:
         return None
     return cast(lmap.PersistentMap, meta)
@@ -485,22 +487,22 @@ def _ast_with_loc(
 ) -> GeneratedPyAST:
     """Hydrate Generated Python AST nodes with line numbers and column offsets
     if they exist in the node environment."""
-    if env.line is not None:
+    if env.line is not None and env.end_line is not None:
         py_ast.node.lineno = env.line
-        py_ast.node.end_lineno = env.end_line
+        py_ast.node.end_lineno = env.end_line  # type: ignore[attr-defined]
         if include_dependencies:
             for dep in py_ast.dependencies:
                 dep.lineno = env.line
-                dep.end_lineno = env.end_line
+                dep.end_lineno = env.end_line  # type: ignore[attr-defined]
 
-    if env.col is not None:
-        py_ast.node.col_offset = env.col-1
-        py_ast.node.end_col_offset = env.end_col-1
+    if env.col is not None and env.end_col is not None:
+        py_ast.node.col_offset = env.col - 1
+        py_ast.node.end_col_offset = env.end_col - 1  # type: ignore[attr-defined]
 
         if include_dependencies:
             for dep in py_ast.dependencies:
-                dep.col_offset = env.col-1
-                dep.end_col_offset = env.end_col-1
+                dep.col_offset = env.col - 1
+                dep.end_col_offset = env.end_col - 1  # type: ignore[attr-defined]
 
     return py_ast
 
@@ -783,9 +785,7 @@ def __should_warn_on_redef(
 
 
 @_with_ast_loc
-def _def_to_py_ast(  # pylint: disable=too-many-branches
-    ctx: GeneratorContext, node: Def
-) -> GeneratedPyAST:
+def _def_to_py_ast(ctx: GeneratorContext, node: Def) -> GeneratedPyAST:
     """Return a Python AST Node for a `def` expression."""
     assert node.op == NodeOp.DEF
 
@@ -981,7 +981,7 @@ def __deftype_property_to_py_ast(
             )
 
 
-def __multi_arity_deftype_dispatch_method(  # pylint: disable=too-many-arguments,too-many-locals
+def __multi_arity_deftype_dispatch_method(
     name: str,
     arity_map: Mapping[int, str],
     default_name: Optional[str] = None,
@@ -1139,7 +1139,7 @@ def __multi_arity_deftype_dispatch_method(  # pylint: disable=too-many-arguments
 
 
 @_with_ast_loc_deps
-def __multi_arity_deftype_method_to_py_ast(  # pylint: disable=too-many-arguments,too-many-locals
+def __multi_arity_deftype_method_to_py_ast(
     ctx: GeneratorContext,
     node: DefTypeMethod,
 ) -> GeneratedPyAST:
@@ -1337,9 +1337,7 @@ def __deftype_or_reify_bases_to_py_ast(
 
 
 @_with_ast_loc
-def _deftype_to_py_ast(  # pylint: disable=too-many-branches,too-many-locals
-    ctx: GeneratorContext, node: DefType
-) -> GeneratedPyAST:
+def _deftype_to_py_ast(ctx: GeneratorContext, node: DefType) -> GeneratedPyAST:
     """Return a Python AST Node for a `deftype*` expression."""
     assert node.op == NodeOp.DEFTYPE
     type_name = munge(node.name)
@@ -2910,7 +2908,7 @@ def __var_find_to_py_ast(
 
 
 @_with_ast_loc
-def _var_sym_to_py_ast(  # pylint: disable=too-many-branches
+def _var_sym_to_py_ast(
     ctx: GeneratorContext, node: VarRef, is_assigning: bool = False
 ) -> GeneratedPyAST:
     """Generate a Python AST node for accessing a Var.
@@ -3264,7 +3262,7 @@ def _collection_literal_to_py_ast(
     yield from map(lambda form: _const_val_to_py_ast(form, ctx), form)
 
 
-def _const_meta_kwargs_ast(  # pylint:disable=inconsistent-return-statements
+def _const_meta_kwargs_ast(
     ctx: GeneratorContext, form: LispForm
 ) -> Optional[GeneratedPyAST]:
     if isinstance(form, IMeta) and form.meta is not None:

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -191,14 +191,19 @@ class Node(ABC, Generic[T]):
                 f(child, *args, **kwargs)
 
     def fix_missing_locations(
-        self, form_loc: Optional[Tuple[int, int]] = None
+        self, form_loc: Optional[Tuple[int, int, int, int]] = None
     ) -> "Node":
         """Return a transformed copy of this node with location in this node's
         environment updated to match the `form_loc` if given, or using its
         existing location otherwise. All child nodes will be recursively
         transformed and replaced. Child nodes will use their parent node
         location if they do not have one."""
-        if self.env.line is None or self.env.col is None:
+        if (
+            self.env.line is None
+            or self.env.col is None
+            or self.env.end_line is None
+            or self.env.end_col is None
+        ):
             loc = form_loc
         else:
             loc = (self.env.line, self.env.col, self.env.end_line, self.env.end_col)
@@ -208,7 +213,9 @@ class Node(ABC, Generic[T]):
         ), "Must specify location information"
 
         new_attrs: MutableMapping[str, Union[NodeEnv, Node, Iterable[Node]]] = {
-            "env": attr.evolve(self.env, line=loc[0], col=loc[1], end_line=loc[2], end_col=loc[3])
+            "env": attr.evolve(
+                self.env, line=loc[0], col=loc[1], end_line=loc[2], end_col=loc[3]
+            )
         }
         for child_kw in self.children:
             child_attr = munge(child_kw.name)

--- a/src/basilisp/lang/delay.py
+++ b/src/basilisp/lang/delay.py
@@ -25,9 +25,7 @@ class Delay(IDeref[T]):
     __slots__ = ("_state",)
 
     def __init__(self, f: Callable[[], T]) -> None:
-        self._state = atom.Atom(  # pylint:disable=assigning-non-slot
-            _DelayState(f=f, value=None, computed=False)
-        )
+        self._state = atom.Atom(_DelayState(f=f, value=None, computed=False))
 
     @staticmethod
     def __deref(state: _DelayState) -> _DelayState:

--- a/src/basilisp/lang/futures.py
+++ b/src/basilisp/lang/futures.py
@@ -1,4 +1,4 @@
-from concurrent.futures import Future as _Future  # noqa # pylint: disable=unused-import
+from concurrent.futures import Future as _Future  # noqa
 from concurrent.futures import ProcessPoolExecutor as _ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 from concurrent.futures import TimeoutError as _TimeoutError

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -32,7 +32,6 @@ class IDeref(Generic[T], ABC):
 class IBlockingDeref(IDeref[T]):
     __slots__ = ()
 
-    # pylint: disable=arguments-differ
     @abstractmethod
     def deref(
         self, timeout: Optional[float] = None, timeout_val: Optional[T] = None
@@ -197,14 +196,14 @@ class ILookup(Generic[K, V], ABC):
         raise NotImplementedError()
 
 
-T_pcoll = TypeVar("T_pcoll", bound="IPersistentCollection", covariant=True)
+T_pcoll_co = TypeVar("T_pcoll_co", bound="IPersistentCollection", covariant=True)
 
 
 class IPersistentCollection(ISeqable[T]):
     __slots__ = ()
 
     @abstractmethod
-    def cons(self: T_pcoll, *elems: T) -> "T_pcoll":
+    def cons(self: T_pcoll_co, *elems: T) -> "T_pcoll_co":
         raise NotImplementedError()
 
     @staticmethod
@@ -305,12 +304,13 @@ class IPersistentVector(
         raise NotImplementedError()
 
 
-T_tcoll = TypeVar("T_tcoll", bound="ITransientCollection", covariant=True)
+T_tcoll_co = TypeVar("T_tcoll_co", bound="ITransientCollection", covariant=True)
+
 
 # Including ABC as a base seems to cause catastrophic meltdown.
-class IEvolveableCollection(Generic[T_tcoll]):
+class IEvolveableCollection(Generic[T_tcoll_co]):
     @abstractmethod
-    def to_transient(self) -> T_tcoll:
+    def to_transient(self) -> T_tcoll_co:
         raise NotImplementedError()
 
 
@@ -318,11 +318,11 @@ class ITransientCollection(Generic[T]):
     __slots__ = ()
 
     @abstractmethod
-    def cons_transient(self: T_tcoll, *elems: T) -> "T_tcoll":
+    def cons_transient(self: T_tcoll_co, *elems: T) -> "T_tcoll_co":
         raise NotImplementedError()
 
     @abstractmethod
-    def to_persistent(self: T_tcoll) -> "IPersistentCollection[T]":
+    def to_persistent(self: T_tcoll_co) -> "IPersistentCollection[T]":
         raise NotImplementedError()
 
 

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -28,8 +28,8 @@ class Keyword(ILispObject):
 
     def _lrepr(self, **kwargs) -> str:
         if self._ns is not None:
-            return ":{ns}/{name}".format(ns=self._ns, name=self._name)
-        return ":{name}".format(name=self._name)
+            return f":{self._ns}/{self._name}"
+        return f":{self._name}"
 
     def __eq__(self, other):
         return self is other or (

--- a/src/basilisp/lang/list.py
+++ b/src/basilisp/lang/list.py
@@ -1,6 +1,6 @@
 from typing import Optional, TypeVar, cast
 
-from pyrsistent import PList, plist  # noqa # pylint: disable=unused-import
+from pyrsistent import PList, plist  # noqa
 from pyrsistent._plist import _EMPTY_PLIST
 
 from basilisp.lang.interfaces import IPersistentList, IPersistentMap, ISeq, IWithMeta
@@ -92,13 +92,9 @@ EMPTY: PersistentList = PersistentList(plist())
 
 def list(members, meta=None) -> PersistentList:  # pylint:disable=redefined-builtin
     """Creates a new list."""
-    return PersistentList(  # pylint: disable=abstract-class-instantiated
-        plist(iterable=members), meta=meta
-    )
+    return PersistentList(plist(iterable=members), meta=meta)
 
 
 def l(*members, meta=None) -> PersistentList:  # noqa
     """Creates a new list from members."""
-    return PersistentList(  # pylint: disable=abstract-class-instantiated
-        plist(iterable=members), meta=meta
-    )
+    return PersistentList(plist(iterable=members), meta=meta)

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -19,7 +19,7 @@ from basilisp.lang.vector import MapEntry
 from basilisp.util import partition
 
 try:
-    from immutables._map import MapMutation  # pylint: disable=unused-import
+    from immutables._map import MapMutation
 except ImportError:
     from immutables.map import MapMutation  # type: ignore[misc]
 
@@ -89,9 +89,7 @@ class TransientMap(ITransientMap[K, V]):
     ) -> "TransientMap[K, V]":
         try:
             for elem in elems:
-                if isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-                    elem, (IPersistentMap, Mapping)
-                ):
+                if isinstance(elem, (IPersistentMap, Mapping)):
                     for k, v in elem.items():
                         self._inner[k] = v
                 elif isinstance(elem, IMapEntry):
@@ -101,10 +99,10 @@ class TransientMap(ITransientMap[K, V]):
                 else:
                     entry: IMapEntry[K, V] = MapEntry.from_vec(elem)
                     self._inner[entry.key] = entry.value
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
             raise ValueError(
                 "Argument to map conj must be another Map or castable to MapEntry"
-            )
+            ) from exc
         else:
             return self
 
@@ -149,9 +147,7 @@ class PersistentMap(
     def __eq__(self, other):
         if self is other:
             return True
-        if not isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-            other, Mapping
-        ):
+        if not isinstance(other, Mapping):
             return NotImplemented
         if len(self._inner) != len(other):
             return False
@@ -233,9 +229,7 @@ class PersistentMap(
         with self._inner.mutate() as m:
             try:
                 for elem in elems:
-                    if isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-                        elem, (IPersistentMap, Mapping)
-                    ):
+                    if isinstance(elem, (IPersistentMap, Mapping)):
                         for k, v in elem.items():
                             m.set(k, v)
                     elif isinstance(elem, IMapEntry):
@@ -245,10 +239,10 @@ class PersistentMap(
                     else:
                         entry: IMapEntry[K, V] = MapEntry.from_vec(elem)
                         m.set(entry.key, entry.value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as exc:
                 raise ValueError(
                     "Argument to map conj must be another Map or castable to MapEntry"
-                )
+                ) from exc
             else:
                 return PersistentMap(m.finish(), meta=self.meta)
 

--- a/src/basilisp/lang/multifn.py
+++ b/src/basilisp/lang/multifn.py
@@ -30,7 +30,6 @@ class MultiFunction(Generic[T]):
         "_isa",
     )
 
-    # pylint:disable=assigning-non-slot
     def __init__(
         self,
         name: sym.Symbol,

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -87,7 +87,7 @@ def map_lrepr(
 
     def entry_reprs():
         for k, v in entries():
-            yield "{k} {v}".format(k=lrepr(k, **kwargs), v=lrepr(v, **kwargs))
+            yield f"{lrepr(k, **kwargs)} {lrepr(v, **kwargs)}"
 
     trailer = []
     print_dup = kwargs["print_dup"]

--- a/src/basilisp/lang/promise.py
+++ b/src/basilisp/lang/promise.py
@@ -6,7 +6,6 @@ from basilisp.lang.interfaces import IBlockingDeref
 T = TypeVar("T")
 
 
-# pylint: disable=assigning-non-slot
 class Promise(IBlockingDeref[T]):
     __slots__ = ("_condition", "_is_delivered", "_value")
 

--- a/src/basilisp/lang/queue.py
+++ b/src/basilisp/lang/queue.py
@@ -1,6 +1,6 @@
 from typing import Optional, TypeVar
 
-from pyrsistent import PDeque, pdeque  # noqa # pylint: disable=unused-import
+from pyrsistent import PDeque, pdeque  # noqa
 
 from basilisp.lang.interfaces import (
     ILispObject,
@@ -84,15 +84,11 @@ class PersistentQueue(IPersistentList[T], IWithMeta, ILispObject):
 EMPTY: PersistentQueue = PersistentQueue(pdeque())
 
 
-def queue(members, meta=None) -> PersistentQueue:  # pylint:disable=redefined-builtin
+def queue(members, meta=None) -> PersistentQueue:
     """Creates a new queue."""
-    return PersistentQueue(  # pylint: disable=abstract-class-instantiated
-        pdeque(iterable=members), meta=meta
-    )
+    return PersistentQueue(pdeque(iterable=members), meta=meta)
 
 
 def q(*members, meta=None) -> PersistentQueue:  # noqa
     """Creates a new queue from members."""
-    return PersistentQueue(  # pylint: disable=abstract-class-instantiated
-        pdeque(iterable=members), meta=meta
-    )
+    return PersistentQueue(pdeque(iterable=members), meta=meta)

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -79,6 +79,8 @@ W = TypeVar("W", bound=LispReaderFn)
 
 READER_LINE_KW = kw.keyword("line", ns="basilisp.lang.reader")
 READER_COL_KW = kw.keyword("col", ns="basilisp.lang.reader")
+READER_END_LINE_KW = kw.keyword("end_line", ns="basilisp.lang.reader")
+READER_END_COL_KW = kw.keyword("end_col", ns="basilisp.lang.reader")
 
 READER_COND_FORM_KW = kw.keyword("form")
 READER_COND_SPLICING_KW = kw.keyword("splicing?")
@@ -473,9 +475,12 @@ def _with_loc(f: W) -> W:
     @functools.wraps(f)
     def with_lineno_and_col(ctx, **kwargs):
         line, col = ctx.reader.line, ctx.reader.col
+
         v = f(ctx, **kwargs)
+        end_line, end_col = ctx.reader.line, ctx.reader.col
         if isinstance(v, IWithMeta):
-            new_meta = lmap.map({READER_LINE_KW: line, READER_COL_KW: col})
+            new_meta = lmap.map({READER_LINE_KW: line, READER_COL_KW: col,
+                                 READER_END_LINE_KW: end_line, READER_END_COL_KW: end_col})
             old_meta = v.meta
             return v.with_meta(
                 old_meta.cons(new_meta) if old_meta is not None else new_meta

--- a/src/basilisp/lang/reference.py
+++ b/src/basilisp/lang/reference.py
@@ -24,7 +24,7 @@ else:
         def __call__(
             self, meta: Optional[IPersistentMap], *args
         ) -> Optional[IPersistentMap]:
-            ...  # pylint: disable=pointless-statement
+            ...
 
 
 class ReferenceBase(IReference):

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -70,7 +70,7 @@ NS_VAR_NAME = "*ns*"
 NS_VAR_SYM = sym.symbol(NS_VAR_NAME, ns=CORE_NS)
 NS_VAR_NS = CORE_NS
 REPL_DEFAULT_NS = "basilisp.user"
-SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 6), (3, 7), (3, 8), (3, 9), (3, 10)})
+SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 6), (3, 7), (3, 8), (3, 9), (3, 10), (3, 11)})
 
 # Public basilisp.core symbol names
 COMPILER_OPTIONS_VAR_NAME = "*compiler-options*"

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -70,7 +70,9 @@ NS_VAR_NAME = "*ns*"
 NS_VAR_SYM = sym.symbol(NS_VAR_NAME, ns=CORE_NS)
 NS_VAR_NS = CORE_NS
 REPL_DEFAULT_NS = "basilisp.user"
-SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 6), (3, 7), (3, 8), (3, 9), (3, 10), (3, 11)})
+SUPPORTED_PYTHON_VERSIONS = frozenset(
+    {(3, 6), (3, 7), (3, 8), (3, 9), (3, 10), (3, 11)}
+)
 
 # Public basilisp.core symbol names
 COMPILER_OPTIONS_VAR_NAME = "*compiler-options*"
@@ -154,9 +156,9 @@ def _supported_python_versions_features() -> Iterable[kw.Keyword]:
      - :lpy36- - to match Basilisp running on Python 3.6 and earlier versions
      - :lpy37- - to match Basilisp running on Python 3.7 and earlier versions
      - :lpy38- - to match Basilisp running on Python 3.8 and earlier versions"""
-    feature_kw = lambda major, minor, suffix="": kw.keyword(
-        f"lpy{major}{minor}{suffix}"
-    )
+
+    def feature_kw(major, minor, suffix=""):
+        return kw.keyword(f"lpy{major}{minor}{suffix}")
 
     yield feature_kw(sys.version_info.major, sys.version_info.minor)
 
@@ -812,7 +814,6 @@ class Namespace(ReferenceBase):
 
         return is_match
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_alias(
         self, prefix: str, name_in_ns: Optional[str] = None
     ) -> Iterable[str]:
@@ -861,7 +862,6 @@ class Namespace(ReferenceBase):
             for candidate_name, _ in candidates:
                 yield f"{candidate_name}/"
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_interns(
         self, value: str, include_private_vars: bool = True
     ) -> Iterable[str]:
@@ -880,7 +880,6 @@ class Namespace(ReferenceBase):
             filter(is_match, ((s, v) for s, v in self.interns.items())),
         )
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_refers(self, value: str) -> Iterable[str]:
         """Return an iterable of possible completions matching the given
         prefix from the list of referred Vars."""
@@ -941,8 +940,10 @@ def pop_thread_bindings() -> None:
     """Pop the thread local bindings set by push_thread_bindings above."""
     try:
         bindings = _THREAD_BINDINGS.pop_bindings()
-    except IndexError:
-        raise RuntimeException("cannot pop thread-local bindings without prior push")
+    except IndexError as exc:
+        raise RuntimeException(
+            "cannot pop thread-local bindings without prior push"
+        ) from exc
 
     for var in bindings:
         var.pop_bindings()
@@ -1107,8 +1108,10 @@ def count(coll) -> int:
     except (AttributeError, TypeError):
         try:
             return sum(1 for _ in coll)
-        except TypeError:
-            raise TypeError(f"count not supported on object of type {type(coll)}")
+        except TypeError as exc:
+            raise TypeError(
+                f"count not supported on object of type {type(coll)}"
+            ) from exc
 
 
 __nth_sentinel = object()

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -101,7 +101,6 @@ class _Sequence(IWithMeta, ISequential, ISeq[T]):
 
     __slots__ = ("_first", "_seq", "_rest", "_meta")
 
-    # pylint:disable=assigning-non-slot
     def __init__(
         self, s: Iterator[T], first: T, *, meta: Optional[IPersistentMap] = None
     ) -> None:
@@ -125,7 +124,6 @@ class _Sequence(IWithMeta, ISequential, ISeq[T]):
     def first(self) -> Optional[T]:
         return self._first
 
-    # pylint:disable=assigning-non-slot
     @property
     def rest(self) -> "ISeq[T]":
         if self._rest:

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -16,7 +16,7 @@ from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
 
 try:
-    from immutables._map import MapMutation  # pylint: disable=unused-import
+    from immutables._map import MapMutation
 except ImportError:
     from immutables.map import MapMutation  # type: ignore[misc]
 
@@ -103,9 +103,7 @@ class PersistentSet(
     def __eq__(self, other):
         if self is other:
             return True
-        if not isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-            other, AbstractSet
-        ):
+        if not isinstance(other, AbstractSet):
             return NotImplemented
         return _PySet.__eq__(self, other)
 

--- a/src/basilisp/lang/symbol.py
+++ b/src/basilisp/lang/symbol.py
@@ -22,7 +22,7 @@ class Symbol(ILispObject, IWithMeta):
         print_meta = kwargs["print_meta"]
 
         if self._ns is not None:
-            sym_repr = "{ns}/{name}".format(ns=self._ns, name=self._name)
+            sym_repr = f"{self._ns}/{self._name}"
         else:
             sym_repr = self._name
 

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -1,8 +1,8 @@
 from functools import total_ordering
 from typing import Iterable, Optional, Sequence, TypeVar, Union
 
-from pyrsistent import PVector, pvector  # noqa # pylint: disable=unused-import
-from pyrsistent.typing import PVectorEvolver  # pylint:disable=unused-import
+from pyrsistent import PVector, pvector  # noqa
+from pyrsistent.typing import PVectorEvolver
 
 from basilisp.lang.interfaces import (
     IEvolveableCollection,
@@ -26,7 +26,7 @@ class TransientVector(ITransientVector[T]):
     __slots__ = ("_inner",)
 
     def __init__(self, wrapped: "PVectorEvolver[T]") -> None:
-        self._inner = wrapped  # pylint: disable=assigning-non-slot
+        self._inner = wrapped
 
     def __bool__(self):
         return True

--- a/src/basilisp/util.py
+++ b/src/basilisp/util.py
@@ -24,7 +24,7 @@ class Maybe(Generic[T]):
     __slots__ = ("_inner",)
 
     def __init__(self, inner: Optional[T]) -> None:
-        self._inner = inner  # pylint:disable=assigning-non-slot
+        self._inner = inner
 
     def __eq__(self, other):
         if isinstance(other, Maybe):

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -2731,8 +2731,14 @@ class TestMacroexpandFunctions:
         )
 
     def test_macroexpand(self, lcompile: CompileFn, example_macro):
-        meta = lmap.map({reader.READER_LINE_KW: 1, reader.READER_COL_KW: 1,
-                         reader.READER_END_LINE_KW: 1, reader.READER_END_COL_KW: 1})
+        meta = lmap.map(
+            {
+                reader.READER_LINE_KW: 1,
+                reader.READER_COL_KW: 1,
+                reader.READER_END_LINE_KW: 1,
+                reader.READER_END_COL_KW: 1,
+            }
+        )
 
         assert llist.l(
             sym.symbol("def"),

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -2731,7 +2731,8 @@ class TestMacroexpandFunctions:
         )
 
     def test_macroexpand(self, lcompile: CompileFn, example_macro):
-        meta = lmap.map({reader.READER_LINE_KW: 1, reader.READER_COL_KW: 1})
+        meta = lmap.map({reader.READER_LINE_KW: 1, reader.READER_COL_KW: 1,
+                         reader.READER_END_LINE_KW: 1, reader.READER_END_COL_KW: 1})
 
         assert llist.l(
             sym.symbol("def"),

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -1355,7 +1355,10 @@ def test_partial_kw():
     )(
         value=82, other_value="a string"
     )
-    assert {"value": 82, "other_value": "a string",} == core.partial_kw(
+    assert {
+        "value": 82,
+        "other_value": "a string",
+    } == core.partial_kw(
         dict, kw.keyword("value"), 3, kw.keyword("other-value"), "some string"
     )(value=82, other_value="a string")
 

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -882,9 +882,13 @@ def test_meta():
     assert s == sym.symbol("s")
     assert issubmap(s.meta, lmap.map({kw.keyword("tag"): sym.symbol("str")}))
     assert issubmap(s.meta, lmap.map({kw.keyword("line", "basilisp.lang.reader"): 1}))
-    assert issubmap(s.meta, lmap.map({kw.keyword("end_line", "basilisp.lang.reader"): 1}))
+    assert issubmap(
+        s.meta, lmap.map({kw.keyword("end_line", "basilisp.lang.reader"): 1})
+    )
     assert issubmap(s.meta, lmap.map({kw.keyword("col", "basilisp.lang.reader"): 6}))
-    assert issubmap(s.meta, lmap.map({kw.keyword("end_col", "basilisp.lang.reader"): 7}))
+    assert issubmap(
+        s.meta, lmap.map({kw.keyword("end_col", "basilisp.lang.reader"): 7})
+    )
 
     s = read_str_first("^:dynamic *ns*")
     assert s == sym.symbol("*ns*")

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -881,6 +881,10 @@ def test_meta():
     s = read_str_first("^str s")
     assert s == sym.symbol("s")
     assert issubmap(s.meta, lmap.map({kw.keyword("tag"): sym.symbol("str")}))
+    assert issubmap(s.meta, lmap.map({kw.keyword("line", "basilisp.lang.reader"): 1}))
+    assert issubmap(s.meta, lmap.map({kw.keyword("end_line", "basilisp.lang.reader"): 1}))
+    assert issubmap(s.meta, lmap.map({kw.keyword("col", "basilisp.lang.reader"): 6}))
+    assert issubmap(s.meta, lmap.map({kw.keyword("end_col", "basilisp.lang.reader"): 7}))
 
     s = read_str_first("^:dynamic *ns*")
     assert s == sym.symbol("*ns*")

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -40,6 +40,7 @@ def test_is_supported_python_version():
                     "lpy38-",
                     "lpy39-",
                     "lpy310-",
+                    "lpy311-"
                 ],
             )
         ),
@@ -56,6 +57,7 @@ def test_is_supported_python_version():
                     "lpy38-",
                     "lpy39-",
                     "lpy310-",
+                    "lpy311-",
                 ],
             )
         ),
@@ -72,6 +74,7 @@ def test_is_supported_python_version():
                     "lpy36+",
                     "lpy39-",
                     "lpy310-",
+                    "lpy311-",
                 ],
             )
         ),
@@ -88,6 +91,7 @@ def test_is_supported_python_version():
                     "lpy37+",
                     "lpy36+",
                     "lpy310-",
+                    "lpy311-",
                 ],
             )
         ),
@@ -98,8 +102,9 @@ def test_is_supported_python_version():
                     "lpy310",
                     "default",
                     "lpy",
+                    "lpy311-",
                     "lpy310+",
-                    "lpy310-",
+                    "lpy310+",
                     "lpy39+",
                     "lpy38+",
                     "lpy37+",
@@ -107,6 +112,23 @@ def test_is_supported_python_version():
                 ],
             )
         ),
+        (3, 11): frozenset(
+            map(
+                kw.keyword,
+                [
+                    "lpy311",
+                    "default",
+                    "lpy",
+                    "lpy311-",
+                    "lpy311+",
+                    "lpy310+",
+                    "lpy39+",
+                    "lpy38+",
+                    "lpy37+",
+                    "lpy36+",
+                ],
+            )
+        )
     }[(sys.version_info.major, sys.version_info.minor)],
 )
 def test_reader_default_featureset(feature):

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -40,7 +40,7 @@ def test_is_supported_python_version():
                     "lpy38-",
                     "lpy39-",
                     "lpy310-",
-                    "lpy311-"
+                    "lpy311-",
                 ],
             )
         ),
@@ -128,7 +128,7 @@ def test_is_supported_python_version():
                     "lpy36+",
                 ],
             )
-        )
+        ),
     }[(sys.version_info.major, sys.version_info.minor)],
 )
 def test_reader_default_featureset(feature):

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -97,7 +97,7 @@ class TestTestrunner:
         ),
     )
     def test_error_repr(self, run_result: RunResult):
-        if (sys.version_info < (3,11)):
+        if sys.version_info < (3, 11):
             expected = [
                 "ERROR in (assertion-test) (test_testrunner.lpy:12)",
                 "",
@@ -113,7 +113,7 @@ class TestTestrunner:
                 "Traceback (most recent call last):",
                 '  File "*test_testrunner.lpy", line 12, in assertion_test',
                 '    (is (throw (ex-info "Uncaught exception" {}))))',
-                '    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
+                "    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
                 "basilisp.lang.exception.ExceptionInfo: Uncaught exception {}",
             ]
 

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -97,15 +97,28 @@ class TestTestrunner:
         ),
     )
     def test_error_repr(self, run_result: RunResult):
-        run_result.stdout.fnmatch_lines(
-            [
+        if (sys.version_info < (3,11)):
+            expected = [
                 "ERROR in (assertion-test) (test_testrunner.lpy:12)",
                 "",
                 "Traceback (most recent call last):",
                 '  File "/*/test_testrunner.lpy", line 12, in assertion_test',
                 '    (is (throw (ex-info "Uncaught exception" {}))))',
                 "basilisp.lang.exception.ExceptionInfo: Uncaught exception {}",
-            ],
+            ]
+        else:
+            expected = [
+                "ERROR in (assertion-test) (test_testrunner.lpy:12)",
+                "",
+                "Traceback (most recent call last):",
+                '  File "*test_testrunner.lpy", line 12, in assertion_test',
+                '    (is (throw (ex-info "Uncaught exception" {}))))',
+                '    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
+                "basilisp.lang.exception.ExceptionInfo: Uncaught exception {}",
+            ]
+
+        run_result.stdout.fnmatch_lines(
+            expected,
             consecutive=True,
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ isolated_build = true
 envlist = py36,py37,py38,py39,py310,py311,pypy3,coverage,py{36,37,38,39,310,311}-mypy,py{36,37,38,39,310,311}-lint,format,safety
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
 setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true
@@ -24,7 +24,7 @@ commands =
 [testenv:coverage]
 depends = py36, py37, py38, py39, py310, py311
 deps =
-    coveralls
+    coveralls==3.3.1
     coverage[toml]
 passenv =
     COVERALLS_REPO_TOKEN
@@ -35,7 +35,7 @@ commands =
 
 [testenv:format]
 deps =
-    black==22.6.0
+    black
     isort
 commands =
     isort --check .
@@ -47,15 +47,17 @@ deps =
     types-docutils
     types-python-dateutil
 commands =
-    mypy --config-file={toxinidir}/pyproject.toml -p basilisp
+    mypy --config-file={toxinidir}/pyproject.toml --no-warn-unused-ignores -p basilisp
 
 [testenv:py{36,37,38,39,310,311}-lint]
 deps =
-    prospector==1.3.1
+    prospector==1.10.2
     pytest
     sphinx
 commands =
-    prospector --profile-path={toxinidir}
+    # for some reason, it tries to use the django plugin,
+    # and thus the use of --no-autodetect to void it.
+    prospector -X --no-autodetect --profile-path={toxinidir}
 
 [testenv:safety]
 deps = safety

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py36,py37,py38,py39,py310,pypy3,coverage,py{36,37,38,39,310}-mypy,py{36,37,38,39,310}-lint,format,safety
+envlist = py36,py37,py38,py39,py310,py311,pypy3,coverage,py{36,37,38,39,310,311}-mypy,py{36,37,38,39,310,311}-lint,format,safety
 
 [testenv]
 whitelist_externals = poetry
@@ -22,7 +22,7 @@ commands =
              {posargs}
 
 [testenv:coverage]
-depends = py36, py37, py38, py39, py310
+depends = py36, py37, py38, py39, py310, py311
 deps =
     coveralls
     coverage[toml]
@@ -35,21 +35,21 @@ commands =
 
 [testenv:format]
 deps =
-    black
+    black==22.6.0
     isort
 commands =
     isort --check .
     black --check .
 
-[testenv:py{36,37,38,39,310}-mypy]
+[testenv:py{36,37,38,39,310,311}-mypy]
 deps =
-    mypy
+    mypy==0.971
     types-docutils
     types-python-dateutil
 commands =
     mypy --config-file={toxinidir}/pyproject.toml -p basilisp
 
-[testenv:py{36,37,38,39,310}-lint]
+[testenv:py{36,37,38,39,310,311}-lint]
 deps =
     prospector==1.3.1
     pytest


### PR DESCRIPTION
Hi,

can you please review patch to support python 3.11. It fixes #689 

Basically, it adds the end of line and columns fields all the way from the reader to the AST, which is a requirement with 3.11. It also updates the test/linting packages to work from 3.6-311, and fixes any new linting issues.

Unfortunately, 3.6 fails the `safety` task because of `setup` tools vulnerabilities with the latest version of the package for 3.6, and also the latest version of prospector fails to run on 3.6, thus both have been disabled (removed) from the CI.

In addition to main change, there were many linter fixes, mostly with the removal of unused pylint configuration comments that are now defunct and nested exception propagation.

Thanks