### PR TITLE
Fix issue with `concat` on maps returning keys instead of key/values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where the function returned by `partial` retained the meta, arities, and `with_meta` method of the wrapped function rather than creating new ones (#847)
  * Fix a bug where exceptions arising while reading reader conditional forms did not include line and column information (#854)
  * Fix a bug where names `def`'ed without reader metadata would cause the compiler to throw an exception (#850) 
+ * Fix an issue where `concat` on maps was iterating over the keys instead of the key/value pairs (#871)
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1073,7 +1073,8 @@ to_seq = lseq.to_seq
 
 def concat(*seqs: Any) -> ISeq:
     """Concatenate the sequences given by seqs into a single ISeq."""
-    return lseq.sequence(itertools.chain.from_iterable(filter(None, seqs)))
+    s = [to_seq(seq) if isinstance(seq, IPersistentMap) else seq for seq in seqs if seq]
+    return lseq.sequence(itertools.chain.from_iterable(s))
 
 
 def apply(f, args):

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1073,8 +1073,7 @@ to_seq = lseq.to_seq
 
 def concat(*seqs: Any) -> ISeq:
     """Concatenate the sequences given by seqs into a single ISeq."""
-    s = [to_seq(seq) if isinstance(seq, IPersistentMap) else seq for seq in seqs if seq]
-    return lseq.sequence(itertools.chain.from_iterable(s))
+    return lseq.sequence(itertools.chain.from_iterable(filter(None, map(to_seq, seqs))))
 
 
 def apply(f, args):

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -247,6 +247,9 @@ def test_concat():
     s1 = runtime.concat(llist.l(1, 2, 3), vec.v(4, 5, 6))
     assert s1 == llist.l(1, 2, 3, 4, 5, 6)
 
+    s1 = runtime.concat(lmap.map({"a": 1}), lmap.map({"b": 2}))
+    assert s1 == llist.l(vec.v("a", 1), vec.v("b", 2))
+
 
 def test_apply():
     assert vec.v() == runtime.apply(vec.v, [[]])

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -250,6 +250,9 @@ def test_concat():
     s1 = runtime.concat(lmap.map({"a": 1}), lmap.map({"b": 2}))
     assert s1 == llist.l(vec.v("a", 1), vec.v("b", 2))
 
+    s1 = runtime.concat(vec.v(1, 2), None, "ab")
+    assert s1 == llist.l(1, 2, "a", "b")
+
 
 def test_apply():
     assert vec.v() == runtime.apply(vec.v, [[]])


### PR DESCRIPTION
Hi,

could you please consider patch to have `concat` on maps return k/v pairs instead of keys. It fixes #871.

The issue as I understand it that the underlying map library iterates over keys rather than k/v pairs, and thus it needs to be converted first to a sequence (which correctly converts map into a seq of pairs).

Thanks