### PR TITLE
Trigger test runs only on PRs rather than push

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push]
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  push:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
Per [this thread](https://github.com/orgs/community/discussions/36561) it seems that I needed to change the trigger for the workflow to `pull_request` rather than `push` to get builds in the base repo.