### PR TITLE
CI test for minimal python & deps versions support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -123,6 +123,7 @@ jobs:
           TOXENV: ${{ matrix.tox-env }}
         run: |
           DEPENDENCY_REGEX="$(poetry show -T --without=dev | awk '{print $1}' | paste -s -d '|' -)"
+          echo :deps $DEPENDENCY_REGEX
           sed -i -E 's/('"$DEPENDENCY_REGEX"')( = )"(\^|>=)([0-9])/\1\2"==\4/' pyproject.toml
           git diff
           tox run-parallel -p 2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -77,6 +77,55 @@ jobs:
           name: code-coverage
           path: coverage/.coverage.py*
 
+  min-deps-test:
+    # Run the TOX-ENV tests for the given OS and python VERSION, for
+    # the dependencies mentioned in DEPS-REGEX.
+    #
+    # The dependencies affected are expected to be found in
+    # `pyproject.toml` and have the following format
+    #
+    # <dependency-name> = "^..."
+    # or 
+    # <dependency-name> = ">=..."
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        version: ['3.8']
+        tox-env: ['py38']
+        deps-regex: ['attrs|immutables|prompt-toolkit|pyrsistent|python-dateutil|readerwriterlock|typing_extensions']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v3
+        with:
+          path: |
+            .tox
+            ~/.cache/pip
+            ~/.cache/pypoetry
+            ~/.local/share/pypoetry
+          key: ${{ runner.os }}-python-min-deps-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+      - name: Install Poetry
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: curl -sSL https://install.python-poetry.org | python3 -
+      - name: Install Tox
+        run: |
+          pip install -U pip
+          pip install tox
+      - name: Run tests
+        env:
+          TOX_PARALLEL_NO_SPINNER: 1
+          TOX_SHOW_OUTPUT: "True"
+          TOXENV: ${{ matrix.tox-env }}
+        run: |
+          sed -i -E 's/(${{ matrix.deps-regex }})( = )"(\^|>=)([0-9])/\1\2"==\4/' pyproject.toml
+          git diff
+          tox run-parallel -p 2
+
   report-coverage:
     runs-on: ubuntu-latest
     needs: run-tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,11 +78,12 @@ jobs:
           path: coverage/.coverage.py*
 
   min-deps-test:
-    # Run the TOX-ENV tests for the given OS and python VERSION, for
-    # the dependencies mentioned in DEPS-REGEX.
+    # Run the TOX-ENV tests for the given OS and python VERSION with
+    # the minimal possible Basilisp dependencies versions.
     #
-    # The dependencies affected are expected to be found in
-    # `pyproject.toml` and have the following format
+    # For dependencies to be elligible for minimal version testing,
+    # they should be declared in `pyproject.toml` as such in the
+    # following format
     #
     # <dependency-name> = "^..."
     # or 
@@ -93,12 +94,11 @@ jobs:
         os: [ubuntu-latest]
         version: ['3.8']
         tox-env: ['py38']
-        deps-regex: ['attrs|immutables|prompt-toolkit|pyrsistent|python-dateutil|readerwriterlock|typing_extensions']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.version }}
       - name: Cache dependencies
         id: cache-deps
         uses: actions/cache@v3
@@ -122,7 +122,8 @@ jobs:
           TOX_SHOW_OUTPUT: "True"
           TOXENV: ${{ matrix.tox-env }}
         run: |
-          sed -i -E 's/(${{ matrix.deps-regex }})( = )"(\^|>=)([0-9])/\1\2"==\4/' pyproject.toml
+          DEPENDENCY_REGEX="$(poetry show -T --without=dev | awk '{print $1}' | paste -s -d '|' -)"
+          sed -i -E 's/('"$DEPENDENCY_REGEX"')( = )"(\^|>=)([0-9])/\1\2"==\4/' pyproject.toml
           git diff
           tox run-parallel -p 2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -78,8 +78,9 @@ jobs:
           path: coverage/.coverage.py*
 
   min-deps-test:
