### PR TITLE
Fixed issue with import modules aliasing using ns eval (#719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with `sort-*` family of funtions returning an error on an empty seq (#716).
  * Fix issue with `intern` failing when used (#725).
  * Fix issue with `ns` not being available after `in-ns` on the REPL (#718).
+ * Fixed issue with import modules aliasing using ns eval (#719).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4642,7 +4642,13 @@
   Use of ``import`` directly is discouraged in favor of the ``:import`` directive in
   the :lpy:fn:`ns` macro."
   [& modules]
-  `(import* ~@modules))
+  ;; We need to use eval here, because there could have been an ns
+  ;; switch inside an eval earlier, and although *ns* is correctly set
+  ;; to the new ns, the global python namespace can still refer to the
+  ;; old python global ns where the import would have been evaluated
+  ;; otherwise.
+  (let [form `(import* ~@modules)]
+    `(eval '~form  *ns*)))
 
 (defn ^:private rewrite-clojure-libspec
   "Rewrite libspecs which point to namespaces starting with 'clojure.' to use a

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2021,4 +2021,10 @@
     (binding [*ns* *ns*]
       (eval '(in-ns 'test-core-fns.ns-after-in-ns))
       (eval '(ns test-core-fns.ns-after-in-ns))
-      (is (= *ns* (the-ns 'test-core-fns.ns-after-in-ns))))))
+      (is (= *ns* (the-ns 'test-core-fns.ns-after-in-ns)))))
+
+  (testing "eval ns with import aliases"
+    (binding [*ns* *ns*]
+      (eval '(ns test-core-fns.ns-with-import (:import [time :as time-alias])))
+      (is (= *ns* (the-ns 'test-core-fns.ns-with-import)))
+      (is (= "Thu Jan  1 00:00:01 1970" (eval '(time-alias/asctime (time-alias/gmtime 1))))))))


### PR DESCRIPTION
Hi,

could you please review patch to fix issue with import name aliasing in the context of an `eval` operation. It addresses #719.

(part of breaking the individual bugfixes from https://github.com/basilisp-lang/basilisp/pull/723)

Thanks.