### PR TITLE
Added rudimentary support for basilisp.stacktrace/print-cause-trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ * Added rudimentary support for `clojure.stacktrace` with `print-cause-trace` (part of #721).
+
+### Fixed
  * Fix issue with `case` evaluating all of its clauses expressions (#699).
  * Fix issue with relative paths dropping their first character on MS-Windows (#703).
  * Fix incompatibility with `(str nil)` returning "nil" (#706).

--- a/src/basilisp/stacktrace.lpy
+++ b/src/basilisp/stacktrace.lpy
@@ -1,0 +1,13 @@
+(ns basilisp.stacktrace
+  "Prints stacktraces."
+  (:require [basilisp.string :as str])
+  (:import [traceback :as tb]))
+
+(defn print-cause-trace
+  "Prints the stacktrace of chained ``exc`` (cause), using ``n`` stack
+  frames (defaults to all)."
+  ([exc]
+   (print-cause-trace exc nil))
+  ([exc n]
+   (print (str/join " "  (tb/format_exception (python/type exc) exc (.-__traceback__ exc)
+                                              ** :limit n :chain true)))))

--- a/tests/basilisp/stacktrace_test.lpy
+++ b/tests/basilisp/stacktrace_test.lpy
@@ -1,0 +1,27 @@
+(ns tests.basilisp.stacktrace-test
+  (:require [basilisp.stacktrace :as s]
+            [basilisp.string :as str]
+            [basilisp.test :refer [deftest are is testing]]))
+
+
+(defn- exception-test []
+  (/ 5 0))
+
+(deftest stacktrace-basic
+  (try
+    (exception-test)
+    (catch python/Exception e
+      ;; one stack frame
+      (let [trace1 (-> (with-out-str (s/print-cause-trace e 1))
+                       (str/split-lines))]
+        (is (= 4 (count trace1)) trace1)
+        (is (= "Traceback (most recent call last):" (first trace1)))
+        (is (= ["    (try" " ZeroDivisionError: Fraction(5, 0)" ] (take-last 2 trace1))))
+
+      ;; full stack
+      (let [trace (-> (with-out-str (s/print-cause-trace e))
+                      (str/split-lines))]
+        (is (< 4 (count trace)) trace)
+        (is (= "Traceback (most recent call last):" (first trace)))
+        (is (= ["    raise ZeroDivisionError('Fraction(%s, 0)' % numerator)"
+                " ZeroDivisionError: Fraction(5, 0)" ] (take-last 2 trace)))))))


### PR DESCRIPTION
Hi,

could you please review patch to introduce a new namespace `basilisp.stacktrace` and a `print-cause-trace`. It partly addresses #721.

This is a requirement of the upcoming nbb nrepl-server port implemented in #723. CIDER specifically requests this function when an exception is thrown to display to the user, making it essential.

thanks