### PR TITLE
Provide names for methods generated via `extend-type` and `extend-procol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * No longer warn on unused bindings when their name begins with `_` (#756)
  * Improve the Python generation for `do`, `if`, `let*`, and `letfn*` forms to avoid unnecessary extra assignments (#793, #794, #799)
  * Generate Python classes for `deftype*` and `reify*` forms using modern `@attr.define`, `@attr.frozen`, and `@attr.field` APIs (#799)
+ * Generate Protocol functions with nicer names based on the protocol function and dispatch type (#803)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -6153,12 +6153,12 @@
                    (let [impl-method-arities (get impl-method-arity-map proto-method-name)]
                      (when (not= impl-method-arities proto-method-arities)
                        (throw (ex-info "target-type must implement all protocol method arities"
-                                       {:proto-method    proto-method-name
+                                       {:proto-method         proto-method-name
                                         :proto-method-arities proto-method-arity-map
-                                        :impl-method-arities impl-method-arity-map
-                                        :missing-arities (->> proto-method-arities
-                                                              (remove impl-method-arities)
-                                                              (set))}))))))
+                                        :impl-method-arities  impl-method-arity-map
+                                        :missing-arities      (->> proto-method-arities
+                                                                   (remove impl-method-arities)
+                                                                   (set))}))))))
                (doseq [method-def method-map
                        :let       [[method-name fn] method-def]]
                  (let [dispatch-method (get proto-methods method-name)]
@@ -6196,12 +6196,18 @@
   "Convert a vector of method definitions (as expected by ``extend-protocol`` and
   ``extend-type``\\) into a map of method definitions which can be passed to
   ``extend``\\."
-  [methods]
+  [target-type methods]
   (->> (group-by first methods)
        (reduce (fn [m [method-name arities]]
-                 (->> (map rest arities)
-                      (apply list `fn)
-                      (assoc! m (keyword (name method-name)))))
+                 (let [genned-method-name (symbol
+                                           (str (name method-name)
+                                                "-"
+                                                (if (nil? target-type)
+                                                  "nil"
+                                                  (name target-type))))]
+                   (->> (map rest arities)
+                        (apply list `fn genned-method-name)
+                        (assoc! m (keyword (name method-name))))))
                (transient {}))
        (persistent!)))
 
@@ -6246,7 +6252,7 @@
   `(do ~@(map (fn [[target-type methods]]
                 `(extend ~target-type
                    ~proto
-                   ~(extend-map methods)))
+                   ~(extend-map target-type methods)))
               (sym-and-method-groups specs))))
 
 (defmacro extend-type
@@ -6281,7 +6287,7 @@
   [target-type & specs]
   `(extend ~target-type
      ~@(mapcat (fn [[proto methods]]
-                 [proto (extend-map methods)])
+                 [proto (extend-map target-type methods)])
                (sym-and-method-groups specs))))
 
 (defn extenders


### PR DESCRIPTION
Fixes #803 