### PR TITLE
`for` bindings destructuring support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for explicit cause exception chaining to the `throw` special form (#862)
  * Added `basilisp.stacktrace` namespace (#721)
  * Added support for `*flush-on-newline*` to flush the `prn` and `println` output stream after the last newline (#865)
+ * Added support for binding destructuring in `for` bindings (#774)
 
 ### Changed
  * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3509,12 +3509,12 @@
   For comprehensions consist of a vector of bindings, with optional modifiers, and a
   user specified body in an implicit ``do`` block.
 
-  Symbol bindings look like standard ``let`` bindings without destructuring. Values
-  bound to symbols should be sequences or otherwise seqable. The body of the ``for``
-  comprehension will be executed with the given symbol bound to successive values of the
-  sequence. If multiple sequences are bound to symbols, iteration will proceed in a
-  nested fashion with latest sequences iterated first and earlier sequences iterated
-  later (as nested ``for`` loops in procedural languages).
+  Symbol bindings look like standard ``let`` bindings. Values bound to symbols should be
+  sequences or otherwise seqable. The body of the ``for`` comprehension will be executed
+  with the given symbol bound to successive values of the sequence. If multiple sequences
+  are bound to symbols, iteration will proceed in a nested fashion with latest sequences
+  iterated first and earlier sequences iterated later (as nested ``for`` loops in
+  procedural languages).
 
   For example, a simple non-nested for comprehension will yield::
 
@@ -3554,10 +3554,6 @@
 
     (not (even? (count bindings)))
     (throw (ex-info "for expression must have an even number of bindings"
-                    {:bindings bindings}))
-
-    (not (symbol? (first bindings)))
-    (throw (ex-info "for expression bindings must start with symbol binding"
                     {:bindings bindings})))
 
   (let [;; Generate the body of a for binding iterator, applying any relevant
@@ -3626,7 +3622,7 @@
                            ;; (which will be applied to this iterator) and additional
                            ;; bindings (which will be generated as new, inner iterators).
                            groups        (split-with (fn [pair]
-                                                       (not (symbol? (first pair))))
+                                                       (keyword? (first pair)))
                                                      (rest pairs))
                            mods          (first groups)
                            rest-bindings (second groups)

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -438,7 +438,16 @@
              (for [x      (range 3)
                    y      [:a :b :c]
                    :while (= y :b)]
-               [x y]))))))
+               [x y])))))
+
+  (testing "destructuring"
+    (is (= [[1 15 5 6] [1 15 7 8]
+            [2 15 5 6] [2 15 7 8]]
+             (for [{:keys [a]} [{:a 1} {:a 2}]
+                   b [15 16]
+                   :while (= b 15)
+                   [x y] [[5 6] [7 8]]]
+               [a b x y])))))
 
 (deftest comment-test
   (is (= nil (comment 1)))


### PR DESCRIPTION
Hi,

can you please consider attempt to support binding destructuring in `for` bindings. It fixes #774.

Basically, it seems that destructuring support is not available because the general destruturing dispatch mechanism is not defined yet at the point when `for` is defined.

The idea with this patch is to rename the initial implementation as `for*` and redefine `for` later on after the destructuring dispatch mechanism is available and picked up for free.

Thanks