### PR TITLE
Fix issue with `ns` being unavail after `in-ns` during `eval` (#718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with `with` failing with a traceback error when an exception is thrown (#714).
  * Fix issue with `sort-*` family of funtions returning an error on an empty seq (#716).
  * Fix issue with `intern` failing when used (#725).
+ * Fix issue with `ns` not being available after `in-ns` on the REPL (#718).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -768,6 +768,13 @@ class Namespace(ReferenceBase):
         if ns is not None:
             return ns_cache
         new_ns = Namespace(name, module=module)
+        # The `ns` macro is important for setting up an new namespace,
+        # but it becomes available only after basilisp.core has been
+        # loaded.
+        ns_var = Var.find_in_ns(CORE_NS_SYM, sym.symbol("ns"))
+        if ns_var:
+            new_ns.add_refer(sym.symbol("ns"), ns_var)
+
         return ns_cache.assoc(name, new_ns)
 
     @classmethod

--- a/tests/basilisp/namespace_test.py
+++ b/tests/basilisp/namespace_test.py
@@ -32,6 +32,15 @@ def test_create_ns(ns_sym: sym.Symbol, ns_cache: atom.Atom[NamespaceMap]):
     assert isinstance(ns, Namespace)
     assert ns.name == ns_sym.name
     assert len(list(ns_cache.deref().keys())) == 2
+    assert ns.get_refer(sym.symbol("ns"))
+
+
+def test_in_ns(ns_sym: sym.Symbol):
+    in_ns = Var.find_in_ns(runtime.CORE_NS_SYM, sym.symbol("in-ns"))
+    assert in_ns
+    ns = in_ns.value(ns_sym)
+    assert isinstance(ns, Namespace)
+    assert ns.name == ns_sym.name
 
 
 @pytest.fixture

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2010,3 +2010,15 @@
             [:a2 "and this one!"]]
            @a2-atom))
     (is (= [] @b-atom))))
+
+
+;;;;;;;;;;
+;; eval ;;
+;;;;;;;;;;
+
+(deftest eval-test
+  (testing "can ns after in-ns"
+    (binding [*ns* *ns*]
+      (eval '(in-ns 'test-core-fns.ns-after-in-ns))
+      (eval '(ns test-core-fns.ns-after-in-ns))
+      (is (= *ns* (the-ns 'test-core-fns.ns-after-in-ns))))))


### PR DESCRIPTION
Hi can you please review patch to fix the problem of `ns` becoming unavailable after executing `in-ns` in the context of the `eval` operation. It addresses #718.

(part of breaking the individual bugfixes from #723)

thanks