### PR TITLE
Fix `basilisp.test/is` macro error reporting when used within macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ lispcore.py
 .envrc
 poetry.lock
 **/*.~undo-tree~
+.nrepl-port

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added a subcommand for bootstrapping the Python installation with Basilisp (#790)
  * Added support for executing Basilisp namespaces directly via `basilisp run` and by `python -m` (#791)
  * Added the `memoize` core fn (#812)
+ * Added support for `thrown-with-msg?` assertions to `basilisp.test/is` (#831)
 
 ### Changed
  * Optimize calls to Python's `operator` module into their corresponding native operators (#754)
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with the variadic ampersand operator treated as a binding in macros (#772)
  * Fix a bug the variadic arg symbol was not correctly bound to `nil` when no variadic arguments were provided (#801)
  * Fix a bug where the quotient of very large numbers was incorrect (#822)
+ * Fix a bug where `basilisp.test/is` may fail to generate expected/actual info on failures when declared inside a macro (#829)
 
 ### Removed
  * Removed support for PyPy 3.8 (#785)

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -73,12 +73,20 @@
   "Implementation detail of :lpy:fn:`is` for generating macros."
   (fn [expr _ _]
     (cond
-      (list? expr) (first expr)
-      :else        :default)))
+      (vector? expr)     :default
+      (sequential? expr) (let [maybe-f (first expr)]
+                           (if (and (symbol? maybe-f)
+                                    (or (= 'basilisp.core/= maybe-f)
+                                        (#{'thrown-with-msg? 'thrown?} (symbol (name maybe-f)))))
+                             (symbol (name maybe-f))
+                             maybe-f))
+      :else              :default)))
 
+;; clojure.test does not special case '=, but this means that its expected/actual
+;; results just show expected `expr` and `(not expr)`
 (defmethod gen-assert '=
   [expr msg line-num]
-  `(let [actual# ~(nth expr 2)
+  `(let [actual#   ~(nth expr 2)
          expected# ~(second expr)]
      (when-not (= expected# actual#)
        (vswap! *test-failures*
@@ -121,6 +129,50 @@
                   :line         ~line-num
                   :type         :failure})))))
 
+(defmethod gen-assert 'thrown-with-msg?
+  [expr msg line-num]
+  (let [exc-type (second expr)
+        pattern  (nth expr 2)
+        body     (nthnext expr 3)]
+    `(try
+       (let [result# (do ~@body)]
+         (vswap! *test-failures*
+                 conj
+                 {:test-name    *test-name*
+                  :test-section *test-section*
+                  :message      ~msg
+                  :expr         (quote ~expr)
+                  :actual       result#
+                  :expected     (quote ~exc-type)
+                  :line         ~line-num
+                  :type         :failure}))
+       (catch ~exc-type e#
+         ;; Use python/str rather than Basilisp str to get the raw "message"
+         ;; from the exception.
+         (let [string-exc# (python/str e#)]
+           (when-not (re-find ~pattern string-exc#)
+             (vswap! *test-failures*
+                     conj
+                     {:test-name    *test-name*
+                      :test-section *test-section*
+                      :message      "Regex pattern did not match"
+                      :expr         (quote ~expr)
+                      :actual       string-exc#
+                      :expected     ~pattern
+                      :line         ~line-num
+                      :type         :failure}))))
+       (catch python/Exception e#
+         (vswap! *test-failures*
+                 conj
+                 {:test-name    *test-name*
+                  :test-section *test-section*
+                  :message      (str "Expected " ~exc-type "; got " (python/type e#) " instead")
+                  :expr         (quote ~expr)
+                  :actual       e#
+                  :expected     ~exc-type
+                  :line         ~line-num
+                  :type         :failure})))))
+
 (defmethod gen-assert :default
   [expr msg line-num]
   `(let [computed# ~expr]
@@ -148,6 +200,10 @@
     is the expected value and the second element is the actual value
   - ``(is (thrown? ExceptionType expr))`` generates a basic assertion that ``expr``
     does generate an exception of the type ``ExceptionType``
+  - ``(is (thrown-with-msg? ExceptionType pattern expr))`` generates a basic assertion
+    that ``expr`` does generate an exception of the type ``ExceptionType`` and that
+    the stringified exception (as by ``python/str``) matches the regular expression
+    ``pattern`` using :lpy:fn:`re-find`
   - ``(is expr)`` is the most basic assertion type that just asserts that ``expr`` is
     truthy
 


### PR DESCRIPTION
Fixes #829 