### PR TITLE
Evalue (is (= exp act)) only once when failing the equality test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix incompatibility with `(str nil)` returning "nil" (#706).
  * Fix `sort-by` support for maps and boolean comparator fns (#709).
  * Fix `sort` support for maps and boolean comparator fns (#711).
+ * Fix `(is (= exp act))` should only evaluate its args once on failure (#712).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -78,17 +78,19 @@
 
 (defmethod gen-assert '=
   [expr msg line-num]
-  `(when-not ~expr
-    (vswap! *test-failures*
-            conj
-            {:test-name    *test-name*
-             :test-section *test-section*
-             :message      ~msg
-             :expr         (quote ~expr)
-             :actual       ~(nth expr 2)
-             :expected     ~(second expr)
-             :line         ~line-num
-             :type         :failure})))
+  `(let [actual# ~(nth expr 2)
+         expected# ~(second expr)]
+     (when-not (= expected# actual#)
+       (vswap! *test-failures*
+               conj
+               {:test-name    *test-name*
+                :test-section *test-section*
+                :message      ~msg
+                :expr         (quote ~expr)
+                :actual       actual#
+                :expected     expected#
+                :line         ~line-num
+                :type         :failure}))))
 
 (defmethod gen-assert 'thrown?
   [expr msg line-num]


### PR DESCRIPTION
Hi,

could you please review patch to have `(is (= exp act)` evaluate its argument only once when failing. It fixes #712.

Previously, the arguments were evaluated once in the `when` close, and then once more in the `:actual` and `:expected` keys.

I haven't introduced a test case, because this issue manifest itself only when the test fails, which inadvertently will fail the test suite. Thus I was expecting perhaps you could reason about its behavior for the review? 
(Though now that I think of it, it might be possible to write a test case for the `gen-assert` multimethod  rather than the `is` case which will fail the test suite)

Here are the result running the same test in #712 with the fix, it only prints `:5` once as expected this time:
``` clojure
basilisp.user=> (require '[basilisp.test :refer [deftest is]])
nil

basilisp.user=> (deftest issue
                    (is (= 8 (println :5))))
#'basilisp.user/issue

basilisp.user=> (issue)
:5
{:failures [{:actual nil :message "Test failure: (= 8 (println :5))" :test-section nil :type :failure :expr (= 8 (println :5)) :expected 8 :test-name "issue" :line 2}]}
```

Thanks