### PR TITLE
Deprecate `astor` for Python 3.9+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with `ns-resolve` throwing an error on macros (#720)
  * Fix issue with py module `readerwritelock` locks handling (#722)
 
+### Removed
+ * Removed the dependency `astor` for versions of Python 3.9+ (#736)
+
 ## [v0.1.0a2]
 ### Added
  * Added support for fixtures in `basilisp.test` (#654)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ include = ["README.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-astor = "^0.8.1"
 attrs = ">=20.1.0"
 immutables = "^0.15"
 prompt-toolkit = "^3.0.0"
@@ -38,6 +37,7 @@ pyrsistent = "^0.18.0"
 python-dateutil = "^2.8.1"
 readerwriterlock = "^1.0.8"
 
+astor = { version = "^0.8.1", python = "<3.9", optional = true }
 pytest = { version = "^6.2.5", optional = true }
 pygments = { version = "^2.9.0", optional = true }
 


### PR DESCRIPTION
Fixes #736