### PR TITLE
Emit OS specific line endings for `prn` and `println`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Loosen the dependency specification for Immutables and Pyrsistent to allow for a wider version range (#805)
  * Allow `case` forms with only a default expression (#807)
  * Make `pr` a dynamic variable (#820)
+ * Emit OS specific line endings for the `println` and `prn` fns (#810)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4136,12 +4136,12 @@
 (defn prn
   "Same as :lpy:fn:`pr`, but appending a newline afterwards."
   ([]
-   (.write *out* \newline)
+   (.write *out* os/linesep)
    nil)
   ([x]
    (let [stdout *out*]
      (.write stdout (repr x))
-     (.write stdout \newline)
+     (.write stdout os/linesep)
      nil))
   ([x & args]
    (let [stdout    *out*
@@ -4150,7 +4150,7 @@
      (.write stdout (repr x))
      (.write stdout sep)
      (.write stdout (apply str repr-args))
-     (.write stdout \newline)
+     (.write stdout os/linesep)
      nil)))
 
 (defn pr-str
@@ -4191,7 +4191,7 @@
   ([x]
    (let [stdout *out*]
      (.write stdout (basilisp.lang.runtime/lstr x))
-     (.write stdout \newline)
+     (.write stdout os/linesep)
      nil))
   ([x & args]
    (let [stdout    *out*
@@ -4200,7 +4200,7 @@
      (.write stdout (basilisp.lang.runtime/lstr x))
      (.write stdout sep)
      (.write stdout (apply str repr-args))
-     (.write stdout \newline)
+     (.write stdout os/linesep)
      nil)))
 
 (defn print-str

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -116,7 +116,7 @@ class TestBootstrap:
 
 def test_debug_flag(run_cli):
     result = run_cli(["run", "--disable-ns-cache", "true", "-c", "(println (+ 1 2))"])
-    assert "3\n" == result.lisp_out
+    assert f"3{os.linesep}" == result.lisp_out
     assert os.environ["BASILISP_DO_NOT_CACHE_NAMESPACES"].lower() == "true"
 
 
@@ -125,14 +125,14 @@ class TestCompilerFlags:
         result = run_cli(
             ["run", "--warn-on-var-indirection", "-c", "(println (+ 1 2))"]
         )
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("val", BOOL_TRUE | BOOL_FALSE)
     def test_valid_flag(self, run_cli, val):
         result = run_cli(
             ["run", "--warn-on-var-indirection", val, "-c", "(println  (+ 1 2))"]
         )
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("val", ["maybe", "not-no", "4"])
     def test_invalid_flag(self, run_cli, val):
@@ -211,10 +211,10 @@ class TestREPL:
 
 class TestRun:
     cli_args_params = [
-        ([], "0\n"),
-        (["--"], "0\n"),
-        (["1", "2", "3"], "6\n"),
-        (["--", "1", "2", "3"], "6\n"),
+        ([], f"0{os.linesep}"),
+        (["--"], f"0{os.linesep}"),
+        (["1", "2", "3"], f"6{os.linesep}"),
+        (["--", "1", "2", "3"], f"6{os.linesep}"),
     ]
     cli_args_code = "(println (apply + (map int *command-line-args*)))"
 
@@ -224,11 +224,11 @@ class TestRun:
 
     def test_run_code(self, run_cli):
         result = run_cli(["run", "-c", "(println (+ 1 2))"])
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     def test_run_code_main_ns(self, run_cli):
         result = run_cli(["run", "-c", "(println *main-ns*)"])
-        assert "nil\n" == result.lisp_out
+        assert f"nil{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_code_with_args(self, run_cli, args: List[str], ret: str):
@@ -239,13 +239,13 @@ class TestRun:
         with open("test.lpy", mode="w") as f:
             f.write("(println (+ 1 2))")
         result = run_cli(["run", "test.lpy"])
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     def test_run_file_main_ns(self, isolated_filesystem, run_cli):
         with open("test.lpy", mode="w") as f:
             f.write("(println *main-ns*)")
         result = run_cli(["run", "test.lpy"])
-        assert "nil\n" == result.lisp_out
+        assert f"nil{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_file_with_args(
@@ -275,14 +275,14 @@ class TestRun:
     def test_run_namespace(self, run_cli, namespace_file: pathlib.Path):
         namespace_file.write_text("(println (+ 1 2))")
         result = run_cli(["run", "-n", "package.core"])
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     def test_run_namespace_main_ns(self, run_cli, namespace_file: pathlib.Path):
         namespace_file.write_text(
             "(ns package.core) (println (name *ns*)) (println *main-ns*)"
         )
         result = run_cli(["run", "-n", "package.core"])
-        assert "package.core\npackage.core\n" == result.lisp_out
+        assert f"package.core{os.linesep}package.core{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_namespace_with_args(
@@ -294,11 +294,11 @@ class TestRun:
 
     def test_run_stdin(self, run_cli):
         result = run_cli(["run", "-"], input="(println (+ 1 2))")
-        assert "3\n" == result.lisp_out
+        assert f"3{os.linesep}" == result.lisp_out
 
     def test_run_stdin_main_ns(self, run_cli):
         result = run_cli(["run", "-"], input="(println *main-ns*)")
-        assert "nil\n" == result.lisp_out
+        assert f"nil{os.linesep}" == result.lisp_out
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_stdin_with_args(self, run_cli, args: List[str], ret: str):

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -312,14 +312,14 @@
             {:id @id* :out ":hi"}
             {:id @id* :out " "}
             {:id @id* :out "there"}
-            {:id @id* :out "\n"}
+            {:id @id* :out os/linesep}
             {:id @id* :ns "user" :value "nil"}
             {:id @id* :ns "user" :status ["done"]})
 
           (client-send! client {:id (id-inc!) :op "eval" :ns "xyz" :code "(ns xyz (:import [sys :as s])) (println s/__name__) (* 2 3)"})
           (are [response] (= response (client-recv! client))
             {:id @id* :out "sys"}
-            {:id @id* :out "\n"}
+            {:id @id* :out os/linesep}
             {:id @id* :ns "xyz" :value "6"}
             {:id @id* :ns "xyz" :status ["done"]})
 
@@ -336,7 +336,7 @@
           (client-send! client {:id (id-inc!) :op "eval" :code "(println :hey)\n(/ 4 0)"})
           (are [response] (= response (client-recv! client))
             {:id @id* :out ":hey"}
-            {:id @id* :out "\n"}
+            {:id @id* :out os/linesep}
             {:id @id* :err "ZeroDivisionError('Fraction(4, 0)')"})
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import re
 from decimal import Decimal
 from fractions import Fraction
@@ -1599,10 +1600,12 @@ class TestPrintFunctions:
         assert ':hi "there" 3' == core.pr_str(kw.keyword("hi"), "there", 3)
 
     def test_prn_str(self):
-        assert "\n" == core.prn_str()
-        assert '""\n' == core.prn_str("")
-        assert ":kw\n" == core.prn_str(kw.keyword("kw"))
-        assert ':hi "there" 3\n' == core.prn_str(kw.keyword("hi"), "there", 3)
+        assert os.linesep == core.prn_str()
+        assert '""' + os.linesep == core.prn_str("")
+        assert ":kw" + os.linesep == core.prn_str(kw.keyword("kw"))
+        assert ':hi "there" 3' + os.linesep == core.prn_str(
+            kw.keyword("hi"), "there", 3
+        )
 
     def test_print_str(self):
         assert "" == core.print_str()
@@ -1611,10 +1614,12 @@ class TestPrintFunctions:
         assert ":hi there 3" == core.print_str(kw.keyword("hi"), "there", 3)
 
     def test_println_str(self):
-        assert "\n" == core.println_str()
-        assert "\n" == core.println_str("")
-        assert ":kw\n" == core.println_str(kw.keyword("kw"))
-        assert ":hi there 3\n" == core.println_str(kw.keyword("hi"), "there", 3)
+        assert os.linesep == core.println_str()
+        assert os.linesep == core.println_str("")
+        assert ":kw" + os.linesep == core.println_str(kw.keyword("kw"))
+        assert ":hi there 3" + os.linesep == core.println_str(
+            kw.keyword("hi"), "there", 3
+        )
 
 
 class TestRegexFunctions:


### PR DESCRIPTION
Hi,

can you please consider patch to emit OS specific line endings for print fns. It fixes #810.

thanks