### PR TITLE
*print-namespace-maps* support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added `merge-with` core function (#860)
  * Added `fnext` core function (#879)
  * Added `INamed` interface for Keywords and Symbols (#884)
+ * Added `*print-namespace-maps*` dynamic var support (#882)
 
 ### Changed
  * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -422,6 +422,7 @@ def repl(
                     runtime.PRINT_READABLY_VAR_NAME,
                     runtime.PRINT_LEVEL_VAR_NAME,
                     runtime.PRINT_META_VAR_NAME,
+                    runtime.PRINT_NAMESPACE_MAPS_VAR_NAME,
                 ],
             )
         }

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -129,7 +129,6 @@ def map_lrepr(  # pylint: disable=too-many-locals
     entries: Callable[[], Iterable[Tuple[Any, Any]]],
     start: str,
     end: str,
-    py_map: bool = False,
     meta: Optional[IPersistentMap] = None,
     **kwargs: Unpack[PrintSettings],
 ) -> str:
@@ -140,10 +139,6 @@ def map_lrepr(  # pylint: disable=too-many-locals
     If the keyword argument print_namespace_maps is True and all keys
     share the same namespace, then print the namespace of the keys at
     the beginning of the map instead of beside the keys.
-
-    if py_map is True then do not print any meta or namespace
-    information before the map (default: False).
-
 
     The keyword arguments will be passed along to lrepr for the sequence
     elements.
@@ -170,9 +165,7 @@ def map_lrepr(  # pylint: disable=too-many-locals
                 break
         return next(iter(nses)) if len(nses) == 1 else None
 
-    ns_name_shared = (
-        check_same_ns() if not py_map and kwargs["print_namespace_maps"] else None
-    )
+    ns_name_shared = check_same_ns() if kwargs["print_namespace_maps"] else None
 
     entries_updated = entries
     if ns_name_shared:
@@ -193,7 +186,7 @@ def map_lrepr(  # pylint: disable=too-many-locals
     trailer = []
     print_dup = kwargs["print_dup"]
     print_length = kwargs["print_length"]
-    if not py_map and not print_dup and isinstance(print_length, int):
+    if not print_dup and isinstance(print_length, int):
         items = list(islice(entry_reprs(), print_length + 1))
         if len(items) > print_length:
             items.pop()
@@ -214,7 +207,7 @@ def map_lrepr(  # pylint: disable=too-many-locals
 
 @lrepr.register(dict)
 def _lrepr_py_dict(o: dict, **kwargs: Unpack[PrintSettings]) -> str:
-    return f"#py {map_lrepr(o.items, '{', '}', py_map=True, **kwargs)}"
+    return f"#py {map_lrepr(o.items, '{', '}', **kwargs)}"
 
 
 class PersistentMap(

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -43,7 +43,7 @@ def _dec_print_level(lvl: PrintCountSetting) -> PrintCountSetting:
     return lvl
 
 
-def process_kwargs(**kwargs: Unpack[PrintSettings]) -> PrintSettings:
+def process_lrepr_kwargs(**kwargs: Unpack[PrintSettings]) -> PrintSettings:
     """Process keyword arguments, decreasing the print-level. Should be called
     after examining the print level for the current level."""
     return cast(
@@ -94,7 +94,7 @@ def seq_lrepr(
     if isinstance(print_level, int) and print_level < 1:
         return SURPASSED_PRINT_LEVEL
 
-    kwargs = process_kwargs(**kwargs)
+    kwargs = process_lrepr_kwargs(**kwargs)
 
     trailer = []
     print_dup = kwargs["print_dup"]
@@ -143,9 +143,9 @@ def lrepr(  # pylint: disable=too-many-arguments
     - print_level: the depth of the object graph to print, starting with 0, or
                    no limit if bound to a logical falsey value (default: nil)
     - print_namespace_maps: if logical true, and the object is a map consisting
-                            exclusively with keys of symbols or keywords all
-                            belonging to the same namespace, print the namespace
-                            at the beginning of the map instead of beside the keys.
+                            with keys belonging to the same namespace, print the
+                            namespace at the beginning of the map instead of
+                            beside the keys (default: false)
     - print_meta: if logical true, print objects meta in a way that can be
                   read back by the reader (default: false)
     - print_readably: if logical false, print strings and characters with

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -91,6 +91,7 @@ PRINT_DUP_VAR_NAME = "*print-dup*"
 PRINT_LENGTH_VAR_NAME = "*print-length*"
 PRINT_LEVEL_VAR_NAME = "*print-level*"
 PRINT_META_VAR_NAME = "*print-meta*"
+PRINT_NAMESPACE_MAPS_VAR_NAME = "*print-namespace-maps*"
 PRINT_READABLY_VAR_NAME = "*print-readably*"
 PYTHON_VERSION_VAR_NAME = "*python-version*"
 BASILISP_VERSION_VAR_NAME = "*basilisp-version*"
@@ -1636,6 +1637,7 @@ def lrepr(o, human_readable: bool = False) -> str:
             sym.symbol(PRINT_LEVEL_VAR_NAME)
         ).value,
         print_meta=core_ns.find(sym.symbol(PRINT_META_VAR_NAME)).value,  # type: ignore
+        print_namespace_maps=core_ns.find(sym.symbol(PRINT_NAMESPACE_MAPS_VAR_NAME)).value,  # type: ignore
         print_readably=core_ns.find(  # type: ignore
             sym.symbol(PRINT_READABLY_VAR_NAME)
         ).value,
@@ -2190,6 +2192,22 @@ def bootstrap_core(compiler_opts: CompilerOpts) -> None:
     )
     Var.intern(
         CORE_NS_SYM, sym.symbol(PRINT_META_VAR_NAME), lobj.PRINT_META, dynamic=True
+    )
+    Var.intern(
+        CORE_NS_SYM,
+        sym.symbol(PRINT_NAMESPACE_MAPS_VAR_NAME),
+        lobj.PRINT_NAMESPACE_MAPS,
+        dynamic=True,
+        meta=lmap.map(
+            {
+                _DOC_META_KEY: (
+                    "Indicates to print the namespace of keys in a map exclusively"
+                    " consisting of only symbols or keywords belonging to the same"
+                    " namespace, at the beginning of the map instead of beside the keys."
+                    " Defaults to false."
+                )
+            }
+        ),
     )
     Var.intern(
         CORE_NS_SYM,

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -2201,8 +2201,7 @@ def bootstrap_core(compiler_opts: CompilerOpts) -> None:
         meta=lmap.map(
             {
                 _DOC_META_KEY: (
-                    "Indicates to print the namespace of keys in a map exclusively"
-                    " consisting of only symbols or keywords belonging to the same"
+                    "Indicates to print the namespace of keys in a map belonging to the same"
                     " namespace, at the beginning of the map instead of beside the keys."
                     " Defaults to false."
                 )

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2160,7 +2160,7 @@
 
   (testing "with *print-namespace-maps*"
     (is (= "#py {:a/x 5}" (binding [*print-namespace-maps* false] (pr-str #py {:a/x 5}))))
-    (is (= "#py {:a/x 5}" (binding [*print-namespace-maps* true] (pr-str #py {:a/x 5}))))
+    (is (= "#py #:a{:x 5}" (binding [*print-namespace-maps* true] (pr-str #py {:a/x 5}))))
 
     (are [res m b] (contains? res (binding [*print-namespace-maps* b] (pr-str m)))
       #{"{:a/x 5}"} {:a/x 5} false

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2159,16 +2159,39 @@
     (is (= '(1) (binding [pr (fn [& more] more)] (pr 1)))))
 
   (testing "with *print-namespace-maps*"
+    (is (= "#py {:a/x 5}" (binding [*print-namespace-maps* false] (pr-str #py {:a/x 5}))))
+    (is (= "#py {:a/x 5}" (binding [*print-namespace-maps* true] (pr-str #py {:a/x 5}))))
+
     (are [res m b] (contains? res (binding [*print-namespace-maps* b] (pr-str m)))
       #{"{:a/x 5}"} {:a/x 5} false
       #{"#:a{:x 5}"} {:a/x 5} true
       #{"{:x 5}"} {:x 5} true
+      #{"{1 2}"} {1 2} false
+      #{"{1 2}"} {1 2} true
       #{"{:a/y 6 :a/x 5}" "{:a/x 5 :a/y 6}"} {:a/x 5 :a/y 6} false
       #{"#:a{:y 6 :x 5}" "#:a{:x 5 :y 6}"} {:a/x 5 :a/y 6} true
+      #{"{6 6 :a/x 5}" "{:a/x 5 6 6}"} {:a/x 5 6 6} false
+      #{"{6 6 :a/x 5}" "{:a/x 5 6 6}"} {:a/x 5 6 6} true
       #{"{:a/x 5 :b/y 6}" "{:b/y 6 :a/x 5}"} {:a/x 5 :b/y 6} true
       #{"#:a{y 6 x 5}" "#:a{x 5 y 6}"} {'a/x 5 'a/y 6} true
       #{"#:a{y 6 :x 5}" "#:a{:x 5 y 6}"} {:a/x 5 'a/y 6} true
-      #{"{y 6 :a/x 5}" "{:a/x 5 y 6}"} {:a/x 5 'y 6} true)))
+      #{"{y 6 :a/x 5}" "{:a/x 5 y 6}"} {:a/x 5 'y 6} true)
+
+    (are [res m pnm pm] (= res (binding [*print-namespace-maps* pnm
+                                         *print-meta*           pm]
+                                 (pr-str m)))
+      "^{:m 1} {:a/x 5}"     ^{:m 1} {:a/x 5}   false true
+      "^{:m 1} #:a{:x 5}"    ^{:m 1} {:a/x 5}   true true
+      "^#:l{:m 1} #:a{:x 5}" ^{:l/m 1} {:a/x 5} true true)
+
+    (are [res m pl] (= res (binding [*print-namespace-maps* true
+                                     *print-meta*           true
+                                     *print-level* pl]
+                             (pr-str m)))
+      "#"                                ^{:m 1} {:a/x 5} 0
+      "^{:m 1} #:a{:x 5}"                ^{:m 1} {:a/x 5} 1
+      "^{:m 1} #:a{:x #}"                ^{:m 1} {:a/x ^{:x 22} {:b 36}} 1
+      "^{:m 1} #:a{:x ^{:x 22} {:b 36}}" ^{:m 1} {:a/x ^{:x 22} {:b 36}} 2)))
 
 (defn- bio-write
   "Helper fn to write the ``strings`` to the ByteIO buffer ``bio``

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2156,7 +2156,19 @@
 
 (deftest pr-test
   (testing "is dynamic"
-    (is (= '(1) (binding [pr (fn [& more] more)] (pr 1))))))
+    (is (= '(1) (binding [pr (fn [& more] more)] (pr 1)))))
+
+  (testing "with *print-namespace-maps*"
+    (are [res m b] (contains? res (binding [*print-namespace-maps* b] (pr-str m)))
+      #{"{:a/x 5}"} {:a/x 5} false
+      #{"#:a{:x 5}"} {:a/x 5} true
+      #{"{:x 5}"} {:x 5} true
+      #{"{:a/y 6 :a/x 5}" "{:a/x 5 :a/y 6}"} {:a/x 5 :a/y 6} false
+      #{"#:a{:y 6 :x 5}" "#:a{:x 5 :y 6}"} {:a/x 5 :a/y 6} true
+      #{"{:a/x 5 :b/y 6}" "{:b/y 6 :a/x 5}"} {:a/x 5 :b/y 6} true
+      #{"#:a{y 6 x 5}" "#:a{x 5 y 6}"} {'a/x 5 'a/y 6} true
+      #{"#:a{y 6 :x 5}" "#:a{:x 5 y 6}"} {:a/x 5 'a/y 6} true
+      #{"{y 6 :a/x 5}" "{:a/x 5 y 6}"} {:a/x 5 'y 6} true)))
 
 (defn- bio-write
   "Helper fn to write the ``strings`` to the ByteIO buffer ``bio``


### PR DESCRIPTION
Hi,

could you please review draft support for the *print-namespace-maps* dynamic variable. It resolves #882.

I implemented the support at the lowest `obj.py` level, though this required to bring in the `keyword.py` and `symbol.py` modules resulting to cyclic dependencies. Not sure how else to implement it, so any other suggestions are most welcome.

I've also blindly followed the example of *print-dup* on how I ended setup the variable in the cli/runtime/object .py files.

In addition, I've used a set to compare the printed output of the map result with multiple k/v, exhaustively covering the possible orderings, is there perhaps a better simpler way to do this? This currently is prune to user errors.

Thanks