### PR TITLE
Fix issue with relative MS-windows paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
  * Fix issue with `case` evaluating all of its clauses expressions (#699).
+ * Fix issue with relative paths dropping their first character on MS-Windows (#703).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/io.lpy
+++ b/src/basilisp/io.lpy
@@ -33,8 +33,8 @@
   (as-path [f]
     (if (contains? #{"file" ""} (.-scheme f))
       (let [path (.-path f)]
-        (if (= sys/platform "win32")
-          ;; On MS-Windows, extracting the path from the URL
+        (if (and (= sys/platform "win32") (os.path/isabs path))
+          ;; On MS-Windows, extracting an absolute path from the URL
           ;; incorrectly adds a leading `/', .e.g. /C:\xyz.
           (pathlib/Path (subs path 1))
 

--- a/tests/basilisp/test_io.lpy
+++ b/tests/basilisp/test_io.lpy
@@ -162,7 +162,18 @@
       (testing "cannot write read-only file"
         (with-open [f (python/open path ** :mode "r")]
           (is (thrown? basilisp.lang.exception/ExceptionInfo
-                       (spit f "some content")))))))
+                       (spit f "some content")))))
+
+      (testing "relative path"
+        (let [[fd filename] (tempfile/mkstemp ** :dir "." :prefix "test-rel-path-")]
+          (try
+            (let [filename-rel (os.path/relpath filename ".")]
+              (with-open [f (python/open filename-rel ** :mode "w")]
+                (spit f "hello rel"))
+              (is (= "hello rel" (slurp filename-rel))))
+            (finally
+              (os/close fd)
+              (os/unlink filename)))))))
 
   (testing "http requests"
     (let [url (str "http://localhost:" *http-port* "/writer-http-req.txt")]


### PR DESCRIPTION
Hi,

can you please consider a fix for not dropping the first character of paths on MS-windows. It fixes #703.

This issue was introduced with a fix in #688 where the redundant first char should only be dropped from absolute paths.

I've added a test for the same.

Thanks