### PR TITLE
Fix issue with basilisp.io/writer :append failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed issue with import modules aliasing using ns eval (#719)
  * Fix issue with `ns-resolve` throwing an error on macros (#720)
  * Fix issue with py module `readerwritelock` locks handling (#722)
+ * Fix issue with basilisp.io/writer :append mode not working (#741).
 
 ### Removed
  * Removed the dependency `astor` for versions of Python 3.9+ (#736)

--- a/src/basilisp/io.lpy
+++ b/src/basilisp/io.lpy
@@ -80,7 +80,8 @@
 
 (defn- clean-writer-mode
   [opts]
-  (let [mode       (:mode opts "w")
+  (let [append?    (:append opts)
+        mode       (:mode opts "")
         clean-mode (cond
                      (:append opts)                 (str "a" mode)
                      (not (str/includes? mode "w")) (str "w" mode)
@@ -96,7 +97,8 @@
        (ex-info "Writers may only be open in write or append mode"
                 {:mode mode})))
 
-    (assoc opts :mode clean-mode)))
+    (-> (assoc opts :mode clean-mode)
+        (dissoc :append))))
 
 (defn- clean-binary-mode
   [opts]
@@ -324,6 +326,11 @@
 
   The writer instances returned are always text-based, not binary. In general, the
   writers should be compatible with Python's ``io.TextIOBase`` interface.
+
+  ``opts`` is an optional collection of keyword/value pairs
+  transmitted as a map to the writer. The acceptable keywords align
+  with those recognized by the fn:``open`` function. Moreover, setting the
+  :append option to true will configure the writer for append mode.
 
   Callers should take care to open a writer instance using
   :lpy:fn:`basilisp.core/with-open` to ensure that any resources are properly closed

--- a/tests/basilisp/test_io.lpy
+++ b/tests/basilisp/test_io.lpy
@@ -175,6 +175,22 @@
               (os/close fd)
               (os/unlink filename)))))))
 
+  (testing "writer local files"
+    (let [path (bio/path *tempdir* "writer-test-writer-local-files.txt")]
+      (testing "writer file object write"
+        (with-open [f (bio/writer path)]
+          (.write f "some file contents"))
+        (is (= "some file contents" (slurp path))))
+
+      (testing "writer file object append"
+        (with-open [f (bio/writer path :append true)]
+          (.write f " and then some more"))
+        (is (= "some file contents and then some more" (slurp path)))
+
+        (with-open [f (bio/writer path :append false)]
+          (.write f "some other content"))
+        (is (= "some other content" (slurp path))))))
+
   (testing "http requests"
     (let [url (str "http://localhost:" *http-port* "/writer-http-req.txt")]
       (is (thrown? basilisp.lang.exception/ExceptionInfo


### PR DESCRIPTION
Hi,

could you please review fix to make `basilisp.io/writer`'s :append true option working. It fixes #741.

I've also added some basic tests for it.

Thanks