### PR TITLE
Update Prospector version and fix the myriad new errors that appear

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,5 +1,6 @@
 output-format: text
 
+autodetect: false
 strictness: medium
 test-warnings: true
 doc-warnings: false
@@ -40,5 +41,6 @@ pylint:
     - no-else-raise
     - no-else-return
     - protected-access
+    - unnecessary-lambda-assignment
     - unsubscriptable-object
     - useless-import-alias

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
  * Run CPython CI checks on Github Actions rather than CircleCI (#683)
- * Remove support for Python 3.6 and 3.7, which are both EOL
+ * Remove support for Python 3.6 and 3.7, which are both EOL (#691)
+ * Update Prospector version for linting (#694)
 
 ## [v0.1.0a1]
 ### Added

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -6,7 +6,7 @@ from typing import Callable, Iterable, Iterator, Optional, Tuple
 import py
 import pytest
 from _pytest.config import Config
-from _pytest.main import Session  # pylint: disable=unused-import
+from _pytest.main import Session
 
 from basilisp import main as basilisp
 from basilisp.lang import keyword as kw
@@ -102,8 +102,10 @@ class FixtureManager:
                 teardown = cls._run_fixture(fixture)
                 if teardown is not None:
                     teardown_fixtures.append(teardown)
-        except Exception:
-            raise runtime.RuntimeException("Exception occurred during fixture setup")
+        except Exception as e:
+            raise runtime.RuntimeException(
+                "Exception occurred during fixture setup"
+            ) from e
         else:
             return teardown_fixtures
 
@@ -115,10 +117,10 @@ class FixtureManager:
                 next(teardown)
             except StopIteration:
                 pass
-            except Exception:
+            except Exception as e:
                 raise runtime.RuntimeException(
                     "Exception occurred during fixture teardown"
-                )
+                ) from e
 
     def setup(self) -> None:
         """Setup fixtures and store any teardowns for cleanup later.
@@ -245,7 +247,7 @@ class BasilispTestItem(pytest.Item):
         filename: str,
         fixture_manager: FixtureManager,
     ) -> None:
-        super(BasilispTestItem, self).__init__(name, parent)
+        super().__init__(name, parent)
         self._run_test = run_test
         self._namespace = namespace
         self._filename = filename
@@ -288,7 +290,7 @@ class BasilispTestItem(pytest.Item):
         if runtime.to_seq(failures):
             raise TestFailuresInfo("Test failures", lmap.map(results))
 
-    def repr_failure(self, excinfo, style=None):  # pylint: disable=unused-argument
+    def repr_failure(self, excinfo, style=None):
         """Representation function called when self.runtest() raises an exception."""
         if isinstance(excinfo.value, TestFailuresInfo):
             exc = excinfo.value

--- a/src/basilisp/contrib/sphinx/domain.py
+++ b/src/basilisp/contrib/sphinx/domain.py
@@ -293,7 +293,7 @@ class BasilispNamespaceIndex(Index):
     localname = "Namespace Index"
     shortname = "namespaces"
 
-    def generate(  # pylint: disable=too-many-branches,too-many-locals
+    def generate(  # pylint: disable=too-many-locals
         self, docnames: Optional[Iterable[str]] = None
     ) -> Tuple[List[Tuple[str, List[IndexEntry]]], bool]:
         content: Dict[str, List[IndexEntry]] = defaultdict(list)
@@ -369,7 +369,7 @@ class BasilispNamespaceIndex(Index):
 
 
 class BasilispXRefRole(XRefRole):
-    def process_link(  # pylint: disable=too-many-arguments,unused-argument
+    def process_link(  # pylint: disable=too-many-arguments
         self,
         env: BuildEnvironment,
         refnode: Element,
@@ -382,19 +382,19 @@ class BasilispXRefRole(XRefRole):
         return title, target
 
 
-class FormEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class FormEntry(NamedTuple):
     docname: str
     node_id: str
 
 
-class VarEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class VarEntry(NamedTuple):
     docname: str
     node_id: str
     objtype: str
     aliased: bool
 
 
-class NamespaceEntry(NamedTuple):  # pylint: disable=inherit-non-class
+class NamespaceEntry(NamedTuple):
     docname: str
     node_id: str
     synopsis: str
@@ -515,7 +515,7 @@ class BasilispDomain(Domain):
             if ns_entry.docname in docnames:
                 self.namespaces[ns_name] = ns_entry
 
-    def resolve_xref(  # pylint: disable=too-many-arguments,too-many-locals,unused-argument
+    def resolve_xref(  # pylint: disable=too-many-arguments
         self,
         env: BuildEnvironment,
         fromdocname: str,

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -194,9 +194,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
         super().invalidate_caches()
         self._cache = {}
 
-    def _cache_bytecode(
-        self, source_path, cache_path, data
-    ):  # pylint: disable=unused-argument
+    def _cache_bytecode(self, source_path, cache_path, data):
         self.set_data(cache_path, data)
 
     def path_stats(self, path):
@@ -215,8 +213,8 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
     def get_filename(self, fullname: str) -> str:  # pragma: no cover
         try:
             cached = self._cache[fullname]
-        except KeyError:
-            raise ImportError(f"Could not import module '{fullname}'")
+        except KeyError as e:
+            raise ImportError(f"Could not import module '{fullname}'") from e
         spec = cached["spec"]
         return spec.loader_state.filename
 
@@ -289,7 +287,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):
                 Iterable[ReaderForm],
                 reader.read_file(filename, resolver=runtime.resolve_alias),
             )
-            compiler.compile_module(  # pylint: disable=unexpected-keyword-arg
+            compiler.compile_module(
                 forms,
                 compiler.CompilerContext(
                     filename=filename, opts=runtime.get_compiler_opts()
@@ -349,6 +347,4 @@ def hook_imports():
     using standard `import module.submodule` syntax."""
     if any(isinstance(o, BasilispImporter) for o in sys.meta_path):
         return
-    sys.meta_path.insert(
-        0, BasilispImporter()  # pylint:disable=abstract-class-instantiated
-    )
+    sys.meta_path.insert(0, BasilispImporter())

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -119,7 +119,7 @@ def _emit_ast_string(
         runtime.add_generated_python(to_py_str(module), which_ns=ns)
 
 
-def compile_and_exec_form(  # pylint: disable= too-many-arguments
+def compile_and_exec_form(
     form: ReaderForm,
     ctx: CompilerContext,
     ns: runtime.Namespace,

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -193,7 +193,6 @@ class SymbolTableEntry:
         return self.binding.local
 
 
-# pylint: disable=unsupported-membership-test,unsupported-delete-operation,unsupported-assignment-operation
 @attr.s(auto_attribs=True, slots=True)
 class SymbolTable:
     name: str
@@ -713,7 +712,7 @@ def _body_ast(
     return stmts, ret
 
 
-def _call_args_ast(  # pylint: disable=too-many-branches
+def _call_args_ast(
     form: ISeq, ctx: AnalyzerContext
 ) -> Tuple[Iterable[Node], KeywordArgs]:
     """Return a tuple of positional arguments and keyword arguments, splitting at the
@@ -853,7 +852,7 @@ def _await_ast(form: ISeq, ctx: AnalyzerContext) -> Await:
     )
 
 
-def _def_ast(  # pylint: disable=too-many-branches,too-many-locals
+def _def_ast(  # pylint: disable=too-many-locals
     form: ISeq, ctx: AnalyzerContext
 ) -> Def:
     assert form.first == SpecialForm.DEF
@@ -1101,10 +1100,10 @@ def __deftype_classmethod(
     ):
         try:
             cls_arg = args[0]
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 "deftype* class method must include 'cls' argument", form=args
-            )
+            ) from e
         else:
             if not isinstance(cls_arg, sym.Symbol):
                 raise AnalyzerException(
@@ -1162,11 +1161,11 @@ def __deftype_or_reify_method(  # pylint: disable=too-many-arguments,too-many-lo
     with ctx.new_symbol_table(method_name, is_context_boundary=True):
         try:
             this_arg = args[0]
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 f"{special_form} method must include 'this' or 'self' argument",
                 form=args,
-            )
+            ) from e
         else:
             if not isinstance(this_arg, sym.Symbol):
                 raise AnalyzerException(
@@ -1226,11 +1225,11 @@ def __deftype_or_reify_property(
     with ctx.new_symbol_table(method_name, is_context_boundary=True):
         try:
             this_arg = args[0]
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 f"{special_form} property must include 'this' or 'self' argument",
                 form=args,
-            )
+            ) from e
         else:
             if not isinstance(this_arg, sym.Symbol):
                 raise AnalyzerException(
@@ -1317,7 +1316,7 @@ def __deftype_staticmethod(
         return method
 
 
-def __deftype_or_reify_prop_or_method_arity(  # pylint: disable=too-many-branches
+def __deftype_or_reify_prop_or_method_arity(
     form: Union[llist.PersistentList, ISeq],
     ctx: AnalyzerContext,
     special_form: sym.Symbol,
@@ -1399,7 +1398,7 @@ def __deftype_or_reify_prop_or_method_arity(  # pylint: disable=too-many-branche
         )
 
 
-def __deftype_or_reify_method_node_from_arities(  # pylint: disable=too-many-branches
+def __deftype_or_reify_method_node_from_arities(
     form: Union[llist.PersistentList, ISeq],
     ctx: AnalyzerContext,
     arities: List[DefTypeMethodArity],
@@ -1585,7 +1584,7 @@ def __is_reify_member(mem) -> bool:
     return inspect.isfunction(mem) or isinstance(mem, property)
 
 
-def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-branches,too-many-locals
+def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-locals
     special_form: sym.Symbol,
     fields: Iterable[str],
     interfaces: Iterable[DefTypeBase],
@@ -1721,7 +1720,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-bran
 __DEFTYPE_DEFAULT_SENTINEL = object()
 
 
-def _deftype_ast(  # pylint: disable=too-many-branches,too-many-locals
+def _deftype_ast(  # pylint: disable=too-many-locals
     form: ISeq, ctx: AnalyzerContext
 ) -> DefType:
     assert form.first == SpecialForm.DEFTYPE
@@ -1827,7 +1826,7 @@ def _do_ast(form: ISeq, ctx: AnalyzerContext) -> Do:
     )
 
 
-def __fn_method_ast(  # pylint: disable=too-many-branches,too-many-locals
+def __fn_method_ast(  # pylint: disable=too-many-locals
     form: ISeq,
     ctx: AnalyzerContext,
     fnname: Optional[sym.Symbol] = None,
@@ -1927,11 +1926,11 @@ def __fn_kwargs_support(o: IMeta) -> Optional[KeywordArgSupport]:
 
     try:
         return KeywordArgSupport(kwarg_support)
-    except ValueError:
+    except ValueError as e:
         raise AnalyzerException(
             "fn keyword argument support metadata :kwarg must be one of: #{:apply :collect}",
             form=kwarg_support,
-        )
+        ) from e
 
 
 InlineMeta = Union[Callable, bool, None]
@@ -2000,9 +1999,7 @@ def _inline_fn_ast(
 
 
 @_with_meta  # noqa: MC0001
-def _fn_ast(  # pylint: disable=too-many-branches
-    form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext
-) -> Fn:
+def _fn_ast(form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext) -> Fn:
     assert form.first == SpecialForm.FN
 
     idx = 1
@@ -2010,11 +2007,11 @@ def _fn_ast(  # pylint: disable=too-many-branches
     with ctx.new_symbol_table("fn", is_context_boundary=True):
         try:
             name = runtime.nth(form, idx)
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 "fn form must match: (fn* name? [arg*] body*) or (fn* name? method*)",
                 form=form,
-            )
+            ) from e
 
         name_node: Optional[Binding]
         inline: InlineMeta
@@ -2047,11 +2044,11 @@ def _fn_ast(  # pylint: disable=too-many-branches
 
         try:
             arity_or_args = runtime.nth(form, idx)
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 "fn form expects either multiple arities or a vector of arguments",
                 form=form,
-            )
+            ) from e
 
         if isinstance(arity_or_args, llist.PersistentList):
             arities = vec.vector(
@@ -2171,11 +2168,11 @@ def _host_prop_ast(form: ISeq, ctx: AnalyzerContext) -> HostField:
     if field.name == ".-":
         try:
             field = runtime.nth(form, 2)
-        except IndexError:
+        except IndexError as e:
             raise AnalyzerException(
                 "host interop prop must be exactly 3 elems long: (.- target field)",
                 form=form,
-            )
+            ) from e
         else:
             if not isinstance(field, sym.Symbol):
                 raise AnalyzerException(
@@ -2211,9 +2208,7 @@ def _host_prop_ast(form: ISeq, ctx: AnalyzerContext) -> HostField:
         )
 
 
-def _host_interop_ast(  # pylint: disable=too-many-branches
-    form: ISeq, ctx: AnalyzerContext
-) -> Union[HostCall, HostField]:
+def _host_interop_ast(form: ISeq, ctx: AnalyzerContext) -> Union[HostCall, HostField]:
     assert form.first == SpecialForm.INTEROP_CALL
     nelems = count(form)
     assert nelems >= 3
@@ -2302,9 +2297,7 @@ def _if_ast(form: ISeq, ctx: AnalyzerContext) -> If:
     )
 
 
-def _import_ast(  # pylint: disable=too-many-branches
-    form: ISeq, ctx: AnalyzerContext
-) -> Import:
+def _import_ast(form: ISeq, ctx: AnalyzerContext) -> Import:
     assert form.first == SpecialForm.IMPORT
 
     aliases = []
@@ -2694,7 +2687,7 @@ def _assert_no_recur(node: Node) -> None:
         node.visit(_assert_no_recur)
 
 
-def _assert_recur_is_tail(node: Node) -> None:  # pylint: disable=too-many-branches
+def _assert_recur_is_tail(node: Node) -> None:
     """Assert that `recur` forms only appear in the tail position of this
     or child AST nodes.
 
@@ -2797,9 +2790,7 @@ def _reify_ast(form: ISeq, ctx: AnalyzerContext) -> Reify:
         )
 
 
-def _require_ast(  # pylint: disable=too-many-branches
-    form: ISeq, ctx: AnalyzerContext
-) -> Require:
+def _require_ast(form: ISeq, ctx: AnalyzerContext) -> Require:
     assert form.first == SpecialForm.REQUIRE
 
     aliases = []
@@ -2950,9 +2941,7 @@ def _catch_ast(form: ISeq, ctx: AnalyzerContext) -> Catch:
         )
 
 
-def _try_ast(  # pylint: disable=too-many-branches
-    form: ISeq, ctx: AnalyzerContext
-) -> Try:
+def _try_ast(form: ISeq, ctx: AnalyzerContext) -> Try:
     assert form.first == SpecialForm.TRY
 
     try_exprs = []
@@ -3153,7 +3142,7 @@ def _resolve_nested_symbol(ctx: AnalyzerContext, form: sym.Symbol) -> HostField:
     )
 
 
-def __resolve_namespaced_symbol_in_ns(  # pylint: disable=too-many-branches
+def __resolve_namespaced_symbol_in_ns(
     ctx: AnalyzerContext,
     which_ns: runtime.Namespace,
     form: sym.Symbol,
@@ -3642,7 +3631,7 @@ def _const_node(form: ReaderForm, ctx: AnalyzerContext) -> Const:
         )
         or (ctx.should_allow_unresolved_symbols and isinstance(form, sym.Symbol))
         or (isinstance(form, (llist.PersistentList, ISeq)) and form.is_empty)
-        or isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
+        or isinstance(
             form,
             (
                 bool,

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1999,7 +1999,9 @@ def _inline_fn_ast(
 
 
 @_with_meta  # noqa: MC0001
-def _fn_ast(form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext) -> Fn:
+def _fn_ast(  # pylint: disable=too-many-locals
+    form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext
+) -> Fn:
     assert form.first == SpecialForm.FN
 
     idx = 1

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -140,7 +140,6 @@ class SymbolTableEntry:
     symbol: sym.Symbol
 
 
-# pylint: disable=unsupported-membership-test,unsupported-delete-operation,unsupported-assignment-operation
 @attr.s(auto_attribs=True, slots=True)
 class SymbolTable:
     name: str
@@ -778,9 +777,7 @@ def __should_warn_on_redef(
 
 
 @_with_ast_loc
-def _def_to_py_ast(  # pylint: disable=too-many-branches
-    ctx: GeneratorContext, node: Def
-) -> GeneratedPyAST:
+def _def_to_py_ast(ctx: GeneratorContext, node: Def) -> GeneratedPyAST:
     """Return a Python AST Node for a `def` expression."""
     assert node.op == NodeOp.DEF
 
@@ -976,7 +973,7 @@ def __deftype_property_to_py_ast(
             )
 
 
-def __multi_arity_deftype_dispatch_method(  # pylint: disable=too-many-arguments,too-many-locals
+def __multi_arity_deftype_dispatch_method(
     name: str,
     arity_map: Mapping[int, str],
     default_name: Optional[str] = None,
@@ -1134,7 +1131,7 @@ def __multi_arity_deftype_dispatch_method(  # pylint: disable=too-many-arguments
 
 
 @_with_ast_loc_deps
-def __multi_arity_deftype_method_to_py_ast(  # pylint: disable=too-many-arguments,too-many-locals
+def __multi_arity_deftype_method_to_py_ast(
     ctx: GeneratorContext,
     node: DefTypeMethod,
 ) -> GeneratedPyAST:
@@ -1332,9 +1329,7 @@ def __deftype_or_reify_bases_to_py_ast(
 
 
 @_with_ast_loc
-def _deftype_to_py_ast(  # pylint: disable=too-many-branches,too-many-locals
-    ctx: GeneratorContext, node: DefType
-) -> GeneratedPyAST:
+def _deftype_to_py_ast(ctx: GeneratorContext, node: DefType) -> GeneratedPyAST:
     """Return a Python AST Node for a `deftype*` expression."""
     assert node.op == NodeOp.DEFTYPE
     type_name = munge(node.name)
@@ -2905,7 +2900,7 @@ def __var_find_to_py_ast(
 
 
 @_with_ast_loc
-def _var_sym_to_py_ast(  # pylint: disable=too-many-branches
+def _var_sym_to_py_ast(
     ctx: GeneratorContext, node: VarRef, is_assigning: bool = False
 ) -> GeneratedPyAST:
     """Generate a Python AST node for accessing a Var.
@@ -3259,7 +3254,7 @@ def _collection_literal_to_py_ast(
     yield from map(lambda form: _const_val_to_py_ast(form, ctx), form)
 
 
-def _const_meta_kwargs_ast(  # pylint:disable=inconsistent-return-statements
+def _const_meta_kwargs_ast(
     ctx: GeneratorContext, form: LispForm
 ) -> Optional[GeneratedPyAST]:
     if isinstance(form, IMeta) and form.meta is not None:

--- a/src/basilisp/lang/delay.py
+++ b/src/basilisp/lang/delay.py
@@ -25,9 +25,7 @@ class Delay(IDeref[T]):
     __slots__ = ("_state",)
 
     def __init__(self, f: Callable[[], T]) -> None:
-        self._state = atom.Atom(  # pylint:disable=assigning-non-slot
-            _DelayState(f=f, value=None, computed=False)
-        )
+        self._state = atom.Atom(_DelayState(f=f, value=None, computed=False))
 
     @staticmethod
     def __deref(state: _DelayState) -> _DelayState:

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -32,7 +32,6 @@ class IDeref(Generic[T], ABC):
 class IBlockingDeref(IDeref[T]):
     __slots__ = ()
 
-    # pylint: disable=arguments-differ
     @abstractmethod
     def deref(
         self, timeout: Optional[float] = None, timeout_val: Optional[T] = None
@@ -196,14 +195,14 @@ class ILookup(Generic[K, V], ABC):
         raise NotImplementedError()
 
 
-T_pcoll = TypeVar("T_pcoll", bound="IPersistentCollection", covariant=True)
+T_pcoll_co = TypeVar("T_pcoll_co", bound="IPersistentCollection", covariant=True)
 
 
 class IPersistentCollection(ISeqable[T]):
     __slots__ = ()
 
     @abstractmethod
-    def cons(self: T_pcoll, *elems: T) -> "T_pcoll":
+    def cons(self: T_pcoll_co, *elems: T) -> "T_pcoll_co":
         raise NotImplementedError()
 
     @staticmethod
@@ -304,13 +303,13 @@ class IPersistentVector(
         raise NotImplementedError()
 
 
-T_tcoll = TypeVar("T_tcoll", bound="ITransientCollection", covariant=True)
+T_tcoll_co = TypeVar("T_tcoll_co", bound="ITransientCollection", covariant=True)
 
 
 # Including ABC as a base seems to cause catastrophic meltdown.
-class IEvolveableCollection(Generic[T_tcoll]):
+class IEvolveableCollection(Generic[T_tcoll_co]):
     @abstractmethod
-    def to_transient(self) -> T_tcoll:
+    def to_transient(self) -> T_tcoll_co:
         raise NotImplementedError()
 
 
@@ -318,11 +317,11 @@ class ITransientCollection(Generic[T]):
     __slots__ = ()
 
     @abstractmethod
-    def cons_transient(self: T_tcoll, *elems: T) -> "T_tcoll":
+    def cons_transient(self: T_tcoll_co, *elems: T) -> "T_tcoll_co":
         raise NotImplementedError()
 
     @abstractmethod
-    def to_persistent(self: T_tcoll) -> "IPersistentCollection[T]":
+    def to_persistent(self: T_tcoll_co) -> "IPersistentCollection[T]":
         raise NotImplementedError()
 
 

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -28,8 +28,8 @@ class Keyword(ILispObject):
 
     def _lrepr(self, **kwargs) -> str:
         if self._ns is not None:
-            return ":{ns}/{name}".format(ns=self._ns, name=self._name)
-        return ":{name}".format(name=self._name)
+            return f":{self._ns}/{self._name}"
+        return f":{self._name}"
 
     def __eq__(self, other):
         return self is other or (

--- a/src/basilisp/lang/list.py
+++ b/src/basilisp/lang/list.py
@@ -92,13 +92,9 @@ EMPTY: PersistentList = PersistentList(plist())
 
 def list(members, meta=None) -> PersistentList:  # pylint:disable=redefined-builtin
     """Creates a new list."""
-    return PersistentList(  # pylint: disable=abstract-class-instantiated
-        plist(iterable=members), meta=meta
-    )
+    return PersistentList(plist(iterable=members), meta=meta)
 
 
 def l(*members, meta=None) -> PersistentList:  # noqa
     """Creates a new list from members."""
-    return PersistentList(  # pylint: disable=abstract-class-instantiated
-        plist(iterable=members), meta=meta
-    )
+    return PersistentList(plist(iterable=members), meta=meta)

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -19,7 +19,7 @@ from basilisp.lang.vector import MapEntry
 from basilisp.util import partition
 
 try:
-    from immutables._map import MapMutation  # pylint: disable=unused-import
+    from immutables._map import MapMutation
 except ImportError:
     from immutables.map import MapMutation  # type: ignore[assignment]
 
@@ -89,9 +89,7 @@ class TransientMap(ITransientMap[K, V]):
     ) -> "TransientMap[K, V]":
         try:
             for elem in elems:
-                if isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-                    elem, (IPersistentMap, Mapping)
-                ):
+                if isinstance(elem, (IPersistentMap, Mapping)):
                     for k, v in elem.items():
                         self._inner[k] = v
                 elif isinstance(elem, IMapEntry):
@@ -101,10 +99,10 @@ class TransientMap(ITransientMap[K, V]):
                 else:
                     entry: IMapEntry[K, V] = MapEntry.from_vec(elem)
                     self._inner[entry.key] = entry.value
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as e:
             raise ValueError(
                 "Argument to map conj must be another Map or castable to MapEntry"
-            )
+            ) from e
         else:
             return self
 
@@ -149,9 +147,7 @@ class PersistentMap(
     def __eq__(self, other):
         if self is other:
             return True
-        if not isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-            other, Mapping
-        ):
+        if not isinstance(other, Mapping):
             return NotImplemented
         if len(self._inner) != len(other):
             return False
@@ -233,9 +229,7 @@ class PersistentMap(
         with self._inner.mutate() as m:
             try:
                 for elem in elems:
-                    if isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-                        elem, (IPersistentMap, Mapping)
-                    ):
+                    if isinstance(elem, (IPersistentMap, Mapping)):
                         for k, v in elem.items():
                             m.set(k, v)
                     elif isinstance(elem, IMapEntry):
@@ -245,10 +239,10 @@ class PersistentMap(
                     else:
                         entry: IMapEntry[K, V] = MapEntry.from_vec(elem)
                         m.set(entry.key, entry.value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError) as e:
                 raise ValueError(
                     "Argument to map conj must be another Map or castable to MapEntry"
-                )
+                ) from e
             else:
                 return PersistentMap(m.finish(), meta=self.meta)
 

--- a/src/basilisp/lang/multifn.py
+++ b/src/basilisp/lang/multifn.py
@@ -30,7 +30,6 @@ class MultiFunction(Generic[T]):
         "_isa",
     )
 
-    # pylint:disable=assigning-non-slot
     def __init__(
         self,
         name: sym.Symbol,

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -87,7 +87,7 @@ def map_lrepr(
 
     def entry_reprs():
         for k, v in entries():
-            yield "{k} {v}".format(k=lrepr(k, **kwargs), v=lrepr(v, **kwargs))
+            yield f"{lrepr(k, **kwargs)} {lrepr(v, **kwargs)}"
 
     trailer = []
     print_dup = kwargs["print_dup"]

--- a/src/basilisp/lang/promise.py
+++ b/src/basilisp/lang/promise.py
@@ -6,7 +6,6 @@ from basilisp.lang.interfaces import IBlockingDeref
 T = TypeVar("T")
 
 
-# pylint: disable=assigning-non-slot
 class Promise(IBlockingDeref[T]):
     __slots__ = ("_condition", "_is_delivered", "_value")
 

--- a/src/basilisp/lang/queue.py
+++ b/src/basilisp/lang/queue.py
@@ -84,15 +84,11 @@ class PersistentQueue(IPersistentList[T], IWithMeta, ILispObject):
 EMPTY: PersistentQueue = PersistentQueue(pdeque())
 
 
-def queue(members, meta=None) -> PersistentQueue:  # pylint:disable=redefined-builtin
+def queue(members, meta=None) -> PersistentQueue:
     """Creates a new queue."""
-    return PersistentQueue(  # pylint: disable=abstract-class-instantiated
-        pdeque(iterable=members), meta=meta
-    )
+    return PersistentQueue(pdeque(iterable=members), meta=meta)
 
 
 def q(*members, meta=None) -> PersistentQueue:  # noqa
     """Creates a new queue from members."""
-    return PersistentQueue(  # pylint: disable=abstract-class-instantiated
-        pdeque(iterable=members), meta=meta
-    )
+    return PersistentQueue(pdeque(iterable=members), meta=meta)

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -254,15 +254,15 @@ def _py_list_from_vec(form: vec.PersistentVector) -> list:
 def _inst_from_str(inst_str: str) -> datetime:
     try:
         return langutil.inst_from_str(inst_str)
-    except (ValueError, OverflowError):
-        raise SyntaxError(f"Unrecognized date/time syntax: {inst_str}")
+    except (ValueError, OverflowError) as e:
+        raise SyntaxError(f"Unrecognized date/time syntax: {inst_str}") from e
 
 
 def _uuid_from_str(uuid_str: str) -> uuid.UUID:
     try:
         return langutil.uuid_from_str(uuid_str)
-    except (ValueError, TypeError):
-        raise SyntaxError(f"Unrecognized UUID format: {uuid_str}")
+    except (ValueError, TypeError) as e:
+        raise SyntaxError(f"Unrecognized UUID format: {uuid_str}") from e
 
 
 class ReaderContext:
@@ -425,10 +425,10 @@ class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
                     )
                 found_features.add(k)
                 feature_list.append((k, v))
-        except ValueError:
+        except ValueError as e:
             raise SyntaxError(
                 "Reader conditionals must contain an even number of forms"
-            )
+            ) from e
 
         return vec.vector(feature_list)
 
@@ -690,8 +690,8 @@ def _read_map(
             if k in d:
                 raise ctx.syntax_error(f"Duplicate key '{k}' in map literal")
             d[k] = v
-    except ValueError:
-        raise ctx.syntax_error("Unexpected token '}'; expected map value")
+    except ValueError as e:
+        raise ctx.syntax_error("Unexpected token '}'; expected map value") from e
     else:
         return lmap.map(d)
 
@@ -748,10 +748,10 @@ def _read_num(  # noqa: C901  # pylint: disable=too-many-statements
                 try:
                     for _ in chars:
                         reader.pushback()
-                except IndexError:
+                except IndexError as e:
                     raise ctx.syntax_error(
                         "Requested to pushback too many characters onto StreamReader"
-                    )
+                    ) from e
                 return _read_sym(ctx)
             chars.append(token)
             continue
@@ -1245,8 +1245,8 @@ def _read_regex(ctx: ReaderContext) -> Pattern:
     s = _read_str(ctx, allow_arbitrary_escapes=True)
     try:
         return langutil.regex_from_str(s)
-    except re.error:
-        raise ctx.syntax_error(f"Unrecognized regex pattern syntax: {s}")
+    except re.error as e:
+        raise ctx.syntax_error(f"Unrecognized regex pattern syntax: {s}") from e
 
 
 _NUMERIC_CONSTANTS = {
@@ -1609,7 +1609,7 @@ def read_file(  # pylint: disable=too-many-arguments
 
     Keyword arguments to this function have the same meanings as those of
     basilisp.lang.reader.read."""
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         yield from read(
             f,
             resolver=resolver,

--- a/src/basilisp/lang/reference.py
+++ b/src/basilisp/lang/reference.py
@@ -24,7 +24,7 @@ else:
         def __call__(
             self, meta: Optional[IPersistentMap], *args
         ) -> Optional[IPersistentMap]:
-            ...  # pylint: disable=pointless-statement
+            ...
 
 
 class ReferenceBase(IReference):

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -814,7 +814,6 @@ class Namespace(ReferenceBase):
 
         return is_match
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_alias(
         self, prefix: str, name_in_ns: Optional[str] = None
     ) -> Iterable[str]:
@@ -863,7 +862,6 @@ class Namespace(ReferenceBase):
             for candidate_name, _ in candidates:
                 yield f"{candidate_name}/"
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_interns(
         self, value: str, include_private_vars: bool = True
     ) -> Iterable[str]:
@@ -882,7 +880,6 @@ class Namespace(ReferenceBase):
             filter(is_match, ((s, v) for s, v in self.interns.items())),
         )
 
-    # pylint: disable=unnecessary-comprehension
     def __complete_refers(self, value: str) -> Iterable[str]:
         """Return an iterable of possible completions matching the given
         prefix from the list of referred Vars."""
@@ -943,8 +940,10 @@ def pop_thread_bindings() -> None:
     """Pop the thread local bindings set by push_thread_bindings above."""
     try:
         bindings = _THREAD_BINDINGS.pop_bindings()
-    except IndexError:
-        raise RuntimeException("cannot pop thread-local bindings without prior push")
+    except IndexError as e:
+        raise RuntimeException(
+            "cannot pop thread-local bindings without prior push"
+        ) from e
 
     for var in bindings:
         var.pop_bindings()
@@ -1109,8 +1108,10 @@ def count(coll) -> int:
     except (AttributeError, TypeError):
         try:
             return sum(1 for _ in coll)
-        except TypeError:
-            raise TypeError(f"count not supported on object of type {type(coll)}")
+        except TypeError as e:
+            raise TypeError(
+                f"count not supported on object of type {type(coll)}"
+            ) from e
 
 
 __nth_sentinel = object()

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -101,7 +101,6 @@ class _Sequence(IWithMeta, ISequential, ISeq[T]):
 
     __slots__ = ("_first", "_seq", "_rest", "_meta")
 
-    # pylint:disable=assigning-non-slot
     def __init__(
         self, s: Iterator[T], first: T, *, meta: Optional[IPersistentMap] = None
     ) -> None:
@@ -125,7 +124,6 @@ class _Sequence(IWithMeta, ISequential, ISeq[T]):
     def first(self) -> Optional[T]:
         return self._first
 
-    # pylint:disable=assigning-non-slot
     @property
     def rest(self) -> "ISeq[T]":
         if self._rest:

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -16,7 +16,7 @@ from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
 
 try:
-    from immutables._map import MapMutation  # pylint: disable=unused-import
+    from immutables._map import MapMutation
 except ImportError:
     from immutables.map import MapMutation  # type: ignore[assignment]
 
@@ -103,9 +103,7 @@ class PersistentSet(
     def __eq__(self, other):
         if self is other:
             return True
-        if not isinstance(  # pylint: disable=isinstance-second-argument-not-valid-type
-            other, AbstractSet
-        ):
+        if not isinstance(other, AbstractSet):
             return NotImplemented
         return _PySet.__eq__(self, other)
 

--- a/src/basilisp/lang/symbol.py
+++ b/src/basilisp/lang/symbol.py
@@ -22,7 +22,7 @@ class Symbol(ILispObject, IWithMeta):
         print_meta = kwargs["print_meta"]
 
         if self._ns is not None:
-            sym_repr = "{ns}/{name}".format(ns=self._ns, name=self._name)
+            sym_repr = f"{self._ns}/{self._name}"
         else:
             sym_repr = self._name
 

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -2,7 +2,7 @@ from functools import total_ordering
 from typing import Iterable, Optional, Sequence, TypeVar, Union
 
 from pyrsistent import PVector, pvector  # noqa # pylint: disable=unused-import
-from pyrsistent.typing import PVectorEvolver  # pylint:disable=unused-import
+from pyrsistent.typing import PVectorEvolver
 
 from basilisp.lang.interfaces import (
     IEvolveableCollection,
@@ -26,7 +26,7 @@ class TransientVector(ITransientVector[T]):
     __slots__ = ("_inner",)
 
     def __init__(self, wrapped: "PVectorEvolver[T]") -> None:
-        self._inner = wrapped  # pylint: disable=assigning-non-slot
+        self._inner = wrapped
 
     def __bool__(self):
         return True

--- a/src/basilisp/util.py
+++ b/src/basilisp/util.py
@@ -24,7 +24,7 @@ class Maybe(Generic[T]):
     __slots__ = ("_inner",)
 
     def __init__(self, inner: Optional[T]) -> None:
-        self._inner = inner  # pylint:disable=assigning-non-slot
+        self._inner = inner
 
     def __eq__(self, other):
         if isinstance(other, Maybe):

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ commands =
 
 [testenv:py{38,39,310}-lint]
 deps =
-    prospector==1.3.1
+    prospector
     pytest
     sphinx
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-isolated_build = true
 envlist = py38,py39,py310,pypy3,coverage,py{38,39,310}-mypy,py{38,39,310}-lint,format,safety
 
 [testenv]
-whitelist_externals = poetry
+allowlist_externals = poetry
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
 setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true


### PR DESCRIPTION
Update to the latest Prospector version (1.10.2 as of this PR) and then remove the unnecessary suppressions and fix the new errors it found.