### PR TITLE
Fix issue with `with` failing with traceback error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix `sort-by` support for maps and boolean comparator fns (#709).
  * Fix `sort` support for maps and boolean comparator fns (#711).
  * Fix `(is (= exp act))` should only evaluate its args once on failure (#712).
+ * Fix issue with `with` failing with a traceback error when an exception is thrown (#714).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3716,7 +3716,7 @@
            res#)
          (catch python/Exception e#
            (vreset! hit-except# true)
-           (when-not (. obj# (~'__exit__ (python/type e#) e# (. e# ~'__traceback__)))
+           (when-not (. obj# (~'__exit__ (python/type e#) e# (.- e# ~'__traceback__)))
              (throw e#)))
          (finally
            (when-not @hit-except#

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1,5 +1,5 @@
 (ns tests.basilisp.test-core-macros
-  (:import inspect os tempfile)
+  (:import inspect os socket tempfile)
   (:require
    [basilisp.test :refer [deftest is testing]]))
 
@@ -450,15 +450,21 @@
   (is (= #py ["A" "B" "C"] (.. "a,b,c" upper (split ",")))))
 
 (deftest with-test
-  (let [[fh filename] (tempfile/mkstemp)]
-    (try
-      (with-open [file (python/open filename "w")]
-        (.write file "Testing text"))
-      (with-open [file (python/open filename)]
-        (is (= "Testing text" (.read file))))
-      (finally
-        (os/close fh)
-        (os/unlink filename)))))
+  (testing "basic"
+    (let [[fh filename] (tempfile/mkstemp)]
+      (try
+        (with-open [file (python/open filename "w")]
+          (.write file "Testing text"))
+        (with-open [file (python/open filename)]
+          (is (= "Testing text" (.read file))))
+        (finally
+          (os/close fh)
+          (os/unlink filename)))))
+
+  (testing "exceptions"
+    (is (thrown? python/FloatingPointError
+                 (with [sock (socket/socket socket/AF_INET socket/SOCK_STREAM)]
+                       (throw python/FloatingPointError))))))
 
 (deftest if-let-test
   (is (= :a (if-let [a :a] a :b)))


### PR DESCRIPTION
Hi,

could you please fix for `with` to not fail with traceback error when an exception is thrown. It fixes #714 .

It seems that the `with` macro expected the `__traceback__` field of an exception to be a method, but it is rather a __field__
https://docs.python.org/3/library/traceback.html
> The module uses traceback objects — these are objects of type [types.TracebackType](https://docs.python.org/3/library/types.html#types.TracebackType), which are assigned to the __traceback__ field of [BaseException](https://docs.python.org/3/library/exceptions.html#BaseException) instances.

For some reason this issue does not manifest with `python/open` resources, as if the `__enter__` magic method is not hit (or perhaps it is lazy gc and it will eventually happen).

I've added a test for the same.

Thanks,
