### PR TITLE
`case` should only evaluate the matching clause expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ * Fix issue with `case` evaluating all of its clauses expressions (#699).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3409,25 +3409,30 @@
   (let [default (if (odd? (count clauses))
                   (last clauses)
                   :basilisp.core.case/no-default)
-        pairs   (mapcat identity
-                        (mapcat (fn [pair]
-                                  (let [binding (first pair)
-                                        expr    (second pair)]
-                                    (if (list? binding)
-                                      (map #(vector (list 'quote %) expr) binding)
-                                      [[(list 'quote binding) expr]])))
-                                (partition 2
-                                           (if (= default :basilisp.core.case/no-default)
-                                             clauses
-                                             (drop-last clauses)))))
-        expr-gs (gensym "expr")]
-    `(let [~expr-gs ~expr
-           m#       ~(apply hash-map pairs)]
-       (if-not (contains? m# ~expr-gs)
-         ~(if (= default :basilisp.core.case/no-default)
-            `(throw (python/ValueError (str "No case clause matches " ~expr-gs)))
-            `~default)
-         (get m# ~expr-gs)))))
+        pairs   (mapcat (fn [pair]
+                          (let [binding (first pair)
+                                expr    (second pair)]
+                            (if (list? binding)
+                              (map #(vector % expr) binding)
+                              [[binding expr]])))
+                        (partition 2
+                                   (if (= default :basilisp.core.case/no-default)
+                                     clauses
+                                     (drop-last clauses))))
+        expr-gs (gensym "expr")
+        pairs-cond (mapcat identity (map (fn [pair]
+                                           (let [t (first pair)
+                                                 e (second pair)]
+                                             (list `(= ~expr-gs ~(if (symbol? t)
+                                                                   `'~t
+                                                                   t)) e)))
+                                         pairs))
+        pairs-cond-else (concat pairs-cond
+                                [:else `(if (= ~default :basilisp.core.case/no-default)
+                                          (throw (python/ValueError (str "No case clause matches " ~expr-gs)))
+                                          ~default)])]
+    `(let [~expr-gs ~expr]
+       (cond ~@pairs-cond-else))))
 
 (defmacro condp
   "Take a predicate and an expression and a series of clauses, call ``(pred test expr)``

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3401,7 +3401,8 @@
 
   The clauses are pairs of a matching value and a return value. The matching values are
   not evaluated and must be compile-time constants. Symbols will not be resolved. Lists
-  may be passed to match multiple compile time values to a single return value."
+  may be passed to match multiple compile time values to a single return value. The
+  dispatch is done in constant time."
   [expr & clauses]
   (when (< (count clauses) 2)
     (throw (ex-info "case expression must have at least one clause"
@@ -3409,30 +3410,25 @@
   (let [default (if (odd? (count clauses))
                   (last clauses)
                   :basilisp.core.case/no-default)
-        pairs   (mapcat (fn [pair]
-                          (let [binding (first pair)
-                                expr    (second pair)]
-                            (if (list? binding)
-                              (map #(vector % expr) binding)
-                              [[binding expr]])))
-                        (partition 2
-                                   (if (= default :basilisp.core.case/no-default)
-                                     clauses
-                                     (drop-last clauses))))
-        expr-gs (gensym "expr")
-        pairs-cond (mapcat identity (map (fn [pair]
-                                           (let [t (first pair)
-                                                 e (second pair)]
-                                             (list `(= ~expr-gs ~(if (symbol? t)
-                                                                   `'~t
-                                                                   t)) e)))
-                                         pairs))
-        pairs-cond-else (concat pairs-cond
-                                [:else `(if (= ~default :basilisp.core.case/no-default)
-                                          (throw (python/ValueError (str "No case clause matches " ~expr-gs)))
-                                          ~default)])]
-    `(let [~expr-gs ~expr]
-       (cond ~@pairs-cond-else))))
+        pairs   (mapcat identity
+                        (mapcat (fn [pair]
+                                  (let [binding (first pair)
+                                        expr    `(fn [] ~(second pair))]
+                                    (if (list? binding)
+                                      (map #(vector (list 'quote %) expr) binding)
+                                      [[(list 'quote binding) expr]])))
+                                (partition 2
+                                           (if (= default :basilisp.core.case/no-default)
+                                             clauses
+                                             (drop-last clauses)))))
+        expr-gs (gensym "expr")]
+    `(let [~expr-gs ~expr
+           m#       ~(apply hash-map pairs)]
+       (if-not (contains? m# ~expr-gs)
+         ~(if (= default :basilisp.core.case/no-default)
+            `(throw (python/ValueError (str "No case clause matches " ~expr-gs)))
+            `~default)
+         ((get m# ~expr-gs))))))
 
 (defmacro condp
   "Take a predicate and an expression and a series of clauses, call ``(pred test expr)``

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -326,6 +326,13 @@
   (is (= "also no" (case 'c :a "no" (b c d) "also no" "duh")))
   (is (= "also no" (case 'd :a "no" (b c d) "also no" "duh")))
   (is (= "duh" (case 'e :a "no" (b c d) "also no" "duh")))
+  (let [out* (atom [])]
+    (is (= 2 (case :2
+               :1 (do (swap! out* conj 1) 1)
+               :2 (do (swap! out* conj 2) 2)
+               :3 (do (swap! out* conj 3) 3)
+               (do (swap! out* conj 4) 4))))
+    (is (= [2] @out*)))
   (is (thrown? python/ValueError
                (case "da" :b "nope" :c "mega nope" :a "yes"))))
 


### PR DESCRIPTION
Hi,

can you please consider a patch to evaluate only the expression that matches the clause. It fixes #699 .

The issue was that `~(apply hash-map pairs)` evaluated all the clauses expressions.

With this update, the clauses are turned into `cond` clauses, taking extra case to quote any symbol bindings.

I tried to keep as match of the old code as possible, I could not think of any other way of doing so. It seems as if this requires a special form to as not to evaluate the clauses (e.g. `cond`). The drawback with this approach is that we went from O(1) to find the right expr to return it's value, to O(n).

Feel free to update or discard in case there is an obvious better solution.

I've included a test to confirm the same.

Thanks,

(the corresponding def in clojure-1.11 is [quite involved](https://github.com/clojure/clojure/blob/ce55092f2b2f5481d25cff6205470c1335760ef6/src/clj/clojure/core.clj#L6748))