### PR TITLE
Warn at compile time on arity mismatch for function invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added filename metadata to compiler exceptions (#844)
- * Added a compile-time warning for attemping to call a function with an unsupported number of arguments (#671)
+ * Added a compile-time warning for attempting to call a function with an unsupported number of arguments (#671)
 
 ### Fixed
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)
+ * Fix a bug where the function returned by `partial` retained the meta, arities, and `with_meta` method of the wrapped function rather than creating new ones (#847)
 
 ## [v0.1.0b1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added filename metadata to compiler exceptions (#844)
+ * Added a compile-time warning for attemping to call a function with an unsupported number of arguments (#671)
 
 ### Fixed
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)

--- a/docs/compiler.rst
+++ b/docs/compiler.rst
@@ -35,6 +35,12 @@ Warnings
 
 The following settings enable and disable warnings from the Basilisp compiler during compilation.
 
+* ``warn-on-arity-mismatch`` - if ``true``, emit warnings if a Basilisp function invocation is detected with an unsupported number of arguments
+
+  * Environment Variable: ``BASILISP_WARN_ON_ARITY_MISMATCH``
+  * Default: ``true``
+
+
 * ``warn-on-shadowed-name`` - if ``true``, emit warnings if a local name is shadowed by another local name
 
   * Environment Variable: ``BASILISP_WARN_ON_SHADOWED_NAME``

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -137,6 +137,19 @@ def _add_compiler_arg_group(parser: argparse.ArgumentParser) -> None:
         ),
     )
     group.add_argument(
+        "--warn-on-arity-mismatch",
+        action="store",
+        nargs="?",
+        const=os.getenv("BASILISP_WARN_ON_ARITY_MISMATCH"),
+        type=_to_bool,
+        help=(
+            "if true, emit warnings if a Basilisp function invocation is detected with "
+            "an unsupported number of arguments "
+            "(env: BASILISP_WARN_ON_ARITY_MISMATCH; default: "
+            f"{DEFAULT_COMPILER_OPTS['warn-on-arity-mismatch']})"
+        ),
+    )
+    group.add_argument(
         "--warn-on-shadowed-name",
         action="store",
         nargs="?",

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -30,7 +30,7 @@ def pytest_collect_file(file_path: Path, path, parent):
     """Primary PyTest hook to identify Basilisp test files."""
     if file_path.suffix == ".lpy":
         if file_path.name.startswith("test_") or file_path.stem.endswith("_test"):
-            return BasilispFile.from_parent(parent, fspath=path, path=file_path)
+            return BasilispFile.from_parent(parent, path=file_path)
     return None
 
 

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -10,6 +10,7 @@ from basilisp.lang import runtime as runtime
 from basilisp.lang.compiler.analyzer import (  # noqa
     GENERATE_AUTO_INLINES,
     INLINE_FUNCTIONS,
+    WARN_ON_ARITY_MISMATCH,
     WARN_ON_NON_DYNAMIC_SET,
     WARN_ON_SHADOWED_NAME,
     WARN_ON_SHADOWED_VAR,
@@ -32,6 +33,7 @@ from basilisp.lang.compiler.generator import statementize as _statementize
 from basilisp.lang.compiler.optimizer import PythonASTOptimizer
 from basilisp.lang.typing import CompilerOpts, ReaderForm
 from basilisp.lang.util import genname
+from basilisp.util import Maybe
 
 _DEFAULT_FN = "__lisp_expr__"
 
@@ -97,6 +99,7 @@ class CompilerContext:
 def compiler_opts(  # pylint: disable=too-many-arguments
     generate_auto_inlines: Optional[bool] = None,
     inline_functions: Optional[bool] = None,
+    warn_on_arity_mismatch: Optional[bool] = None,
     warn_on_shadowed_name: Optional[bool] = None,
     warn_on_shadowed_var: Optional[bool] = None,
     warn_on_unused_names: Optional[bool] = None,
@@ -108,15 +111,16 @@ def compiler_opts(  # pylint: disable=too-many-arguments
     return lmap.map(
         {
             # Analyzer options
-            GENERATE_AUTO_INLINES: generate_auto_inlines or True,
-            INLINE_FUNCTIONS: inline_functions or True,
-            WARN_ON_SHADOWED_NAME: warn_on_shadowed_name or False,
-            WARN_ON_SHADOWED_VAR: warn_on_shadowed_var or False,
-            WARN_ON_UNUSED_NAMES: warn_on_unused_names or True,
-            WARN_ON_NON_DYNAMIC_SET: warn_on_non_dynamic_set or True,
+            GENERATE_AUTO_INLINES: Maybe(generate_auto_inlines).or_else_get(True),
+            INLINE_FUNCTIONS: Maybe(inline_functions).or_else_get(True),
+            WARN_ON_ARITY_MISMATCH: Maybe(warn_on_arity_mismatch).or_else_get(True),
+            WARN_ON_SHADOWED_NAME: Maybe(warn_on_shadowed_name).or_else_get(False),
+            WARN_ON_SHADOWED_VAR: Maybe(warn_on_shadowed_var).or_else_get(False),
+            WARN_ON_UNUSED_NAMES: Maybe(warn_on_unused_names).or_else_get(True),
+            WARN_ON_NON_DYNAMIC_SET: Maybe(warn_on_non_dynamic_set).or_else_get(True),
             # Generator options
-            USE_VAR_INDIRECTION: use_var_indirection or False,
-            WARN_ON_VAR_INDIRECTION: warn_on_var_indirection or True,
+            USE_VAR_INDIRECTION: Maybe(use_var_indirection).or_else_get(False),
+            WARN_ON_VAR_INDIRECTION: Maybe(warn_on_var_indirection).or_else_get(True),
         }
     )
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2492,10 +2492,9 @@ def _do_warn_on_arity_mismatch(
                     if fn.env.line is not None
                     else f" ({fn.env.file})"
                 )
-                print(fn, arities)
                 logger.warning(
                     f"calling function {fn.var}{loc} with {num_args} arguments; "
-                    f"expected any of: {', '.join(map(str, report_arities))}",
+                    f"expected any of: {', '.join(sorted(map(str, report_arities)))}",
                 )
 
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2487,9 +2487,14 @@ def _do_warn_on_arity_mismatch(
                 if has_variadic:
                     report_arities.discard(cast(int, max_fixed_arity))
                     report_arities.add(f"{max_fixed_arity}+")
-                loc = f"{fn.env.file}:{fn.env.line}"
+                loc = (
+                    f" ({fn.env.file}:{fn.env.line})"
+                    if fn.env.line is not None
+                    else f" ({fn.env.file})"
+                )
+                print(fn, arities)
                 logger.warning(
-                    f"calling function {fn.var} ({loc}) with {num_args} arguments; "
+                    f"calling function {fn.var}{loc} with {num_args} arguments; "
                     f"expected any of: {', '.join(map(str, report_arities))}",
                 )
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2473,19 +2473,22 @@ def _do_warn_on_arity_mismatch(
         )
         if arities is not None:
             has_variadic = REST_KW in arities
-            fixed_arities = frozenset(filter(lambda v: v is not REST_KW, arities))
+            fixed_arities = set(filter(lambda v: v != REST_KW, arities))
             max_fixed_arity = max(fixed_arities) if fixed_arities else None
             # This count could be off by 1 for cases where kwargs are being passed,
             # but only Basilisp functions intended to be called by Python code
             # (e.g. with a :kwargs strategy) should ever be called with kwargs,
             # so this seems unlikely enough.
             num_args = runtime.count(form.rest)
-            if has_variadic and max_fixed_arity is None or num_args > max_fixed_arity:
+            if has_variadic and (max_fixed_arity is None or num_args > max_fixed_arity):
                 return
             if num_args not in fixed_arities:
+                if has_variadic:
+                    fixed_arities.discard(max_fixed_arity)
+                    fixed_arities.add(f"{max_fixed_arity}+")
                 logger.warning(
                     f"calling function {fn.var} with {num_args} arguments; "
-                    f"expected any of: {', '.join(map(str, arities))}"
+                    f"expected any of: {', '.join(map(str, fixed_arities))}"
                 )
 
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2483,12 +2483,14 @@ def _do_warn_on_arity_mismatch(
             if has_variadic and (max_fixed_arity is None or num_args > max_fixed_arity):
                 return
             if num_args not in fixed_arities:
+                report_arities = cast(Set[Union[int, str]], set(fixed_arities))
                 if has_variadic:
-                    fixed_arities.discard(max_fixed_arity)
-                    fixed_arities.add(f"{max_fixed_arity}+")
+                    report_arities.discard(cast(int, max_fixed_arity))
+                    report_arities.add(f"{max_fixed_arity}+")
+                loc = f"{fn.env.file}:{fn.env.line}"
                 logger.warning(
-                    f"calling function {fn.var} with {num_args} arguments; "
-                    f"expected any of: {', '.join(map(str, fixed_arities))}"
+                    f"calling function {fn.var} ({loc}) with {num_args} arguments; "
+                    f"expected any of: {', '.join(map(str, report_arities))}",
                 )
 
 

--- a/src/basilisp/lang/compiler/constants.py
+++ b/src/basilisp/lang/compiler/constants.py
@@ -52,6 +52,8 @@ SYM_STATICMETHOD_META_KEY = kw.keyword("staticmethod")
 SYM_TAG_META_KEY = kw.keyword("tag")
 
 ARGLISTS_KW = kw.keyword("arglists")
+INTERFACE_KW = kw.keyword("interface")
+REST_KW = kw.keyword("rest")
 COL_KW = kw.keyword("col")
 DOC_KW = kw.keyword("doc")
 FILE_KW = kw.keyword("file")

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -3231,7 +3231,6 @@ def _interop_prop_to_py_ast(
     assert node.op == NodeOp.HOST_FIELD
 
     target_ast = gen_py_ast(ctx, node.target)
-    assert not target_ast.dependencies
 
     return GeneratedPyAST(
         node=ast.Attribute(

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -45,6 +45,8 @@ from basilisp.lang import symbol as sym
 from basilisp.lang import vector as vec
 from basilisp.lang.compiler.constants import (
     DEFAULT_COMPILER_FILE_PATH,
+    INTERFACE_KW,
+    REST_KW,
     SYM_DYNAMIC_META_KEY,
     SYM_NO_WARN_ON_REDEF_META_KEY,
     SYM_REDEF_META_KEY,
@@ -131,10 +133,6 @@ _SET_BANG_TEMP_PREFIX = "set_bang_val"
 _THROW_PREFIX = "lisp_throw"
 _TRY_PREFIX = "lisp_try"
 _NS_VAR = "_NS"
-
-# Keyword constants used in generating code
-_INTERFACE_KW = kw.keyword("interface")
-_REST_KW = kw.keyword("rest")
 
 
 @attr.frozen
@@ -1417,7 +1415,7 @@ def __deftype_or_reify_bases_to_py_ast(
                         ast.Call(
                             func=_NEW_KW_FN_NAME,
                             args=[
-                                ast.Constant(hash(_INTERFACE_KW)),
+                                ast.Constant(hash(INTERFACE_KW)),
                                 ast.Constant("interface"),
                             ],
                             keywords=[],
@@ -1695,7 +1693,7 @@ def __fn_decorator(
                                     ast.Call(
                                         func=_NEW_KW_FN_NAME,
                                         args=[
-                                            ast.Constant(hash(_REST_KW)),
+                                            ast.Constant(hash(REST_KW)),
                                             ast.Constant("rest"),
                                         ],
                                         keywords=[],

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -209,7 +209,7 @@ class RecurType(Enum):
 class RecurPoint:
     loop_id: str
     type: RecurType
-    binding_names: Optional[Collection[str]] = None
+    binding_names: Optional[Iterable[str]] = None
     is_variadic: Optional[bool] = None
     has_recur: bool = False
 
@@ -273,7 +273,7 @@ class GeneratorContext:
             return False
 
     @property
-    def recur_point(self):
+    def recur_point(self) -> RecurPoint:
         return self._recur_points[-1]
 
     @contextlib.contextmanager
@@ -281,7 +281,7 @@ class GeneratorContext:
         self,
         loop_id: str,
         type_: RecurType,
-        binding_names: Optional[Collection[str]] = None,
+        binding_names: Optional[Iterable[str]] = None,
         is_variadic: Optional[bool] = None,
     ):
         self._recur_points.append(
@@ -305,7 +305,7 @@ class GeneratorContext:
             self._st.pop()
 
     @property
-    def current_this(self):
+    def current_this(self) -> sym.Symbol:
         return self._this[-1]
 
     @contextlib.contextmanager
@@ -2567,6 +2567,7 @@ def __loop_recur_to_py_ast(
 ) -> GeneratedPyAST[ast.expr]:
     """Return a Python AST node for `recur` occurring inside a `loop`."""
     assert node.op == NodeOp.RECUR
+    assert ctx.recur_point.binding_names is not None
 
     recur_deps: List[ast.AST] = []
     recur_targets: List[ast.Name] = []

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1286,8 +1286,12 @@ def _conj_ipersistentcollection(coll: IPersistentCollection, *xs):
     return coll.cons(*xs)
 
 
-def _update_arities(f: BasilispFunction, num_args: int) -> None:
-    """Partial applications change the number of arities a function appears to have."""
+def _update_arities_for_partial(f: BasilispFunction, num_args: int) -> None:
+    """Update the `arities` property of a wrapped function.
+
+    Partial applications change the number of arities a function appears to have.
+    This function computes the new `arities` set for the partial function by removing
+    any now-invalid fixed arities from the original function's set."""
     existing_arities: IPersistentSet[Union[kw.Keyword, int]] = f.arities
     new_arities: Set[Union[kw.Keyword, int]] = set()
     for arity in existing_arities:
@@ -1306,7 +1310,7 @@ def partial(f, *args, **kwargs):
         return f(*itertools.chain(args, inner_args), **{**kwargs, **inner_kwargs})
 
     if hasattr(partial_f, "_basilisp_fn"):
-        _update_arities(cast(BasilispFunction, partial_f), len(args))
+        _update_arities_for_partial(cast(BasilispFunction, partial_f), len(args))
 
     return partial_f
 

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1303,14 +1303,15 @@ def _update_signature_for_partial(f: BasilispFunction, num_args: int) -> None:
             new_arities.add(arity)
         elif arity > num_args:
             new_arities.add(arity - num_args)
-    if not new_arities and num_args in existing_arities:
-        new_arities.add(0)
     if not new_arities:
-        logger.warning(
-            f"invalid partial function application of '{f.__name__}' detected: "  # type: ignore[attr-defined]
-            f"{num_args} arguments given; expected any of: "
-            f"{', '.join(sorted(map(str, existing_arities)))}"
-        )
+        if num_args in existing_arities:
+            new_arities.add(0)
+        else:
+            logger.warning(
+                f"invalid partial function application of '{f.__name__}' detected: "  # type: ignore[attr-defined]
+                f"{num_args} arguments given; expected any of: "
+                f"{', '.join(sorted(map(str, existing_arities)))}"
+            )
     f.arities = lset.set(new_arities)
     f.meta = None
     f.with_meta = partial(_fn_with_meta, f)  # type: ignore[method-assign]

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1760,7 +1760,7 @@ def _fn_with_meta(f, meta: Optional[lmap.PersistentMap]):
     return wrapped_f
 
 
-def _basilisp_fn(arities: Tuple[Union[int, kw.Keyword]]):
+def _basilisp_fn(arities: Tuple[Union[int, kw.Keyword], ...]):
     """Create a Basilisp function, setting meta and supplying a with_meta
     method implementation."""
 

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -259,13 +259,11 @@ def sequence(s: Iterable[T]) -> ISeq[T]:
 
 
 @overload
-def _seq_or_nil(s: None) -> None:
-    ...
+def _seq_or_nil(s: None) -> None: ...
 
 
 @overload
-def _seq_or_nil(s: ISeq) -> Optional[ISeq]:
-    ...
+def _seq_or_nil(s: ISeq) -> Optional[ISeq]: ...
 
 
 def _seq_or_nil(s):

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -259,11 +259,13 @@ def sequence(s: Iterable[T]) -> ISeq[T]:
 
 
 @overload
-def _seq_or_nil(s: None) -> None: ...
+def _seq_or_nil(s: None) -> None:
+    ...
 
 
 @overload
-def _seq_or_nil(s: ISeq) -> Optional[ISeq]: ...
+def _seq_or_nil(s: ISeq) -> Optional[ISeq]:
+    ...
 
 
 def _seq_or_nil(s):

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from fractions import Fraction
-from typing import Pattern, Union
+from typing import Callable, Optional, Pattern, Protocol, Union
 
 from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
@@ -11,7 +11,14 @@ from basilisp.lang import queue as lqueue
 from basilisp.lang import set as lset
 from basilisp.lang import symbol as sym
 from basilisp.lang import vector as vec
-from basilisp.lang.interfaces import IPersistentMap, IRecord, ISeq, IType
+from basilisp.lang.interfaces import (
+    IPersistentMap,
+    IPersistentSet,
+    IRecord,
+    ISeq,
+    IType,
+    IWithMeta,
+)
 
 CompilerOpts = IPersistentMap[kw.Keyword, bool]
 
@@ -43,3 +50,13 @@ LispForm = Union[
 PyCollectionForm = Union[dict, list, set, tuple]
 ReaderForm = Union[LispForm, IRecord, ISeq, IType, PyCollectionForm]
 SpecialForm = Union[llist.PersistentList, ISeq]
+
+
+class BasilispFunction(Protocol):
+    _basilisp_fn: bool
+    arities: IPersistentSet[Union[kw.Keyword, int]]
+    meta: Optional[IPersistentMap]
+
+    def __call__(self, *args, **kwargs): ...
+
+    def with_meta(self, meta: Optional[IPersistentMap]) -> "BasilispFunction": ...

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from fractions import Fraction
-from typing import Callable, Optional, Pattern, Protocol, Union
+from typing import Optional, Pattern, Protocol, Union
 
 from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
@@ -17,7 +17,6 @@ from basilisp.lang.interfaces import (
     IRecord,
     ISeq,
     IType,
-    IWithMeta,
 )
 
 CompilerOpts = IPersistentMap[kw.Keyword, bool]

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -5867,6 +5867,52 @@ class TestWarnOnArityMismatch:
             f"calling function {var} ({compiler_file_path}:1) with 0 arguments; expected any of: 1+",
         ) in caplog.record_tuples
 
+    def test_no_runtime_warning_on_arity_mismatch_variadic_with_partial(
+        self,
+        lcompile: CompileFn,
+        ns: runtime.Namespace,
+        compiler_file_path: str,
+        caplog,
+    ):
+        # This case is tricky to detect at compile time, so we implemented a runtime
+        # check instead.
+        lcompile(
+            """
+            (defn klkpqkc [a] a)
+            (def yyqeken (partial klkpqkc :a))
+            """
+        )
+        assert not list(
+            filter(
+                lambda rec: re.match(
+                    "invalid partial function application of 'klkpqkc' detected",
+                    rec[2],
+                ),
+                caplog.record_tuples,
+            )
+        )
+
+    def test_runtime_warning_on_arity_mismatch_variadic_with_partial(
+        self,
+        lcompile: CompileFn,
+        ns: runtime.Namespace,
+        compiler_file_path: str,
+        caplog,
+    ):
+        # This case is tricky to detect at compile time, so we implemented a runtime
+        # check instead.
+        lcompile(
+            """
+            (defn ueqhenn [])
+            (def pqencka (partial ueqhenn :a))
+            """
+        )
+        assert (
+            "basilisp.lang.runtime",
+            logging.WARNING,
+            "invalid partial function application of 'ueqhenn' detected: 1 arguments given; expected any of: 0",
+        ) in caplog.record_tuples
+
 
 class TestWarnOnVarIndirection:
     @pytest.fixture

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -5841,7 +5841,30 @@ class TestWarnOnArityMismatch:
         assert (
             "basilisp.lang.compiler.analyzer",
             logging.WARNING,
-            f"calling function {var} ({compiler_file_path}:1) with 1 arguments; expected any of: 0, 2+",
+            f"calling function {var} ({compiler_file_path}:1) with 1 arguments; expected any of: 0, 2, 4+",
+        ) in caplog.record_tuples
+
+    def test_warning_on_arity_mismatch_variadic_with_partial(
+        self,
+        lcompile: CompileFn,
+        ns: runtime.Namespace,
+        compiler_file_path: str,
+        caplog,
+    ):
+        var = lcompile(
+            """
+            (defn dazhqpe ([] :none) ([a b] [a b]) ([a b c d & others] [a b c d others]))
+            (def zjpqeee (partial dazhqpe :a :b :c))
+            """
+        )
+        lcompile(
+            "(fn* [] (zjpqeee))",
+            opts={compiler.WARN_ON_ARITY_MISMATCH: True},
+        )
+        assert (
+            "basilisp.lang.compiler.analyzer",
+            logging.WARNING,
+            f"calling function {var} ({compiler_file_path}:1) with 0 arguments; expected any of: 1+",
         ) in caplog.record_tuples
 
 

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -599,10 +599,12 @@
         (is (= #{1 3 :rest} (.-arities new-f)))
         (is (nil? (meta new-f)))
         (is (= {:different-tag :yes} (meta new-f-meta)))
+        (is (= [:a :c] (new-f-meta :c)))
 
         (let [partial-of-partial (partial new-f-meta :b)]
           (is (= #{2 :rest} (.-arities partial-of-partial)))
-          (is (nil? (meta partial-of-partial))))))))
+          (is (nil? (meta partial-of-partial)))
+          (is (= [:a :b :e :f '(:g :h)] (partial-of-partial :e :f :g :h))))))))
 
 (deftest reduce-test
   (testing "with no init"

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -579,6 +579,31 @@
 ;; Higher Order and Collection Functions ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(deftest partial-test
+  (testing "no arguments"
+    (let [f-no-args (fn [] :no-args)]
+      (is (identical? f-no-args (partial f-no-args)))))
+
+  (testing "with arguments"
+    (let [f ^{:meta-tag :value}
+          (fn
+            ([] :no-args)
+            ([a b] [a b])
+            ([a b c d & rest]
+             [a b c d rest]))]
+      (is (= #{0 2 4 :rest} (.-arities f)))
+      (is (= {:meta-tag :value} (meta f)))
+
+      (let [new-f      (partial f :a)
+            new-f-meta (with-meta new-f {:different-tag :yes})]
+        (is (= #{1 3 :rest} (.-arities new-f)))
+        (is (nil? (meta new-f)))
+        (is (= {:different-tag :yes} (meta new-f-meta)))
+
+        (let [partial-of-partial (partial new-f-meta :b)]
+          (is (= #{2 :rest} (.-arities partial-of-partial)))
+          (is (nil? (meta partial-of-partial))))))))
+
 (deftest reduce-test
   (testing "with no init"
     (are [coll f res] (= res (reduce f coll))


### PR DESCRIPTION
Add a compile-time warning for arity mismatches on function invocations. The warning is enabled by default (if the dev logger is enabled and configured for at least `WARNING` level logs).

In order to facilitate this work, we also had to change the computation of the Basilisp function `arities` attribute set. Previously this included only fixed arities (the argument count for each non-variadic function arity) and a `:rest` keyword if the function included a variadic arity. Now `arities` will include all fixed arities including the number of fixed (non-variadic) arguments to the varidic arity. This allows for more sophisticated warnings.

As part of this bill of work, it was also required to update `partial` to support computing a new set of `arities` for partial applications. `functools.wraps` copies all values from `__dict__` to wrapped functions, so partials were appearing to have the same set of arities as their wrapped function which was never correct.

Fixes #671 
Fixes #847 