### PR TITLE
fix issue with _test filename suffix in pytest testrunner

### DIFF
--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
 def pytest_collect_file(file_path: Path, path, parent):
     """Primary PyTest hook to identify Basilisp test files."""
     if file_path.suffix == ".lpy":
-        if file_path.name.startswith("test_") or file_path.name.endswith("_test"):
+        if file_path.name.startswith("test_") or file_path.stem.endswith("_test"):
             return BasilispFile.from_parent(parent, fspath=path, path=file_path)
     return None
 

--- a/tests/basilisp/test_stacktrace.lpy
+++ b/tests/basilisp/test_stacktrace.lpy
@@ -1,4 +1,4 @@
-(ns tests.basilisp.stacktrace-test
+(ns tests.basilisp.test-stacktrace
   (:require [basilisp.stacktrace :as s]
             [basilisp.string :as str]
             [basilisp.test :refer [deftest are is testing]]))


### PR DESCRIPTION
Hi, 

could you please review patch to fix a break with the  recent upgrade to pytest 7 in #738 in the circle CI coverage test. Fixes #740.

The `_test` suffix was not preperly identified as a basilisp test suffix, and was failing the coverage tests for `stacktrace_test.lpy`, which was not following the same pattern as of the other test files.

I've both fixed the testrunner to properly identifying these as before the upgrade, but also renamed the  above to `test_stacktrace.lpy` for conformity with the current pattern.

Thanks