### PR TITLE
basilisp.core/load input path compatibility with clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)
  * Allow vars to be callable to adhere to Clojure conventions (#767)
+ * Adjust input path compatibility in basilisp.core/load input path to be relative to the namespace or the root path (#782)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4374,7 +4374,24 @@
   this function."
   [& paths]
   (doseq [path (seq paths)]
-    (load-file (str path ".lpy"))))
+    (let [path-rel (if (.startswith path "/")
+                     path
+                     (let [nsname (.-name *ns*)
+                           dot-last (.rfind nsname ".")
+                           path-parent (-> (subs nsname 0 (if (= dot-last -1) (count nsname) dot-last))
+                                           (.replace "." "/"))]
+                       (str "/" path-parent "/" path)))
+          path-rel (.replace path-rel "-" "_")
+          path-abs (if-let [path-full (some (fn [p]
+                                              (let [pf (str p path-rel)]
+                                                (when (os.path/exists (str pf ".lpy"))
+                                                  pf)))
+                                            sys/path)]
+                     path-full
+                     (throw (python/FileNotFoundError (str "Could not locate `"
+                                                           (str (subs path-rel 1) ".lpy")
+                                                           "` on syspath."))))]
+      (load-file (str path-abs ".lpy")))))
 
 (defn ^:inline load-string
   "Read and evaluate the set of forms contained in the string ``s``\\."

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4356,6 +4356,28 @@
   (with-open [f (python/open path ** :mode "r")]
     (load-reader f)))
 
+(defn- resolve-load-path [path]
+  "Resolve load ``path`` relative to the current namespace, or, if it
+  begins with \"/\", relative to the syspath, and return it.
+
+ Throw a python/FileNotFoundError if the ``path`` cannot be resolved."
+  (let [path-rel (if (.startswith path "/")
+                   path
+                   (let [path-parent (-> (name *ns*)
+                                         (.rsplit "." 1)
+                                         (first)
+                                         (.replace "." "/"))]
+                     (str "/" path-parent "/" path)))
+        path-rel (.replace path-rel "-" "_")]
+    (if-let [path-full (some (fn [p]
+                               (let [pf (str p path-rel)]
+                                 (when (os.path/exists (str pf ".lpy"))
+                                   pf)))
+                             sys/path)]
+      path-full
+      (throw (python/FileNotFoundError (str "Could not locate `"
+                                            (subs path-rel 1) ".lpy` on syspath."))))))
+
 (defn load
   "Read and evaluate the set of forms contained in the files identified by ``paths``.
 
@@ -4366,6 +4388,10 @@
   (which is generally preferred, but not right in every scenario). ``load`` will load
   the contents of the named file directly into the current namespace.
 
+  A path is interpreted relative to the syspath if it starts with a
+  forward slash or relative to the root directory of the current
+  namespace otherwise.
+
   Note that unlike ``require``\\, files loaded by ``load`` will not be cached and will
   thus incur compilation time on subsequent loads.
 
@@ -4374,24 +4400,7 @@
   this function."
   [& paths]
   (doseq [path (seq paths)]
-    (let [path-rel (if (.startswith path "/")
-                     path
-                     (let [nsname (.-name *ns*)
-                           dot-last (.rfind nsname ".")
-                           path-parent (-> (subs nsname 0 (if (= dot-last -1) (count nsname) dot-last))
-                                           (.replace "." "/"))]
-                       (str "/" path-parent "/" path)))
-          path-rel (.replace path-rel "-" "_")
-          path-abs (if-let [path-full (some (fn [p]
-                                              (let [pf (str p path-rel)]
-                                                (when (os.path/exists (str pf ".lpy"))
-                                                  pf)))
-                                            sys/path)]
-                     path-full
-                     (throw (python/FileNotFoundError (str "Could not locate `"
-                                                           (str (subs path-rel 1) ".lpy")
-                                                           "` on syspath."))))]
-      (load-file (str path-abs ".lpy")))))
+    (load-file (str (resolve-load-path path) ".lpy"))))
 
 (defn ^:inline load-string
   "Read and evaluate the set of forms contained in the string ``s``\\."

--- a/tests/basilisp/corpus/core_load_1.lpy
+++ b/tests/basilisp/corpus/core_load_1.lpy
@@ -1,1 +1,0 @@
-(print :core-load-1)

--- a/tests/basilisp/corpus/core_load_1.lpy
+++ b/tests/basilisp/corpus/core_load_1.lpy
@@ -1,0 +1,1 @@
+(print :core-load-1)

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2051,3 +2051,22 @@
       (eval '(ns test-core-fns.ns-with-import (:import [time :as time-alias])))
       (is (= *ns* (the-ns 'test-core-fns.ns-with-import)))
       (is (= "Thu Jan  1 00:00:01 1970" (eval '(time-alias/asctime (time-alias/gmtime 1))))))))
+
+
+;;;;;;;;;;
+;; load ;;
+;;;;;;;;;;
+
+(deftest load-test
+
+  (testing "relative load path"
+    (let [output (with-out-str (load "corpus/core-load-1"))]
+      (is (= ":core-load-1" output))))
+
+  (testing "absolute (/) load path"
+    ;; pytest add the top basilisp directory to the classpath
+    (let [output (with-out-str (load "/tests/basilisp/corpus/core-load-1"))]
+      (is (= ":core-load-1" output))))
+
+  (testing "non-existent load path"
+    (is (thrown? python/FileNotFoundError (load "corpus/core-load-99")))))

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -1,6 +1,8 @@
 (ns tests.basilisp.test-core-fns
-  (:import time)
+  (:import shutil
+           time)
   (:require
+   [basilisp.io :as bio]
    [basilisp.set :as set]
    [basilisp.test :refer [deftest are is testing]]))
 
@@ -2059,14 +2061,26 @@
 
 (deftest load-test
 
-  (testing "relative load path"
-    (let [output (with-out-str (load "corpus/core-load-1"))]
-      (is (= ":core-load-1" output))))
+  (let [load-dir-test "tests/basilisp/corpus"
+        load-dir-filepath (str load-dir-test "/core_load_1.lpy")]
+    (try 
+      (when (bio/exists? load-dir-test)
+        (shutil/rmtree load-dir-test))
+      (bio/make-parents load-dir-filepath)
+      (spit load-dir-filepath "(print :core-load-1)")
+      
+      (testing "relative load path"
+        (let [output (with-out-str (load "corpus/core-load-1"))]
+          (is (= ":core-load-1" output))))
 
-  (testing "absolute (/) load path"
-    ;; pytest add the top basilisp directory to the classpath
-    (let [output (with-out-str (load "/tests/basilisp/corpus/core-load-1"))]
-      (is (= ":core-load-1" output))))
+      (testing "absolute (/) load path"
+        ;; pytest add the top basilisp directory to the classpath
+        (let [output (with-out-str (load "/tests/basilisp/corpus/core-load-1"))]
+          (is (= ":core-load-1" output))))
 
-  (testing "non-existent load path"
-    (is (thrown? python/FileNotFoundError (load "corpus/core-load-99")))))
+      (testing "non-existent load path"
+        (is (thrown? python/FileNotFoundError (load "corpus/core-load-99"))))
+
+      (finally
+        (when (bio/exists? load-dir-test)
+          (shutil/rmtree load-dir-test))))))


### PR DESCRIPTION
Hi,

could you please consider patch to adjust the `load` input path to be treated as relative to the current namespace or root path. It fixes #782.

I've also added a `corpus` directory in `tests/basilisp` so I can reference the input file. 

Thanks