### PR TITLE
fixed issue with variadic ampersand symbol in macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix an issue for executing Basilisp scripts via a shebang where certain platforms may not support more than one argument in the shebang line (#764)
  * Fix issue with keywords throwing `TypeError` when used as a function on vectors (#770)
  * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777) 
+ * Fix issue with the variadic ampersand operator treated as a binding in macros (#772)
 
 ## [v0.1.0b0]
 ### Added

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -948,7 +948,9 @@ def _read_sym(ctx: ReaderContext) -> MaybeSymbol:
     If a symbol appears in a syntax quoted form, the reader will attempt
     to resolve the symbol using the resolver in the ReaderContext `ctx`.
     The resolver will look into the current namespace for an alias or
-    namespace matching the symbol's namespace."""
+    namespace matching the symbol's namespace. If no namespace is specififed
+    for the symbol, it will be assigned to the current namespace, unless the
+    symbol is `&`."""
     ns, name = _read_namespaced(ctx, allowed_suffix="#")
     if not ctx.is_syntax_quoted and name.endswith("#"):
         raise ctx.syntax_error("Gensym may not appear outside syntax quote")
@@ -967,6 +969,8 @@ def _read_sym(ctx: ReaderContext) -> MaybeSymbol:
             return True
         elif name == "false":
             return False
+        elif name == "&":
+            return _AMPERSAND
     if ctx.is_syntax_quoted and not name.endswith("#"):
         return ctx.resolve(sym.symbol(name, ns))
     return sym.symbol(name, ns=ns)

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -773,6 +773,14 @@ def test_syntax_quoted(test_ns: str, ns: runtime.Namespace):
         ),
     ) == read_str_first("`(~'my-symbol)"), "Do not resolve unquoted quoted syms"
 
+    assert llist.l(sym.symbol("quote"), sym.symbol("&")) == read_str_first(
+        "`&"
+    ), "do not resolve the not namespaced ampersand"
+
+    assert llist.l(
+        sym.symbol("quote"), sym.symbol("&", ns="test-ns")
+    ) == read_str_first("`test-ns/&"), "resolve fq namespaced ampersand"
+
 
 def test_syntax_quote_gensym():
     resolver = lambda s: sym.symbol(s.name, ns="test-ns")

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1456,3 +1456,10 @@
                       (conj coll m)
                       (conj accum a b))
                [coll (apply str accum)]))))))
+
+(defmacro ^:private variadic-fn []
+  `(fn [& r#] r#))
+
+(deftest macro-variadic-fn
+  (testing "defining variadic fn with ampersand"
+    (is (= '(2 3 4) ((variadic-fn) 2 3 4)))))


### PR DESCRIPTION
HI,

could you please review patch to treat the ampersand operator in macros as a standalone symbol. Fixes #772.

Test included.

thanks