### PR TITLE
Collect CLI arguments sent to `basilisp run` or Basilisp scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added support for passing through `:tag` metadata to the generated Python AST (#354)
+ * Added support for calling symbols as functions on maps and sets (#775)
+ * Added support for passing command line arguments to Basilisp (#???)
 
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)
  * Allow vars to be callable to adhere to Clojure conventions (#767)
- * Support symbols as fns for sets and maps (#775)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added support for passing through `:tag` metadata to the generated Python AST (#354)
  * Added support for calling symbols as functions on maps and sets (#775)
- * Added support for passing command line arguments to Basilisp (#???)
+ * Added support for passing command line arguments to Basilisp (#779)
 
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -501,7 +501,7 @@ def run_script():
     The current process is replaced as by `os.execlp`."""
     # os.exec* functions do not perform shell expansion, so we must do so manually.
     script_path = Path(sys.argv[1]).resolve()
-    args = ["basilisp", "run", script_path]
+    args = ["basilisp", "run", str(script_path)]
     # Collect arguments sent to the script and pass them onto `basilisp run`
     if rest := sys.argv[2:]:
         args.append("--")

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -2097,7 +2097,7 @@ def bootstrap_core(compiler_opts: CompilerOpts) -> None:
                     "with command line arguments as by ``basilisp run {file_or_code}`` "
                     "or ``nil`` otherwise.\n\n"
                     "Note that this value will differ from ``sys.argv`` since it will "
-                    "not include the coommand line arguments consumed by Basilisp's "
+                    "not include the command line arguments consumed by Basilisp's "
                     "own CLI."
                 )
             }

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -82,6 +82,7 @@ BASILISP_VERSION = vec.vector(
 
 # Public basilisp.core symbol names
 COMPILER_OPTIONS_VAR_NAME = "*compiler-options*"
+COMMAND_LINE_ARGS_VAR_NAME = "*command-line-args*"
 DEFAULT_READER_FEATURES_VAR_NAME = "*default-reader-features*"
 GENERATED_PYTHON_VAR_NAME = "*generated-python*"
 PRINT_GENERATED_PY_VAR_NAME = "*print-generated-python*"
@@ -2081,6 +2082,26 @@ def bootstrap_core(compiler_opts: CompilerOpts) -> None:
         sym.symbol(COMPILER_OPTIONS_VAR_NAME),
         compiler_opts,
         dynamic=True,
+    )
+
+    # Dynamic Var containing command line arguments passed via `basilisp run`
+    Var.intern(
+        CORE_NS_SYM,
+        sym.symbol(COMMAND_LINE_ARGS_VAR_NAME),
+        None,
+        dynamic=True,
+        meta=lmap.map(
+            {
+                _DOC_META_KEY: (
+                    "A vector of command line arguments if this process was started "
+                    "with command line arguments as by ``basilisp run {file_or_code}`` "
+                    "or ``nil`` otherwise.\n\n"
+                    "Note that this value will differ from ``sys.argv`` since it will "
+                    "not include the coommand line arguments consumed by Basilisp's "
+                    "own CLI."
+                )
+            }
+        ),
     )
 
     # Dynamic Var for introspecting the default reader featureset

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -181,19 +181,19 @@ class TestRun:
         result = run_cli(["run", "-c", self.cli_args_code, *args])
         assert ret == result.lisp_out
 
-    def test_run_file(self, tmp_path: pathlib.Path, run_cli):
-        script_path = tmp_path / "test.lpy"
-        script_path.write_text("(println (+ 1 2))")
-        result = run_cli(["run", str(script_path)])
+    def test_run_file(self, isolated_filesystem, run_cli):
+        with open("test.lpy", mode="w") as f:
+            f.write("(println (+ 1 2))")
+        result = run_cli(["run", "test.lpy"])
         assert "3\n" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_file_with_args(
         self, tmp_path: pathlib.Path, run_cli, args: List[str], ret: str
     ):
-        script_path = tmp_path / "test.lpy"
-        script_path.write_text(self.cli_args_code)
-        result = run_cli(["run", str(script_path), *args])
+        with open("test.lpy", mode="w") as f:
+            f.write(self.cli_args_code)
+        result = run_cli(["run", "test.lpy", *args])
         assert ret == result.lisp_out
 
     def test_run_stdin(self, run_cli):

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -189,7 +189,7 @@ class TestRun:
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_file_with_args(
-        self, tmp_path: pathlib.Path, run_cli, args: List[str], ret: str
+        self, isolated_filesystem, run_cli, args: List[str], ret: str
     ):
         with open("test.lpy", mode="w") as f:
             f.write(self.cli_args_code)

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 import time
 from threading import Thread
-from typing import Optional, Sequence
+from typing import List, Optional, Sequence
 from unittest.mock import patch
 
 import attr
@@ -177,7 +177,7 @@ class TestRun:
         assert "3\n" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_code_with_args(self, run_cli, args: list[str], ret: str):
+    def test_run_code_with_args(self, run_cli, args: List[str], ret: str):
         result = run_cli(["run", "-c", self.cli_args_code, *args])
         assert ret == result.lisp_out
 
@@ -189,7 +189,7 @@ class TestRun:
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_file_with_args(
-        self, tmp_path: pathlib.Path, run_cli, args: list[str], ret: str
+        self, tmp_path: pathlib.Path, run_cli, args: List[str], ret: str
     ):
         script_path = tmp_path / "test.lpy"
         script_path.write_text(self.cli_args_code)
@@ -201,7 +201,7 @@ class TestRun:
         assert "3\n" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_stdin_with_args(self, run_cli, args: list[str], ret: str):
+    def test_run_stdin_with_args(self, run_cli, args: List[str], ret: str):
         result = run_cli(
             ["run", "-", *args],
             input=self.cli_args_code,
@@ -228,7 +228,7 @@ def test_version(run_cli):
         (["1", "hi", "yes"], b"[1 hi yes]\n"),
     ],
 )
-def test_run_script(tmp_path: pathlib.Path, args: list[str], ret: bytes):
+def test_run_script(tmp_path: pathlib.Path, args: List[str], ret: bytes):
     script_path = tmp_path / "script.lpy"
     script_path.write_text(
         "\n".join(


### PR DESCRIPTION
Fixes #779 