### PR TITLE
Attempt to fix the intermittent test failures with nREPL on macos.

### DIFF
--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -159,7 +159,7 @@ class TestnREPLServer:
             # the high retries number is to address the slowness when
             # running on pypy.
             retries = 60
-            while not os.path.exists(tmpfilepath):
+            while not os.path.exists(tmpfilepath) or os.stat(tmpfilepath).st_size == 0:
                 time.sleep(1)
                 retries -= 1
                 assert 0 <= retries


### PR DESCRIPTION
Hi,

could you please review patch to attempt to fix the intermittent failures of the nrepl server cli test on macos. It fixes #824.

It seems that the server has not been given the chance to write the port number to the newly created file, so it attempts to yield control back to the server.

Thanks