### PR TITLE
Retain the original `(var ...)` form during analyis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where names `def`'ed without reader metadata would cause the compiler to throw an exception (#850) 
  * Fix an issue where `concat` on maps was iterating over the keys instead of the key/value pairs (#871)
  * Fix a bug where the compiler would throw an exception partially macroexpanding forms with `recur` forms provided as arguments (#856)
+ * Fix a bug where the original `(var ...)` form is not retained during analysis, causing it to be lost in calls to `macroexpand` (#888)
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1703,7 +1703,9 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
                     "and cannot be checked for abstractness; deferring to runtime",
                 )
                 unverifiably_abstract.add(interface)
-                if _is_artificially_abstract(interface.form):
+                if isinstance(interface.form, IMeta) and _is_artificially_abstract(
+                    interface.form
+                ):
                     artificially_abstract.add(interface)
                 continue
 
@@ -1745,7 +1747,9 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
                 )
 
             all_interface_methods.update(interface_names)
-        elif _is_artificially_abstract(interface.form):
+        elif isinstance(interface.form, IMeta) and _is_artificially_abstract(
+            interface.form
+        ):
             # Given that artificially abstract bases aren't real `abc.ABC`s and do
             # not annotate their `abstractmethod`s, we can't assert right now that
             # any the type will satisfy the artificially abstract base. However,
@@ -3197,7 +3201,7 @@ def _var_ast(form: ISeq, ctx: AnalyzerContext) -> VarRef:
         raise ctx.AnalyzerException(f"cannot resolve var {var_sym}", form=form)
 
     return VarRef(
-        form=var_sym,
+        form=form,
         var=var,
         return_var=True,
         env=ctx.get_node_env(pos=ctx.syntax_position),

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -21,7 +21,12 @@ from basilisp.lang import queue as lqueue
 from basilisp.lang import set as lset
 from basilisp.lang import symbol as sym
 from basilisp.lang import vector as vec
-from basilisp.lang.interfaces import IPersistentMap, IPersistentSet, IPersistentVector
+from basilisp.lang.interfaces import (
+    IPersistentMap,
+    IPersistentSet,
+    IPersistentVector,
+    ISeq,
+)
 from basilisp.lang.runtime import Namespace, Var, to_lisp
 from basilisp.lang.typing import LispForm
 from basilisp.lang.typing import ReaderForm as ReaderLispForm
@@ -901,8 +906,8 @@ class Try(Node[SpecialForm]):
 
 
 @attr.frozen
-class VarRef(Node[sym.Symbol], Assignable):
-    form: sym.Symbol
+class VarRef(Node[Union[sym.Symbol, ISeq]], Assignable):
+    form: Union[sym.Symbol, ISeq]
     var: Var
     env: NodeEnv
     return_var: bool = False


### PR DESCRIPTION
Fixes #888