### PR TITLE
Fix issue with `test/is` in macros may not gen detailed info on fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with the variadic ampersand operator treated as a binding in macros (#772)
  * Fix a bug the variadic arg symbol was not correctly bound to `nil` when no variadic arguments were provided (#801)
  * Fix a bug where the quotient of very large numbers was incorrect (#822)
+ * Fix a bug where `basilisp.test/is` may fail to generate expected/actual info on failures when declared inside a macro (#829)
 
 ### Removed
  * Removed support for PyPy 3.8 (#785)

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -73,7 +73,7 @@
   "Implementation detail of :lpy:fn:`is` for generating macros."
   (fn [expr _ _]
     (cond
-      (list? expr) (first expr)
+      (and (sequential? expr) (not (vector? expr))) (symbol (name (first expr)))
       :else        :default)))
 
 (defmethod gen-assert '=

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -37,6 +37,12 @@ class TestTestrunner:
         (deftest error-test
           (throw
             (ex-info "This test will count as an error." {})))
+
+        ;; syntax quote expands lists to seqs.
+        (defmacro syntax-quote-test-make []
+          `(deftest syntax-quote-seq-test
+             (is (= 5 4))))
+        (syntax-quote-test-make)
         """
         pytester.makefile(".lpy", test_testrunner=code)
         pytester.syspathinsert()
@@ -44,7 +50,7 @@ class TestTestrunner:
         runtime.Namespace.remove(sym.symbol("test-testrunner"))
 
     def test_outcomes(self, run_result: pytest.RunResult):
-        run_result.assert_outcomes(passed=1, failed=2)
+        run_result.assert_outcomes(passed=1, failed=3)
 
     def test_failure_repr(self, run_result: pytest.RunResult):
         run_result.stdout.fnmatch_lines(
@@ -77,6 +83,17 @@ class TestTestrunner:
                 "",
                 '    expected: "true"',
                 "      actual: false",
+            ],
+            consecutive=True,
+        )
+
+        run_result.stdout.fnmatch_lines(
+            [
+                "FAIL in (syntax-quote-seq-test) (test_testrunner.lpy)",
+                "    Test failure: (basilisp.core/= 5 4)",
+                "",
+                "    expected: 5",
+                "      actual: 4",
             ],
             consecutive=True,
         )


### PR DESCRIPTION
Hi,

could you please  consider fix to fix na issue with `(basilisp.core/is (= ...)` not dispatching correctly when `(= ..)` is a seq. It fixes #829.

This issue manifests itself in macros where an the `(= ..)` in ``` `(is (= ...))``` form is expanded to a seq rather than a list, which should be treated accordingly by the = dispatch fn.

Thanks 