### PR TITLE
support symbols as fns for maps and sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)
  * Allow vars to be callable to adhere to Clojure conventions (#767)
+ * Support symbols as fns for sets and maps (#775)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/lang/symbol.py
+++ b/src/basilisp/lang/symbol.py
@@ -1,7 +1,13 @@
 from functools import total_ordering
-from typing import Optional
+from typing import Optional, Union
 
-from basilisp.lang.interfaces import ILispObject, IPersistentMap, IWithMeta
+from basilisp.lang.interfaces import (
+    IAssociative,
+    ILispObject,
+    IPersistentMap,
+    IPersistentSet,
+    IWithMeta,
+)
 from basilisp.lang.obj import lrepr
 from basilisp.lang.util import munge
 
@@ -70,6 +76,14 @@ class Symbol(ILispObject, IWithMeta):
         if other._ns is None:
             return False
         return self._ns < other._ns or self._name < other._name
+
+    def __call__(self, m: Union[IAssociative, IPersistentSet], default=None):
+        if isinstance(m, IPersistentSet):
+            return self if self in m else default
+        try:
+            return m.val_at(self, default)
+        except (AttributeError, TypeError):
+            return None
 
 
 def symbol(name: str, ns: Optional[str] = None, meta=None) -> Symbol:

--- a/tests/basilisp/symbol_test.py
+++ b/tests/basilisp/symbol_test.py
@@ -3,6 +3,8 @@ import pickle
 import pytest
 
 from basilisp.lang import map as lmap
+from basilisp.lang import set as lset
+from basilisp.lang import vector as lvector
 from basilisp.lang.keyword import keyword
 from basilisp.lang.symbol import Symbol, symbol
 
@@ -42,6 +44,21 @@ def test_symbol_with_meta():
     assert sym2 is not sym3
     assert sym2 == sym3
     assert sym3.meta == lmap.m(tag=keyword("macro"))
+
+
+def test_symbol_as_function():
+    sym = symbol("kw")
+    assert None is sym(None)
+
+    assert 1 == sym(lmap.map({sym: 1}))
+    assert "hi" == sym(lmap.map({sym: "hi"}))
+    assert None is sym(lmap.map({"hi": sym}))
+
+    assert sym == sym(lset.s(sym))
+    assert None is sym(lset.s(1))
+    assert "hi" is sym(lset.s(1), default="hi")
+
+    assert None is sym(lvector.v(1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi,

can you please review patch to add support for symbols as fns for maps and sets. Fixes #775.

Tests are copied from the corresponding call fn for keywords.

Thanks