-    # Run the TOX-ENV tests for the given OS and python VERSION with
-    # the minimal possible Basilisp dependencies versions.
+    # Attempt to run the TOX-ENV tests for the given OS and python
+    # VERSION with the minimal possible Basilisp dependencies
+    # versions.
     #
     # For dependencies to be elligible for minimum version testing,
     # they should be declared in `pyproject.toml` as such in the
@@ -89,14 +90,6 @@ jobs:
     # <dependency-name> = ">=..."
     # <dependency-name> = { version = "^..." ...
     # <dependency-name> = { version = ">=..." ...
-    #
-    # Note that the intention is to modify only the lines in
-    # [tool.poetry.dependencies]. However, the current implementation
-    # for simplicity will blindly alter all lines starting with the
-    # above patterns in the file. While this includes
-    # [tool.poetry.dev-dependencies] too (which is deemed acceptable),
-    # it is important to consistently assess that no other section is
-    # adversely affected in the future.
     runs-on: ${{matrix.os}}
     strategy:
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,7 +81,7 @@ jobs:
     # Run the TOX-ENV tests for the given OS and python VERSION with
     # the minimal possible Basilisp dependencies versions.
     #
-    # For dependencies to be elligible for minimal version testing,
+    # For dependencies to be elligible for minimum version testing,
     # they should be declared in `pyproject.toml` as such in the
     # following format
     #
@@ -89,6 +89,14 @@ jobs:
     # <dependency-name> = ">=..."
     # <dependency-name> = { version = "^..." ...
     # <dependency-name> = { version = ">=..." ...
+    #
+    # Note that the intention is to modify only the lines in
+    # [tool.poetry.dependencies]. However, the current implementation
+    # for simplicity will blindly alter all lines starting with the
+    # above patterns in the file. While this includes
+    # [tool.poetry.dev-dependencies] too (which is deemed acceptable),
+    # it is important to consistently assess that no other section is
+    # adversely affected in the future.
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -117,7 +125,7 @@ jobs:
         run: |
           pip install -U pip
           pip install tox
-      - name: Run tests
+      - name: Run minimum deps test
         env:
           TOX_PARALLEL_NO_SPINNER: 1
           TOX_SHOW_OUTPUT: "True"
@@ -127,10 +135,7 @@ jobs:
           DEPENDENCY_REGEX="$(poetry show -T --without=dev | awk '{print $1}' | paste -s -d '|' -)"
           [[ -z "$DEPENDENCY_REGEX" ]] && { echo "Error: can't source dependencies" ; exit 1; }
           echo ::deps $DEPENDENCY_REGEX
-          SEC_START="$(sed -n '\/^\[tool.poetry.dependencies\]$/=' pyproject.toml)"
-          SEC_END="$(sed -n '\/^\[tool.poetry.dev-dependencies\]$/=' pyproject.toml)"
-          echo ::pyproject.toml-section :line-start $SEC_START :line-end $SEC_END
-          sed -i -E ''$SEC_START,$SEC_END's/('$DEPENDENCY_REGEX')( = )(|\{ version = )"(\^|>=)([0-9])/\1\2\3"==\5/' pyproject.toml
+          sed -i -E 's/('$DEPENDENCY_REGEX')( = )(|\{ version = )"(\^|>=)([0-9])/\1\2\3"==\5/' pyproject.toml
           git diff
           tox run-parallel -p 2
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,8 +86,9 @@ jobs:
     # following format
     #
     # <dependency-name> = "^..."
-    # or 
     # <dependency-name> = ">=..."
+    # <dependency-name> = { version = "^..." ...
+    # <dependency-name> = { version = ">=..." ...
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
@@ -108,7 +109,7 @@ jobs:
             ~/.cache/pip
             ~/.cache/pypoetry
             ~/.local/share/pypoetry
