### PR TITLE
Adress issue with `intern` not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix `(is (= exp act))` should only evaluate its args once on failure (#712).
  * Fix issue with `with` failing with a traceback error when an exception is thrown (#714).
  * Fix issue with `sort-*` family of funtions returning an error on an empty seq (#716).
+ * Fix issue with `intern` failing when used (#725).
 
 ## [v0.1.0a2]
 ### Added

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx~=4.4.0
+sphinx-rtd-theme==1.3.0

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4533,13 +4533,13 @@
   the root binding to ``val``\\, if provided. The namespace must exist. Return the Var."
   ([ns name]
    (let [ns (the-ns ns)
-         v  (basilisp.lang.runtime/Var ns name)]
-     (.intern ns v)))
+         v  (basilisp.lang.runtime/Var ns name ** :meta {:ns ns :name name})]
+     (.intern ns name v)))
   ([ns name val]
    (let [ns (the-ns ns)
-         v  (basilisp.lang.runtime/Var ns name)]
-     (.set-root v val)
-     (.intern ns v))))
+         v  (basilisp.lang.runtime/Var ns name ** :meta {:ns ns :name name})]
+     (.bind-root v val)
+     (.intern ns name v))))
 
 (defn ^:inline create-ns
   "Create a Namespace with the name ``ns-sym`` or return the existing one if it already

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -333,7 +333,7 @@ class AnalyzerContext:
         self._func_ctx: Deque[FunctionContext] = collections.deque([])
         self._is_quoted: Deque[bool] = collections.deque([])
         self._opts = (
-            Maybe(opts).map(lmap.map).or_else_get(lmap.PersistentMap.empty())  # type: ignore
+            Maybe(opts).map(lmap.map).or_else_get(lmap.PersistentMap.empty())  # type: ignore[arg-type, unused-ignore]
         )
         self._recur_points: Deque[RecurPoint] = collections.deque([])
         self._should_macroexpand = should_macroexpand

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -3527,7 +3527,7 @@ def _const_type_to_py_ast(form: IType, ctx: GeneratorContext) -> GeneratedPyAST:
 
     ctor_args = []
     ctor_arg_deps: List[ast.AST] = []
-    for field in attr.fields(tp):  # type: ignore[arg-type]
+    for field in attr.fields(tp):  # type: ignore[arg-type, misc, unused-ignore]
         field_nodes = _const_val_to_py_ast(getattr(form, field.name, None), ctx)
         ctor_args.append(field_nodes.node)
         ctor_args.extend(field_nodes.dependencies)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1963,7 +1963,7 @@ def add_generated_python(
         which_ns = get_current_ns()
     v = Maybe(which_ns.find(sym.symbol(GENERATED_PYTHON_VAR_NAME))).or_else(
         lambda: Var.intern(
-            which_ns,  # type: ignore
+            which_ns,  # type: ignore[arg-type, unused-ignore]
             sym.symbol(GENERATED_PYTHON_VAR_NAME),
             "",
             dynamic=True,

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1363,6 +1363,39 @@
   ;; a valid symbol in that namespace
   (is (= (resolve 'basilisp.shell/sh) (requiring-resolve 'basilisp.shell/sh))))
 
+(deftest intern-test
+  (let [ns-sym (gensym "intern-test-ns")
+        ns0 (create-ns ns-sym)]
+    (testing "unbound"
+      (let [sym (gensym "intern-test")
+            v (intern ns0 sym)
+            {:keys [name ns] :as m} (meta v)]
+        (is (= ns0 ns))
+        (is (= sym name))
+        (is (= false (.-is-bound v)))))
+
+    (testing "unbound ns-sym"
+      (let [sym (gensym "intern-test")
+            v (intern ns-sym sym)
+            {:keys [name ns] :as m} (meta v)]
+        (is (= ns0 ns))
+        (is (= sym name))
+        (is (= false (.-is-bound v)))))
+
+    (testing "bound"
+      (let [sym (gensym "intern-test")
+            v (intern ns0 sym 5)
+            {:keys [name ns] :as m} (meta v)]
+        (is (= ns0 ns))
+        (is (= sym name))
+        (is (= true (.-is-bound v)))
+        (is (= 5 @v))
+        (is (= v (find-var (symbol (str ns0) (str sym))))))))
+
+
+  (testing "ns-not-exists"
+    (is (thrown? python/AttributeError (intern 'ns-non-existant 'xyz)))))
+
 ;;;;;;;;;;;;;;;;;
 ;; Hierarchies ;;
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi,

could you please review patch to fix `intern`. It addresses #724.

It was using var methods such as `.set-root` that don't exist.

Tests included.

Thanks