### PR TITLE
Make `pr` a dynamic var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Generate Protocol functions with nicer names based on the protocol function and dispatch type (#803)
  * Loosen the dependency specification for Immutables and Pyrsistent to allow for a wider version range (#805)
  * Allow `case` forms with only a default expression (#807)
+ * Make `pr` a dynamic variable (#820)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4116,7 +4116,10 @@
   value bound to :lpy:var:`*print-sep*` (default is an ASCII space).
 
   Note that some dynamically created Basilisp forms (such keywords and symbols) and
-  Python objects may not be readable again."
+  Python objects may not be readable again.
+
+  It can be dynamically bound."
+  {:dynamic true}
   ([] nil)
   ([x]
    (.write *out* (repr x))

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2084,3 +2084,11 @@
       (finally
         (when (bio/exists? load-dir-test)
           (shutil/rmtree load-dir-test))))))
+
+;;;;;;;;;;;;;;
+;; printing ;;
+;;;;;;;;;;;;;;
+
+(deftest pr-test
+  (testing "is dynamic"
+    (is (= '(1) (binding [pr (fn [& more] more)] (pr 1))))))


### PR DESCRIPTION
Hi,

could you please review patch to dynamically bind core `pr` fn. It fixes #820.

Thanks