### PR TITLE
Fixed issue with `ns-resolve` throwing error on macros (#720)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with `with` failing with a traceback error when an exception is thrown (#714).
  * Fix issue with `sort-*` family of funtions returning an error on an empty seq (#716).
  * Fix issue with `intern` failing when used (#725).
+ * Fix issue with `ns-resolve` throwing an error on macros (#720).
 
 ## [v0.1.0a2]
 ### Added

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1869,7 +1869,9 @@ def resolve_alias(s: sym.Symbol, ns: Optional[Namespace] = None) -> sym.Symbol:
 def resolve_var(s: sym.Symbol, ns: Optional[Namespace] = None) -> Optional[Var]:
     """Resolve the aliased symbol to a Var from the specified namespace, or the
     current namespace if none is specified."""
-    return Var.find(resolve_alias(s, ns))
+    ns_qualified_sym = resolve_alias(s, ns)
+    var = Var.find(resolve_alias(s, ns)) if ns_qualified_sym.ns else None
+    return var
 
 
 #######################

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1870,8 +1870,7 @@ def resolve_var(s: sym.Symbol, ns: Optional[Namespace] = None) -> Optional[Var]:
     """Resolve the aliased symbol to a Var from the specified namespace, or the
     current namespace if none is specified."""
     ns_qualified_sym = resolve_alias(s, ns)
-    var = Var.find(resolve_alias(s, ns)) if ns_qualified_sym.ns else None
-    return var
+    return Var.find(resolve_alias(s, ns)) if ns_qualified_sym.ns else None
 
 
 #######################

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1363,6 +1363,21 @@
   ;; a valid symbol in that namespace
   (is (= (resolve 'basilisp.shell/sh) (requiring-resolve 'basilisp.shell/sh))))
 
+(deftest ns-resolve-test
+  (is (= #'basilisp.core/apply (ns-resolve *ns* 'apply)))
+  (is (nil? (ns-resolve *ns* 'xyz)))
+
+  (is (= #'basilisp.set/union (ns-resolve *ns* 'basilisp.set/union)))
+  (is (= #'basilisp.set/union (ns-resolve *ns* 'set/union)))
+  (is (nil? (ns-resolve *ns* 'basilisp.set/xyz)))
+  (is (nil? (ns-resolve *ns* 'set/xyz)))
+
+  (is (= #'basilisp.test/is (ns-resolve *ns* 'is)))
+  (is (nil? (ns-resolve *ns* '*test-section*)))
+  (is (= #'basilisp.test/*test-section* (ns-resolve (the-ns 'basilisp.test) '*test-section*)))
+
+  (is (nil? (ns-resolve *ns* 'if))))
+
 (deftest intern-test
   (let [ns-sym (gensym "intern-test-ns")
         ns0 (create-ns ns-sym)]


### PR DESCRIPTION
Hi,

could you please consider patch to fix an issue with with `ns-resolve` erroring out on macros. It addresses #720.

(part of breaking the individual bugfixes from https://github.com/basilisp-lang/basilisp/pull/723)

Thanks