### PR TITLE
Pin sphinx applehelp version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
  * Improve the state of the Python type hints in `basilisp.lang.*` (#797, #784)
+ * Pin the `sphinxcontrib-*` dependencies versions to fix Read The Docs builds issue (#815)
 
 
 ## [v0.1.0b0]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,11 @@
 sphinx~=4.4.0
 sphinx-rtd-theme==1.3.0
-sphinxcontrib-applehelp==1.0.7
+# The Read the Docs CI build is facing an issue where it doesn't
+# automatically identify the correct dependencies versions compatible
+# with Sphinx 4.4.0.  As a result, we need to explicitly specify these
+# versions.
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx~=4.4.0
 sphinx-rtd-theme==1.3.0
+sphinxcontrib-applehelp==1.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,11 @@ isort = "*"
 pygments = "*"
 pytest = "^7.0.0"
 pytest-pycharm = "*"
-sphinx = "*"
-sphinx-rtd-theme = "*"
+# Ensure the Sphinx version remains synchronized with
+# docs/requirements.txt to maintain consistent output during both
+# development and publishing on Read The Docs.
+sphinx = "~=4.4.0"
+sphinx-rtd-theme = "1.3.0"
 tox = "*"
 
 [tool.poetry.extras]


### PR DESCRIPTION
Attempt to fix #815.

There appears to be a recent new sphinx-apphelper version that is not compatible with sphinx 4.4.0?

deptree
``` 
basilisp==0.1.0b0
...
sphinx-rtd-theme==2.0.0
└── sphinxcontrib-jquery [required: >=4,<5, installed: 4.1]
    └── sphinx [required: >=1.8, installed: 7.1.2]
        ├── alabaster [required: >=0.7,<0.8, installed: 0.7.13]
        ├── Babel [required: >=2.9, installed: 2.14.0]
        ├── colorama [required: >=0.4.5, installed: 0.4.6]
        ├── docutils [required: >=0.18.1,<0.21, installed: 0.20.1]
        ├── imagesize [required: >=1.3, installed: 1.4.1]
        ├── Jinja2 [required: >=3.0, installed: 3.1.3]
        │   └── MarkupSafe [required: >=2.0, installed: 2.1.3]
        ├── packaging [required: >=21.0, installed: 23.2]
        ├── pygments [required: >=2.13, installed: 2.17.2]
        ├── requests [required: >=2.25.0, installed: 2.31.0]
        │   ├── certifi [required: >=2017.4.17, installed: 2023.11.17]
        │   ├── charset-normalizer [required: >=2,<4, installed: 3.3.2]
        │   ├── idna [required: >=2.5,<4, installed: 3.6]
        │   └── urllib3 [required: >=1.21.1,<3, installed: 2.1.0]
        ├── snowballstemmer [required: >=2.0, installed: 2.2.0]
        ├── sphinxcontrib-applehelp [required: Any, installed: 1.0.4]
        ├── sphinxcontrib-devhelp [required: Any, installed: 1.0.2]
        ├── sphinxcontrib-htmlhelp [required: >=2.0.0, installed: 2.0.1]
        ├── sphinxcontrib-jsmath [required: Any, installed: 1.0.1]
        ├── sphinxcontrib-qthelp [required: Any, installed: 1.0.3]
        └── sphinxcontrib-serializinghtml [required: >=1.1.5, installed: 1.1.5]
...
```

