### PR TITLE
Support for optional metadata defmulti argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added a compile-time warning for attempting to call a function with an unsupported number of arguments (#671)
 
 ### Changed
- * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)  
+ * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)
+ * Support for optional metadata argument in `defmulti` (#857)
 
 ### Fixed
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -5247,7 +5247,9 @@
 ;;;;;;;;;;;;;;;;;;
 
 (defmacro defmulti
-  "Define a new multimethod with the given dispatch function.
+  "Define a new multimethod with the given ``name`` and a ``body`` consisting of an
+  optional docstring, optional metadata map, a dispatch function and options of key/value
+  pairs.
 
   Multimethod dispatch functions should be defined with the same arity or arities as
   the registered methods. The provided dispatch function will be called first on all
@@ -5286,12 +5288,18 @@
   [name & body]
   (let [doc         (when (string? (first body))
                       (first body))
-        name        (if doc
-                      (vary-meta name assoc :doc doc)
-                      name)
         body        (if doc
                       (rest body)
                       body)
+        mt          (when (map? (first body))
+                      (first body))
+        body        (if mt
+                      (rest body)
+                      body)
+        name        (vary-meta name merge mt)
+        name        (if doc
+                      (vary-meta name assoc :doc doc)
+                      name)
         dispatch-fn (first body)
         opts        (apply hash-map (rest body))]
     `(def ~name (basilisp.lang.multifn/MultiFunction (quote ~name)

--- a/tests/basilisp/test_multifn.lpy
+++ b/tests/basilisp/test_multifn.lpy
@@ -93,3 +93,18 @@
     (testing "cannot establish conflicting preference"
       (is (thrown? basilisp.lang.runtime/RuntimeException)
           (prefer-method os-lineage :os/bsd :os/unix)))))
+
+(defmulti args-test1 "test1" :x)
+(defmulti args-test2 {:test 2} :x)
+(defmulti args-test3 "test3" {:test 3} :x)
+(defmulti args-test4 "test4" {:doc "other"} :x)
+
+(deftest multi-args-optional-test
+  (let [mt1 (meta #'args-test1)
+        mt2 (meta #'args-test2)
+        mt3 (meta #'args-test3)
+        mt4 (meta #'args-test4)]
+    (is (= "test1" (:doc mt1)))
+    (is (= 2 (:test mt2)))
+    (is (= {:doc "test3" :test 3} (select-keys mt3 [:doc :test])))
+    (is (= "test4" (:doc mt4)))))


### PR DESCRIPTION
Hi,

could you please consider support for optional metadata argument in `defmulti`. It fixes #857.

Added tests for the same.

Thanks