### PR TITLE
Fix a bug where deftype names could not be called if they contain a dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)
- * Fix issue with keywords not testing for test membership in sets when called used as a function (#762)
+ * Fix issue with keywords not testing for membership in sets when used as a function (#762)
  * Fix an issue for executing Basilisp scripts via a shebang where certain platforms may not support more than one argument in the shebang line (#764)
  * Fix issue with keywords throwing `TypeError` when used as a function on vectors (#770)
  * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)
- * Fix issue with keyword fn not testing for test membership in sets (#762)
+ * Fix issue with keywords not testing for test membership in sets when called used as a function (#762)
  * Fix an issue for executing Basilisp scripts via a shebang where certain platforms may not support more than one argument in the shebang line (#764)
- * Fix issue with keyword fns throwing type error on vectors (#770)
+ * Fix issue with keywords throwing `TypeError` when used as a function on vectors (#770)
+ * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777) 
 
 ## [v0.1.0b0]
 ### Added

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -1464,7 +1464,7 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-locals
                                 _load_attr(_NS_VAR_VALUE),
                                 ast.Call(
                                     func=_NEW_SYM_FN_NAME,
-                                    args=[ast.Constant(type_name)],
+                                    args=[ast.Constant(node.name)],
                                     keywords=[],
                                 ),
                                 ast.Name(id=type_name, ctx=ast.Load()),

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -609,6 +609,12 @@ class TestDefType:
         with pytest.raises(ExceptionType):
             lcompile(code)
 
+    def test_deftype_name_can_contain_dashes(self, lcompile: CompileFn):
+        cls = lcompile("(deftype* three-axis-point [x y z])")
+        o = lcompile("(three-axis-point. 1 2 3)")
+        assert isinstance(o, cls)
+        assert (o.x, o.y, o.z) == (1, 2, 3)
+
     def test_deftype_allows_empty_abstract_interface(self, lcompile: CompileFn):
         Point = lcompile(
             """


### PR DESCRIPTION
Fixes  #777 