-          key: ${{ runner.os }}-python-min-deps-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+          key: mdt-${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
       - name: Install Poetry
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: curl -sSL https://install.python-poetry.org | python3 -
@@ -122,9 +123,14 @@ jobs:
           TOX_SHOW_OUTPUT: "True"
           TOXENV: ${{ matrix.tox-env }}
         run: |
+          poetry lock
           DEPENDENCY_REGEX="$(poetry show -T --without=dev | awk '{print $1}' | paste -s -d '|' -)"
-          echo :deps $DEPENDENCY_REGEX
-          sed -i -E 's/('"$DEPENDENCY_REGEX"')( = )"(\^|>=)([0-9])/\1\2"==\4/' pyproject.toml
+          [[ -z "$DEPENDENCY_REGEX" ]] && { echo "Error: can't source dependencies" ; exit 1; }
+          echo ::deps $DEPENDENCY_REGEX
+          SEC_START="$(sed -n '\/^\[tool.poetry.dependencies\]$/=' pyproject.toml)"
+          SEC_END="$(sed -n '\/^\[tool.poetry.dev-dependencies\]$/=' pyproject.toml)"
+          echo ::pyproject.toml-section :line-start $SEC_START :line-end $SEC_END
+          sed -i -E ''$SEC_START,$SEC_END's/('$DEPENDENCY_REGEX')( = )(|\{ version = )"(\^|>=)([0-9])/\1\2\3"==\5/' pyproject.toml
           git diff
           tox run-parallel -p 2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Make `pr` a dynamic variable (#820)
  * Emit OS specific line endings for the `println` and `prn` fns (#810)
  * Support any character in character literals (#816)
+ * Loosen `typing-extensions` dependency's minimal version to 4.7.0 (#809)
 
 ### Fixed
  * Fix issue with `(count nil)` throwing an exception (#759)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = ["README.md", "LICENSE"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-attrs = ">=20.1.0"
+attrs = ">=20.2.0"
 immutables = ">=0.20,<1.0.0"
 prompt-toolkit = "^3.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ prompt-toolkit = "^3.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"
 python-dateutil = "^2.8.1"
 readerwriterlock = "^1.0.8"
-typing_extensions = "^4.9.0"
+typing-extensions = "^4.9.0"
 
 astor = { version = "^0.8.1", python = "<3.9", optional = true }
 pytest = { version = "^7.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,6 @@ classifiers = [
 ]
 include = ["README.md", "LICENSE"]
 
-# Ensure that [tool.poetry.dependencies] and
-# [tool.poetry.dev-dependencies] are kept adjacent to each other in
-# that order. This arrangement is essential for the min-deps-test CI
-# job to effectively enforce minimal dependencies versions for its
-# testing.
 [tool.poetry.dependencies]
 python = "^3.8"
 attrs = ">=20.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ prompt-toolkit = "^3.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"
 python-dateutil = "^2.8.1"
 readerwriterlock = "^1.0.8"
-typing-extensions = "^4.9.0"
+typing-extensions = "^4.7.0"
 
 astor = { version = "^0.8.1", python = "<3.9", optional = true }
 pytest = { version = "^7.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ classifiers = [
 ]
 include = ["README.md", "LICENSE"]
 
+# Ensure that [tool.poetry.dependencies] and
+# [tool.poetry.dev-dependencies] are kept adjacent to each other in
+# that order. This arrangement is essential for the min-deps-test CI
+# job to effectively enforce minimal dependencies versions for its
+# testing.
 [tool.poetry.dependencies]
 python = "^3.8"
 attrs = ">=20.2.0"


### PR DESCRIPTION
Hi,

could you please review proposal to have a CI test against checking the minimal support python and deps version can pass the test suite. It fixes #826.

The job is expected to fail the first time it runs, because attrs minimal version of 20.1.0 fails to bootstrap the tests, which is also proving the point of this patch.

It will subsequently be corrected to the next available version which will pass the test.

Thanks

