### PR TITLE
Added `==` as an alias for `=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added `basilisp.stacktrace` namespace (#721)
  * Added support for `*flush-on-newline*` to flush the `prn` and `println` output stream after the last newline (#865)
  * Added support for binding destructuring in `for` bindings (#774)
+ * Added `==` as an alias to `=` (#859)
 
 ### Changed
  * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)

--- a/docs/differencesfromclojure.rst
+++ b/docs/differencesfromclojure.rst
@@ -32,6 +32,15 @@ Type Differences
 
   * Sorted sets, sorted maps, and array maps are not implemented (support is tracked in `#416 <https://github.com/basilisp-lang/basilisp/issues/416>`_).
 
+.. _arithmetic_comparison:
+
+Arithmetic Comparison
+---------------------
+
+Basilisp, in contrast to Clojure, does not distinguish between `integer` and `floating point` as `separate categories for equality comparison purposes <https://clojure.org/guides/equality>`_ where the ``=`` comparison between any `int` and `float` returns `false`. Instead, it adopts Python's ``=`` comparison operator semantics, where the `int` is optimistically converted to a `float` before the comparison. However, beware that this conversion can lead to `certain caveats in comparison <https://stackoverflow.com/a/30100743>`_ where in rare cases seemingly exact `int` and `float` numbers may still compare to `false` due to limitations in floating point number representation.
+
+In Clojure, this optimistic equality comparison is performed by the ``==`` function. In Basilisp though, ``==`` is aliased to behave the same as ``=``, since it is the latter that now conveys that same meaning.
+
 .. _concurrent_programming:
 
 Concurrent Programming

--- a/docs/differencesfromclojure.rst
+++ b/docs/differencesfromclojure.rst
@@ -37,9 +37,17 @@ Type Differences
 Arithmetic Comparison
 ---------------------
 
-Basilisp, in contrast to Clojure, does not distinguish between `integer` and `floating point` as `separate categories for equality comparison purposes <https://clojure.org/guides/equality>`_ where the ``=`` comparison between any `int` and `float` returns `false`. Instead, it adopts Python's ``=`` comparison operator semantics, where the `int` is optimistically converted to a `float` before the comparison. However, beware that this conversion can lead to `certain caveats in comparison <https://stackoverflow.com/a/30100743>`_ where in rare cases seemingly exact `int` and `float` numbers may still compare to `false` due to limitations in floating point number representation.
+Basilisp, in contrast to Clojure, does not distinguish between integer (``int``) and floating point (``float``) as `separate categories for equality comparison purposes <https://clojure.org/guides/equality>`_ where the ``=`` comparison between any ``int`` and ``float`` returns ``false``. Instead, it adopts Python's ``=`` comparison operator semantics, where the ``int`` is optimistically converted to a ``float`` before the comparison. However, beware that this conversion can lead to `certain caveats in comparison <https://stackoverflow.com/a/30100743>`_ where in rare cases seemingly exact ``int`` and ``float`` numbers may still compare to ``false`` due to limitations in floating point number representation.
 
-In Clojure, this optimistic equality comparison is performed by the ``==`` function. In Basilisp though, ``==`` is aliased to behave the same as ``=``, since it is the latter that now conveys that same meaning.
+In Clojure, this optimistic equality comparison is performed by the ``==`` function. In Basilisp, ``==`` is aliased to behave the same as ``=``.
+
+.. note::
+
+   Basilisp's ``=`` will perform as expected when using Python `Decimal <https://docs.python.org/3/library/decimal.html>`__ typed :ref:`floating_point_numbers`.
+
+.. seealso::
+
+   Python's `floating point arithmetic <https://docs.python.org/3/tutorial/floatingpoint.html>`_ documentation
 
 .. _concurrent_programming:
 

--- a/docs/pyinterop.rst
+++ b/docs/pyinterop.rst
@@ -246,7 +246,7 @@ Type hints may be applied to :lpy:form:`def` names, function arguments and retur
    Return annotations are combined as by ``typing.Union``, so ``typing.Union[str, str] == str``.
    The annotations for individual arity arguments are preserved in their compiled form, but they are challenging to access programmatically.
 
-.. _arithmeticdivision
+.. _arithmeticdivision:
 
 Arithmetic division
 -------------------

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -815,7 +815,11 @@
   (operator/is_ x y))
 
 (defn =
-  "Return ``true`` if ``x`` and ``y`` are equal, otherwise ``false``\\."
+  "Return ``true`` if ``x`` and ``y`` are equal, otherwise ``false``\\.
+
+  Number equality follows Python's `=` semantics whereby \"a
+  comparison between numbers of different types behaves as though the
+  exact values of those numbers were being compared\"."
   ([_] true)
   ([x & args]
    (if (seq (rest args))
@@ -828,6 +832,11 @@
   "Return ``true`` if ``x`` and ``y`` are not equal, otherwise ``false``\\."
   [& args]
   (not (apply = args)))
+
+(defmacro ==
+  "Alias for lpy:fn:`=`."
+  [& args]
+  `(= ~@args))
 
 (defn >
   "Return ``true`` if arguments are monotonically decreasing, otherwise ``false``\\."

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -817,7 +817,7 @@
 (defn =
   "Return ``true`` if ``x`` and ``y`` are equal, otherwise ``false``\\.
 
-  Number equality follows Python's `=` semantics whereby \"a
+  Number equality follows Python's ``=`` semantics whereby \"a
   comparison between numbers of different types behaves as though the
   exact values of those numbers were being compared\"."
   ([_] true)
@@ -833,10 +833,10 @@
   [& args]
   (not (apply = args)))
 
-(defmacro ==
+(defn ==
   "Alias for lpy:fn:`=`."
   [& args]
-  `(= ~@args))
+  (apply = args))
 
 (defn >
   "Return ``true`` if arguments are monotonically decreasing, otherwise ``false``\\."

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2211,3 +2211,17 @@
         (.flush *out*)
         (is (= (bio-write expected os/linesep "ab" os/linesep "ab" " " 1 os/linesep)
                (.getvalue bio)))))))
+
+;;;;;;;;;;;;;;;;
+;; arithmetic ;;
+;;;;;;;;;;;;;;;;
+
+(deftest arithmetic-equality-test
+  (testing "int and float type equality"
+    (is (not= 1 1.00001))
+    (is (= 1 1.0000000000000000000000009)))
+
+  (testing "== is an alias of ="
+    (let [f 1.0000000000000000000000009]
+      (is (= 1 f))
+      (is (== 1 f)))))


### PR DESCRIPTION
Hi,

could you please consider patch to add `==` as an alias for `=`. Fixes #859.

I've also updated the doc to describe the difference of int vs float comparison in basilisp vs Clojure.

Thanks