### PR TITLE
Add `INamed` interface for Keywords and Symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added custom exception formatting for `basilisp.lang.compiler.exception.CompilerException` and `basilisp.lang.reader.SyntaxError` to show more useful details to users on errors (#870)
  * Added `merge-with` core function (#860)
  * Added `fnext` core function (#879)
+ * Added `INamed` interface for Keywords and Symbols (#884)
 
 ### Changed
  * Cause exceptions arising from compilation issues during macroexpansion will no longer be nested for each level of macroexpansion (#852)

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -15,8 +15,10 @@ from typing import (
     Union,
 )
 
+from typing_extensions import Unpack
+
 from basilisp.lang.obj import LispObject as _LispObject
-from basilisp.lang.obj import seq_lrepr
+from basilisp.lang.obj import PrintSettings, seq_lrepr
 
 T = TypeVar("T")
 
@@ -104,6 +106,20 @@ class IWithMeta(IMeta):
 
     @abstractmethod
     def with_meta(self: T_with_meta, meta: "Optional[IPersistentMap]") -> T_with_meta:
+        raise NotImplementedError()
+
+
+class INamed(ABC):
+    __slots__ = ()
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def ns(self) -> Optional[str]:
         raise NotImplementedError()
 
 
@@ -407,11 +423,11 @@ class IRecord(ILispObject):
         """Class method constructor from an IPersistentMap instance."""
         raise NotImplementedError()
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         return self._record_lrepr(kwargs)
 
     @abstractmethod
-    def _record_lrepr(self, kwargs: Mapping) -> str:
+    def _record_lrepr(self, kwargs: PrintSettings) -> str:
         """Translation method converting Python keyword arguments into a
         Python dict.
 
@@ -487,7 +503,7 @@ class ISeq(ILispObject, ISeqable[T]):
     def seq(self) -> "Optional[ISeq[T]]":
         return self
 
-    def _lrepr(self, **kwargs):
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]):
         return seq_lrepr(iter(self), "(", ")", **kwargs)
 
     def __eq__(self, other):

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -2,20 +2,24 @@ import threading
 from functools import total_ordering
 from typing import Iterable, Optional, Union
 
+from typing_extensions import Unpack
+
 from basilisp.lang import map as lmap
 from basilisp.lang.interfaces import (
     IAssociative,
     ILispObject,
+    INamed,
     IPersistentMap,
     IPersistentSet,
 )
+from basilisp.lang.obj import PrintSettings
 
 _LOCK = threading.Lock()
 _INTERN: IPersistentMap[int, "Keyword"] = lmap.PersistentMap.empty()
 
 
 @total_ordering
-class Keyword(ILispObject):
+class Keyword(ILispObject, INamed):
     __slots__ = ("_name", "_ns", "_hash")
 
     def __init__(self, name: str, ns: Optional[str] = None) -> None:
@@ -31,7 +35,7 @@ class Keyword(ILispObject):
     def ns(self) -> Optional[str]:
         return self._ns
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         if self._ns is not None:
             return f":{self._ns}/{self._name}"
         return f":{self._name}"

--- a/src/basilisp/lang/list.py
+++ b/src/basilisp/lang/list.py
@@ -2,8 +2,10 @@ from typing import Optional, TypeVar, cast
 
 from pyrsistent import PList, plist  # noqa # pylint: disable=unused-import
 from pyrsistent._plist import _EMPTY_PLIST  # pylint: disable=import-private-name
+from typing_extensions import Unpack
 
 from basilisp.lang.interfaces import IPersistentList, IPersistentMap, ISeq, IWithMeta
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import EMPTY as _EMPTY_SEQ
 
@@ -36,7 +38,7 @@ class PersistentList(IPersistentList[T], ISeq[T], IWithMeta):
     def __len__(self):
         return len(self._inner)
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         return _seq_lrepr(self._inner, "(", ")", meta=self._meta, **kwargs)
 
     @property

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -3,6 +3,7 @@ from typing import Callable, Iterable, Mapping, Optional, Tuple, TypeVar, Union,
 
 from immutables import Map as _Map
 from immutables import MapMutation
+from typing_extensions import Unpack
 
 from basilisp.lang.interfaces import (
     IEvolveableCollection,
@@ -14,6 +15,7 @@ from basilisp.lang.interfaces import (
     ITransientMap,
     IWithMeta,
 )
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import map_lrepr as _map_lrepr
 from basilisp.lang.seq import sequence
 from basilisp.lang.vector import MapEntry
@@ -160,7 +162,7 @@ class PersistentMap(
     def __len__(self):
         return len(self._inner)
 
-    def _lrepr(self, **kwargs):
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]):
         return _map_lrepr(
             self._inner.items, start="{", end="}", meta=self._meta, **kwargs
         )

--- a/src/basilisp/lang/queue.py
+++ b/src/basilisp/lang/queue.py
@@ -1,6 +1,7 @@
 from typing import Optional, TypeVar
 
 from pyrsistent import PDeque, pdeque  # noqa # pylint: disable=unused-import
+from typing_extensions import Unpack
 
 from basilisp.lang.interfaces import (
     ILispObject,
@@ -10,6 +11,7 @@ from basilisp.lang.interfaces import (
     IWithMeta,
     seq_equals,
 )
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
 
@@ -47,7 +49,7 @@ class PersistentQueue(IPersistentList[T], IWithMeta, ILispObject):
     def __len__(self):
         return len(self._inner)
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         return _seq_lrepr(self._inner, "#queue (", ")", meta=self._meta, **kwargs)
 
     @property

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 import attr
+from typing_extensions import Unpack
 
 from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
@@ -56,6 +57,7 @@ from basilisp.lang.interfaces import (
     IType,
     IWithMeta,
 )
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.runtime import (
     READER_COND_DEFAULT_FEATURE_SET,
@@ -520,7 +522,7 @@ class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
                 return form
         return self.FEATURE_NOT_PRESENT
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         return _seq_lrepr(
             chain.from_iterable(self._feature_vec),
             "#?@(" if self.is_splicing else "#?(",

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -3,6 +3,7 @@ from typing import AbstractSet, Iterable, Optional, TypeVar
 
 from immutables import Map as _Map
 from immutables import MapMutation
+from typing_extensions import Unpack
 
 from basilisp.lang.interfaces import (
     IEvolveableCollection,
@@ -13,6 +14,7 @@ from basilisp.lang.interfaces import (
     ITransientSet,
     IWithMeta,
 )
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
 
@@ -111,7 +113,7 @@ class PersistentSet(
     def __len__(self):
         return len(self._inner)
 
-    def _lrepr(self, **kwargs):
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]):
         return _seq_lrepr(self._inner, "#{", "}", meta=self._meta, **kwargs)
 
     issubset = _PySet.__le__

--- a/src/basilisp/lang/symbol.py
+++ b/src/basilisp/lang/symbol.py
@@ -1,19 +1,22 @@
 from functools import total_ordering
 from typing import Optional, Union
 
+from typing_extensions import Unpack
+
 from basilisp.lang.interfaces import (
     IAssociative,
     ILispObject,
+    INamed,
     IPersistentMap,
     IPersistentSet,
     IWithMeta,
 )
-from basilisp.lang.obj import lrepr
+from basilisp.lang.obj import PrintSettings, lrepr
 from basilisp.lang.util import munge
 
 
 @total_ordering
-class Symbol(ILispObject, IWithMeta):
+class Symbol(ILispObject, INamed, IWithMeta):
     __slots__ = ("_name", "_ns", "_meta", "_hash")
 
     def __init__(
@@ -24,7 +27,7 @@ class Symbol(ILispObject, IWithMeta):
         self._meta = meta
         self._hash = hash((ns, name))
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         print_meta = kwargs["print_meta"]
 
         if self._ns is not None:

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Iterable, Optional, Sequence, TypeVar, Union, 
 
 from pyrsistent import PVector, pvector  # noqa # pylint: disable=unused-import
 from pyrsistent.typing import PVectorEvolver
+from typing_extensions import Unpack
 
 from basilisp.lang.interfaces import (
     IEvolveableCollection,
@@ -15,6 +16,7 @@ from basilisp.lang.interfaces import (
     IWithMeta,
     seq_equals,
 )
+from basilisp.lang.obj import PrintSettings
 from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.seq import sequence
 from basilisp.util import partition
@@ -144,7 +146,7 @@ class PersistentVector(
                 return False
         return False
 
-    def _lrepr(self, **kwargs) -> str:
+    def _lrepr(self, **kwargs: Unpack[PrintSettings]) -> str:
         return _seq_lrepr(self._inner, "[", "]", meta=self._meta, **kwargs)
 
     @property


### PR DESCRIPTION
This PR introduces the `INamed` interface (similar to Clojure's `Named`) which is applied to the Keyword and Symbol classes. Having an interface for this allows us to perform type checking for relevant features (in particular, the existence of a name or namespace) without needing the import either class directly (thus avoiding circular dependencies).

I also added type annotations for the Lisp representation keyword arguments (which is a useful addition ahead of #882 merging).

Fixes #884 
