### PR TITLE
Do not warn on unused bindings whose names begin with _

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777) 
  * Fix issue with the variadic ampersand operator treated as a binding in macros (#772)
 
+### Changed
+ * Do not warn on unused bindings when their name begins with `_` (#756).
+
 ## [v0.1.0b0]
 ### Added
  * Added rudimentary support for `clojure.stacktrace` with `print-cause-trace` (part of #721)

--- a/src/basilisp/contrib/bencode.lpy
+++ b/src/basilisp/contrib/bencode.lpy
@@ -15,7 +15,7 @@
 
 (extend-protocol BEncodeable
   nil
-  (to-bencode-encodeable* [_this]
+  (to-bencode-encodeable* [_]
     #b "0:")
   python/bytes
   (to-bencode-encodeable* [this]
@@ -203,7 +203,7 @@
                                    (assoc :key-fn #(keyword (.decode % "utf-8")))))]
     (try
       (decode* data opts)
-      (catch python/Exception _e
+      (catch python/Exception _
         [nil data]))))
 
 (defn decode-all

--- a/src/basilisp/contrib/bencode.lpy
+++ b/src/basilisp/contrib/bencode.lpy
@@ -15,7 +15,7 @@
 
 (extend-protocol BEncodeable
   nil
-  (to-bencode-encodeable* [this]
+  (to-bencode-encodeable* [_this]
     #b "0:")
   python/bytes
   (to-bencode-encodeable* [this]
@@ -193,7 +193,7 @@
         be specified if ``:keywordize-keys`` is also specified
     :keyword ``:string-fn``: a function which will be called for each byte string which
         is not a map key; default  is :lpy:fn:`basilisp.core/identity`"
-  [data {:keys [keywordize-keys key-fn string-fn] :as opts}]
+  [data {:keys [keywordize-keys key-fn] :as opts}]
   (when (and keywordize-keys key-fn)
     (throw (ex-info "Can only specify either :keywordize-keys or :key-fn; not both"
                     {:keywordize-keys keywordize-keys
@@ -203,7 +203,7 @@
                                    (assoc :key-fn #(keyword (.decode % "utf-8")))))]
     (try
       (decode* data opts)
-      (catch python/Exception e
+      (catch python/Exception _e
         [nil data]))))
 
 (defn decode-all

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -83,7 +83,7 @@
 
 (defn- send-value [request send-fn v]
   (let [{:keys [client*]}  request
-        {:keys [*2 *3 *e]} @client*
+        {:keys [*1 *2]} @client*
         [v opts]           v
         ns                 (:ns opts)]
     (swap! client* assoc :*1 v :*2 *1 :*3 *2)
@@ -337,7 +337,7 @@
       (warn "Unhandled operation" op)
       (send-fn request {"status" ["error" "unknown-op" "done"]}))))
 
-(defn- make-request-handler [opts]
+(defn- make-request-handler [_opts]
   (-> handle-request
       coerce-request-mw
       log-request-mw))

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -337,7 +337,7 @@
       (warn "Unhandled operation" op)
       (send-fn request {"status" ["error" "unknown-op" "done"]}))))
 
-(defn- make-request-handler [_opts]
+(defn- make-request-handler [_]
   (-> handle-request
       coerce-request-mw
       log-request-mw))

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -254,6 +254,8 @@ class SymbolTable:
         ), "Only warn when logger is configured for WARNING level"
         ns = runtime.get_current_ns()
         for _, entry in self._table.items():
+            if entry.symbol.name.startswith("_"):
+                continue
             if entry.symbol in _NO_WARN_UNUSED_SYMS:
                 continue
             if entry.warn_if_unused and not entry.used:

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -2245,6 +2245,12 @@ class TestFunctionWarnUnusedName:
             f"symbol 'v' defined but not used ({ns}: 1)",
         ) in caplog.record_tuples
 
+    def test_single_arity_fn_underscore_log_if_warning_enabled(
+        self, lcompile: CompileFn, ns: runtime.Namespace, caplog
+    ):
+        lcompile("(fn [_v] (fn [v] v))", opts={compiler.WARN_ON_UNUSED_NAMES: True})
+        assert_no_logs(caplog)
+
     def test_multi_arity_fn_log_if_warning_enabled(
         self, lcompile: CompileFn, ns: runtime.Namespace, caplog
     ):


### PR DESCRIPTION
Hi,

could you please review patch to not work on unused bindings whose name begins with `_`. It addresses #756.

I've addressed some of such warnings coming up when running the nrepl-server, and added a test.

Thanks