### PR TITLE
Store Poetry binary in the cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,8 +47,9 @@ jobs:
             .tox
             ~/.cache/pip
             ~/.cache/pypoetry
+            ~/.local/bin/poetry
             ~/.local/share/pypoetry
-          key: ${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+          key: ${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('.github/workflows/run-tests.yml', 'pyproject.toml', 'tox.ini') }}
       - name: Install Poetry
         if: steps.cache-deps.outputs.cache-hit != 'true' && ! startsWith (matrix.os, 'windows')
         run: curl -sSL https://install.python-poetry.org | python3 -
@@ -102,17 +103,18 @@ jobs:
         with:
           python-version: ${{ matrix.version }}
       - name: Cache dependencies
-        id: min-deps-test-cache-deps
+        id: cache-deps
         uses: actions/cache@v3
         with:
           path: |
             .tox
             ~/.cache/pip
             ~/.cache/pypoetry
+            ~/.local/bin/poetry
             ~/.local/share/pypoetry
-          key: min-deps-test-${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('pyproject.toml', 'tox.ini') }}
+          key: min-deps-test-${{ runner.os }}-python-${{ matrix.version }}-poetry-${{ hashFiles('.github/workflows/run-tests.yml', 'pyproject.toml', 'tox.ini') }}
       - name: Install Poetry
-        if: steps.min-deps-test-cache-deps.outputs.cache-hit != 'true'
+        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Install Tox
         run: |


### PR DESCRIPTION
There was an issue in #827 where subsequent runs of the minimum dependencies job would fail due to a missing Poetry binary. I believe the cause of that was a missing cache path. The cache paths were copied from the other `run-tests` job which was also wrong, but which did not ever try to execute `poetry` binary directly so the missing binary issue was never discovered.