### PR TITLE
callable var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)
+ * Allow vars to be callable to adhere to Clojure conventions (#767)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -275,6 +275,9 @@ class Var(RefBase):
     def __repr__(self):
         return f"#'{self.ns.name}/{self.name}"
 
+    def __call__(self, *args, **kwargs):
+        return self.value(*args, *kwargs)  # pylint: disable=not-callable
+
     @property
     def ns(self) -> "Namespace":
         return self._ns

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -951,6 +951,11 @@ def test_is_var():
     assert False is core.var__Q__(core.list_)
 
 
+def test_is_var_callable():
+    varlist = runtime.Var.find(sym.symbol("list", ns="basilisp.core"))
+    assert llist.l(2, 3) == varlist(2, 3)
+
+
 class TestExceptionData:
     def test_ex_cause_for_non_exception(self):
         assert None is core.ex_cause("a string")

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1411,6 +1411,14 @@
   (testing "ns-not-exists"
     (is (thrown? python/AttributeError (intern 'ns-non-existant 'xyz)))))
 
+;;;;;;;;;;
+;; Vars ;;
+;;;;;;;;;;
+
+(deftest var-test
+  (testing "calling vars"
+    (is (= '(1 2) (#'basilisp.core/list 1 2)))))
+
 ;;;;;;;;;;;;;;;;;
 ;; Hierarchies ;;
 ;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Hi,

could you please review compatibility patch with Clojure to make vars callable. It addresses #767.

I am not sure this if the `class Var` is the right place to make vars callable or the analyzer, which should expand them to a callable var value last node.

Nevertheless, I will kindly request your help with the type hinting, currently it will fail the linter with the following error

```
src/basilisp/lang/runtime.py:279:15: E1102: self.value is not callable (not-callable)
```

but not sure how to fix it, I've tried the class Var `value` property method to return a maybe Callable but it didn't work.

Thanks