### PR TITLE
Permit default expresssions in `case` without clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Generate Python classes for `deftype*` and `reify*` forms using modern `@attr.define`, `@attr.frozen`, and `@attr.field` APIs (#799)
  * Generate Protocol functions with nicer names based on the protocol function and dispatch type (#803)
  * Loosen the dependency specification for Immutables and Pyrsistent to allow for a wider version range (#805)
+ * Allow `case` forms with only a default expression (#807)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3402,16 +3402,14 @@
 (defmacro case
   "Switch on ``expr`` to return a matching clause from the set of input clauses.
 
-  The input expression may be any valid Basilisp expression.
+  The input expression may be any valid Basilisp expression. A single default expression
+  can follow the clauses, and its value will be returned if no clause matches.
 
   The clauses are pairs of a matching value and a return value. The matching values are
   not evaluated and must be compile-time constants. Symbols will not be resolved. Lists
   may be passed to match multiple compile time values to a single return value. The
   dispatch is done in constant time."
   [expr & clauses]
-  (when (< (count clauses) 2)
-    (throw (ex-info "case expression must have at least one clause"
-                    {:clauses clauses})))
   (let [default (if (odd? (count clauses))
                   (last clauses)
                   :basilisp.core.case/no-default)

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -326,6 +326,7 @@
   (is (= "also no" (case 'c :a "no" (b c d) "also no" "duh")))
   (is (= "also no" (case 'd :a "no" (b c d) "also no" "duh")))
   (is (= "duh" (case 'e :a "no" (b c d) "also no" "duh")))
+  (is (= 0 (case 1 0)))
   (let [out* (atom [])]
     (is (= 2 (case :2
                :1 (do (swap! out* conj 1) 1)


### PR DESCRIPTION
Hi,

could you please review patch to allow `case` to work with exclusive default expressions. Fixes #807.

This is also to maintain Clojure compatibility.

Thanks