### PR TITLE
Fix issue with keyword fns erroring out on vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with `(count nil)` throwing an exception (#759)
  * Fix issue with keyword fn not testing for test membership in sets (#762)
  * Fix an issue for executing Basilisp scripts via a shebang where certain platforms may not support more than one argument in the shebang line (#764)
+ * Fix issue with keyword fns throwing type error on vectors (#770)
 
 ## [v0.1.0b0]
 ### Added

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -63,7 +63,7 @@ class Keyword(ILispObject):
             return self if self in m else default
         try:
             return m.val_at(self, default)
-        except AttributeError:
+        except (AttributeError, TypeError):
             return None
 
     def __reduce__(self):

--- a/tests/basilisp/keyword_test.py
+++ b/tests/basilisp/keyword_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from basilisp.lang import map as lmap
 from basilisp.lang import set as lset
+from basilisp.lang import vector as lvector
 from basilisp.lang.keyword import Keyword, complete, keyword
 
 
@@ -50,6 +51,8 @@ def test_keyword_as_function():
     assert kw == kw(lset.s(kw))
     assert None is kw(lset.s(1))
     assert "hi" is kw(lset.s(1), default="hi")
+
+    assert None is kw(lvector.v(1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi,

could you please review patch to fix an issue with keyword fns throwing a type error on vectors. Fixes #770.

thanks