### PR TITLE
document core int/float fns difference with clojure

### DIFF
--- a/docs/differencesfromclojure.rst
+++ b/docs/differencesfromclojure.rst
@@ -150,6 +150,15 @@ Libs
 
 Support for Clojure libs is `planned <https://github.com/basilisp-lang/basilisp/issues/668>`_\.
 
+.. _core_lib_differences:
+
+basilisp.core
+-------------
+
+- :lpy:fn:`basilisp.core/int` coerces its argument to an integer. When given a string input, Basilisp will try to interpret it as a base 10 number, whereas in Clojure, it will return its ASCII/Unicode index if it is a character (or fail if it is a string).
+
+- :lpy:fn:`basilisp.core/float` coerces its argument to a floating-point number. When given a string input, Basilisp will try to parse it as a floating-point number, whereas Clojure will raise an error if the input is a character or a string.
+
 .. _refs_and_transactions_differences:
 
 Refs and Transactions

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -1604,12 +1604,16 @@
   (python/float x))
 
 (defn ^:inline float
-  "Coerce ``x`` to a float."
+  "Coerce ``x`` to a float.
+
+  If ``x`` is string, it is parsed as a floating point number."
   [x]
   (python/float x))
 
 (defn ^:inline int
-  "Coerce ``x`` to an integer."
+  "Coerce ``x`` to an integer.
+
+  If ``x`` is string, it is parsed as a base 10 number."
   [x]
   (python/int x))
 


### PR DESCRIPTION
Hi, 

I've document the differences of the `int` and `float` functions from Clojure. It resolves #875.

Do we need a changelog entry for this?

Thanks

