### PR TITLE
Migrate Makefile to babashka tasks

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,25 @@
+{:tasks
+ {:requires [[babashka.fs :as fs]]
+
+  docs (shell "poetry" "run" "sphinx-build" "-M" "html" "./docs" "./docs/_build")
+
+  format (shell "poetry" "run" "sh" "-c" "isort . && black .")
+
+  repl (shell {:extra-env {"BASILISP_USE_DEV_LOGGER" "true"}} "poetry run basilisp repl")
+
+  test (do (doseq [cov (fs/list-dir "." ".coverage*")]
+             (fs/delete-tree cov))
+           (shell {:extra-env {"TOX_SKIP_ENV" "pypy3|safety|coverage"}} "poetry run tox run-parallel -p 4"))
+
+  lispcore.py (do (shell {:extra-env {"BASILISP_USE_DEV_LOGGER" "true"}}
+                         "poetry" "run" "basilisp" "run" "-c"
+                         "(spit \"lispcore.py\" @#'basilisp.core/*generated-python*)")
+                  (shell "poetry run black lispcore.py"))
+
+  clean (fs/delete-tree "./lispcore.py")
+
+  pypy-shell (shell "docker run -it
+		--mount src=`pwd`,target=/usr/src/app,type=bind
+		--workdir /usr/src/app
+		pypy:3.10-7.3-slim-buster
+		/bin/sh -c 'pip install -e . && basilisp repl'")}}


### PR DESCRIPTION
Hi,

please find a suggested `bb.edn` file to migrate the `Makefile` to a cross system compatible build file. It addresses #702.

Installation instructions for babashka can be found at https://github.com/babashka/babashka#installation

Once installed,

bb tasks should give a list of tasks as found in bb.edn
``` shell
$ bb tasks

The following tasks are available:

docs
format
repl
test
lispcore.py
clean
pypy-shell
```

and can invoked with `bb <task>`

``` powershell
$ bb repl
basilisp.user=> (println 123)

123
nil

basilisp.user=>
```

Info about babashka tasks can be found at https://book.babashka.org/#tasks

Thanks

Some observations that apply to the tasks (as found in Makefile)

1. `format`: It tries to format everything found under `.`, this includes `venv` (where I store my environment) and `.tox`, should it only look at `src` though and perhaps `test`?
2. `test`: it tries to test all python versions configured in `tox`, so if say I'm working on python311 it will also try to invoke python 3.8 etc and fail since the comp can't be picked up. Should this only be invoked for the current python version? or perhaps I'm missing something.
