### PR TITLE
Fix for (str nil) to return the empty string

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -20,6 +20,7 @@ ignore-paths:
   - pip-wheel-metadata
   - lispcore.py
   - tests
+  - venv
 
 pep8:
   disable:

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -20,7 +20,6 @@ ignore-paths:
   - pip-wheel-metadata
   - lispcore.py
   - tests
-  - venv
 
 pep8:
   disable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
  * Fix issue with `case` evaluating all of its clauses expressions (#699).
  * Fix issue with relative paths dropping their first character on MS-Windows (#703).
+ * Fix incompatibility with `(str nil)` returning "nil" (#706).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/contrib/sphinx/domain.py
+++ b/src/basilisp/contrib/sphinx/domain.py
@@ -135,6 +135,9 @@ class BasilispObject(PyObject):
         """Subclasses should implement this themselves."""
         return NotImplemented
 
+    def get_index_text(self, modname: str, name: Tuple[str, str]) -> str:
+        return "TODO"
+
     def add_target_and_index(
         self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
     ) -> None:

--- a/src/basilisp/contrib/sphinx/domain.py
+++ b/src/basilisp/contrib/sphinx/domain.py
@@ -135,9 +135,6 @@ class BasilispObject(PyObject):
         """Subclasses should implement this themselves."""
         return NotImplemented
 
-    def get_index_text(self, modname: str, name: Tuple[str, str]) -> str:
-        return "TODO"
-
     def add_target_and_index(
         self, name_cls: Tuple[str, str], sig: str, signode: desc_signature
     ) -> None:
@@ -152,7 +149,9 @@ class BasilispObject(PyObject):
         domain.note_var(fullname, self.objtype, node_id)
 
         if "noindexentry" not in self.options:
-            indextext = self.get_index_text(modname, name_cls)
+            indextext = self.get_index_text(  # pylint: disable=assignment-from-no-return, useless-suppression
+                modname, name_cls
+            )
             if indextext:
                 self.indexnode["entries"].append(
                     ("single", indextext, node_id, "", None)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -482,7 +482,7 @@
 
   Return the empty string if ``o`` is nil."
   ([] "")
-  ([o] (basilisp.lang.runtime/lstr o))
+  ([o] (if (nil? o) "" (basilisp.lang.runtime/lstr o)))
   ([o & args]
    (let [coerce (fn [in out]
                   (let [item (first in)
@@ -4174,13 +4174,13 @@
   :lpy:var:`*print-sep*` (default is an ASCII space)."
   ([] (print ""))
   ([x]
-   (.write *out* (str x))
+   (.write *out* (basilisp.lang.runtime/lstr x))
    nil)
   ([x & args]
    (let [stdout    *out*
          sep       *print-sep*
-         repr-args (interpose sep (map str args))]
-     (.write stdout (str x))
+         repr-args (interpose sep (map basilisp.lang.runtime/lstr args))]
+     (.write stdout (basilisp.lang.runtime/lstr x))
      (.write stdout sep)
      (.write stdout (apply str repr-args))
      nil)))
@@ -4193,14 +4193,14 @@
   ([] (println ""))
   ([x]
    (let [stdout *out*]
-     (.write stdout (str x))
+     (.write stdout (basilisp.lang.runtime/lstr x))
      (.write stdout \newline)
      nil))
   ([x & args]
    (let [stdout    *out*
          sep       *print-sep*
-         repr-args (interpose sep (map str args))]
-     (.write stdout (str x))
+         repr-args (interpose sep (map basilisp.lang.runtime/lstr args))]
+     (.write stdout (basilisp.lang.runtime/lstr x))
      (.write stdout sep)
      (.write stdout (apply str repr-args))
      (.write stdout \newline)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -472,16 +472,25 @@
     (recur (rest s))
     (first s)))
 
+(defn  ^:inline nil?
+  "Return ``true`` if ``x`` is ``nil``\\, otherwise ``false``\\."
+  [x]
+  (operator/is- x nil))
+
 (defn str
-  "Create a string representation of ``o``."
+  "Create a string representation of ``o``.
+
+  Return the empty string if ``o`` is nil."
   ([] "")
   ([o] (basilisp.lang.runtime/lstr o))
   ([o & args]
    (let [coerce (fn [in out]
-                  (if (seq (rest in))
-                    (recur (rest in)
-                           (conj out (basilisp.lang.runtime/lstr (first in))))
-                    (conj out (basilisp.lang.runtime/lstr (first in)))))
+                  (let [item (first in)
+                        repr (if (nil? item) "" (basilisp.lang.runtime/lstr item))]
+                    (if (seq (rest in))
+                      (recur (rest in)
+                             (conj out repr))
+                      (conj out repr))))
          strs   (coerce (conj args o) [])]
      (.join "" strs))))
 

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1050,6 +1050,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest str-test
+  (is (= "" (str nil)))
   (is (= "ab" (str "a" nil "b"))))
 
 (deftest subs-test

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1049,6 +1049,9 @@
 ;; String Functions ;;
 ;;;;;;;;;;;;;;;;;;;;;;
 
+(deftest str-test
+  (is (= "ab" (str "a" nil "b"))))
+
 (deftest subs-test
   (is (= "" (subs "" 0)))
   (is (thrown? python/IndexError (subs "" 3)))

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1434,7 +1434,7 @@
     (is (= [[{:nested {:a "A"} :a "a" :b "b"}
              {:nested {:a "C"} :a "c" :b "d"}
              {:a "e" :b "e"}]
-            "AbCdnile"]
+            "AbCde"]
            (loop [items [{:nested {:a "A"} :a "a" :b "b"}
                          {:nested {:a "C"} :a "c" :b "d"}
                          {:a "e" :b "e"}]


### PR DESCRIPTION
Hi,

could you please consider compatibility fix with Clojure for `(str nil)` to return the empty string. It fixes #706.

I have added a basic test for it and also corrected one that was inserting `nil` while concatenating strings.

I've also had to move `nil?` forward to use it in `str`.

Thanks