### PR TITLE
Allow def names without reader metadata by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)
  * Fix a bug where the function returned by `partial` retained the meta, arities, and `with_meta` method of the wrapped function rather than creating new ones (#847)
  * Fix a bug where exceptions arising while reading reader conditional forms did not include line and column information (#854)
+ * Fix a bug where names `def`'ed without reader metadata would cause the compiler to throw an exception (#850) 
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -954,6 +954,9 @@ def _def_ast(  # pylint: disable=too-many-locals,too-many-statements
     def_loc = _loc(form) or _loc(name) or (None, None)
     if def_loc == (None, None):
         logger.warning(f"def line and column metadata not provided for Var {name}")
+    if name.meta is None:
+        logger.warning(f"def name symbol has no metadata for Var {name}")
+        name = name.with_meta(lmap.EMPTY)
     def_node_env = ctx.get_node_env(pos=ctx.syntax_position)
     def_meta = _clean_meta(
         name.meta.update(  # type: ignore [union-attr]

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -259,6 +259,17 @@ class TestDef:
         assert var.root == runtime.Unbound(var)
         assert not var.is_bound
 
+    def test_def_name_with_no_metadata(
+        self, lcompile: CompileFn, ns: runtime.Namespace
+    ):
+        var = lcompile(
+            """
+        (defmacro defxyz [v] `(def ~(symbol "xyz") ~v))
+        (defxyz :val)
+        """
+        )
+        assert var.root == kw.keyword("val")
+
     def test_recursive_def(self, lcompile: CompileFn, ns: runtime.Namespace):
         lcompile("(def a a)")
         var = Var.find_in_ns(sym.symbol(ns.name), sym.symbol("a"))


### PR DESCRIPTION
Fixes #850 