### PR TITLE
Add support for `fnext` core function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added `==` as an alias to `=` (#859)
  * Added custom exception formatting for `basilisp.lang.compiler.exception.CompilerException` and `basilisp.lang.reader.SyntaxError` to show more useful details to users on errors (#870)
  * Added `merge-with` core function (#860)
+ * Added `fnext` core function (#879)
 
 ### Changed
  * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -461,6 +461,11 @@
   [v]
   (next (first v)))
 
+(defn ^:inline fnext
+  "Return the result of calling ``(first (next v))``\\."
+  [v]
+  (first (next v)))
+
 (defn ^:inline nnext
   "Return the result of calling ``(next (next v))``\\."
   [v]

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -233,6 +233,14 @@
 ;; Collection Functions ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(deftest fnext-test
+  (is (= nil (fnext [])))
+  (is (= nil (fnext [1])))
+  (is (= nil (fnext [1 nil])))
+
+  (is (= 2 (fnext [1 2])))
+  (is (= [2] (fnext [1 [2] 3]))))
+
 (deftest bounded-count-test
   (are [x n y] (= x (bounded-count n y))
     0 5 []


### PR DESCRIPTION
Hi,

can you please consider patch to add support for Clojure's `fnext` fn. It resolves #879.

Thanks