### PR TITLE
support any char in character literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Allow `case` forms with only a default expression (#807)
  * Make `pr` a dynamic variable (#820)
  * Emit OS specific line endings for the `println` and `prn` fns (#810)
+ * Support any character in character literals (#816)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -1293,7 +1293,7 @@ def _read_character(ctx: ReaderContext) -> str:
     """Read a character literal from the input stream.
 
     Character literals may appear as:
-      - \\a \\b \\c etc will yield 'a', 'b', and 'c' respectively
+      - \\a \\$ \\[ etc will yield 'a', '$', and '[' respectively
 
       - \\newline, \\space, \\tab, \\formfeed, \\backspace, \\return yield
         the named characters
@@ -1306,13 +1306,13 @@ def _read_character(ctx: ReaderContext) -> str:
     s: List[str] = []
     reader = ctx.reader
     token = reader.peek()
+    is_first_char = True
     while True:
-        if token == "" or whitespace_chars.match(token):
-            break
-        if not alphanumeric_chars.match(token):
+        if token == "" or (not is_first_char and not alphanumeric_chars.match(token)):
             break
         s.append(token)
         token = reader.next_token()
+        is_first_char = False
 
     char = "".join(s)
     special = _SPECIAL_CHARS.get(char, None)

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -1288,6 +1288,10 @@ def test_deref():
 
 def test_character_literal():
     assert "a" == read_str_first("\\a")
+    assert "[" == read_str_first("\\[")
+    assert "," == read_str_first("\\,")
+    assert "^" == read_str_first("\\^")
+    assert " " == read_str_first("\\ ")
     assert "Ω" == read_str_first("\\Ω")
 
     assert "Ω" == read_str_first("\\u03A9")
@@ -1300,6 +1304,7 @@ def test_character_literal():
     assert "\r" == read_str_first("\\return")
 
     assert vec.v("a") == read_str_first("[\\a]")
+    assert vec.v("]") == read_str_first("[\\]]")
     assert vec.v("Ω") == read_str_first("[\\Ω]")
 
     assert llist.l(sym.symbol("str"), "Ω") == read_str_first("(str \\u03A9)")


### PR DESCRIPTION
Hi,

could you please consider patch to accept any character by the reader as character literal. It fixes #816.

I've updated the test to include the new cases.

Thanks