### PR TITLE
Fix where `(str seq)` was printing seq string items without `"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where the compiler would throw an exception partially macroexpanding forms with `recur` forms provided as arguments (#856)
  * Fix a bug where the original `(var ...)` form is not retained during analysis, causing it to be lost in calls to `macroexpand` (#888)
  * Fix issue with the reader var macro failing in syntax quote when unquoting a symbol, e.g. `(#'~symbol) (#889)
+ * Fix issue where `(str seq)` was printing seq string items without quotation marks (#891)
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -97,9 +97,12 @@ def map_lrepr(
 
     kwargs = _process_kwargs(**kwargs)
 
+    kw_items = kwargs
+    kw_items["human_readable"] = False
+
     def entry_reprs():
         for k, v in entries():
-            yield f"{lrepr(k, **kwargs)} {lrepr(v, **kwargs)}"
+            yield f"{lrepr(k, **kw_items)} {lrepr(v, **kw_items)}"
 
     trailer = []
     print_dup = kwargs["print_dup"]
@@ -148,7 +151,9 @@ def seq_lrepr(
     else:
         items = iterable  # type: ignore
 
-    items = list(map(lambda o: lrepr(o, **kwargs), items))
+    kw_items = kwargs
+    kw_items["human_readable"] = False
+    items = list(map(lambda o: lrepr(o, **kw_items), items))
     seq_lrepr = PRINT_SEPARATOR.join(items + trailer)
 
     print_meta = kwargs["print_meta"]

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -97,7 +97,7 @@ def map_lrepr(
 
     kwargs = _process_kwargs(**kwargs)
 
-    kw_items = kwargs
+    kw_items = kwargs.copy()
     kw_items["human_readable"] = False
 
     def entry_reprs():
@@ -151,7 +151,7 @@ def seq_lrepr(
     else:
         items = iterable  # type: ignore
 
-    kw_items = kwargs
+    kw_items = kwargs.copy()
     kw_items["human_readable"] = False
     items = list(map(lambda o: lrepr(o, **kw_items), items))
     seq_lrepr = PRINT_SEPARATOR.join(items + trailer)

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -343,7 +343,7 @@ def test_version(run_cli):
     "args,ret",
     [
         ([], b"nil\n"),
-        (["1", "hi", "yes"], b"[1 hi yes]\n"),
+        (["1", "hi", "yes"], b'["1" "hi" "yes"]\n'),
     ],
 )
 def test_run_script(tmp_path: pathlib.Path, args: List[str], ret: bytes):

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -440,7 +440,7 @@ class TestImporter:
             code = importer.BasilispImporter().get_code("package.module")
             exec(code)
             captured = capsys.readouterr()
-            assert captured.out == "package.module\n[1 2 3]\n"
+            assert captured.out == 'package.module\n["1" "2" "3"]\n'
 
 
 @pytest.fixture
@@ -475,7 +475,7 @@ def bootstrap_file() -> pathlib.Path:
     "args,ret",
     [
         ([], b"package.test-run-ns-as-pymodule\nnil\n"),
-        (["1", "hi", "yes"], b"package.test-run-ns-as-pymodule\n[1 hi yes]\n"),
+        (["1", "hi", "yes"], b'package.test-run-ns-as-pymodule\n["1" "hi" "yes"]\n'),
     ],
 )
 def test_run_namespace_as_python_module(

--- a/tests/basilisp/lrepr_test.py
+++ b/tests/basilisp/lrepr_test.py
@@ -178,6 +178,10 @@ def test_print_readably(lcompile: CompileFn):
             r'#b "\x7fELF\x01\x01\x01\x00"',
             r'(pr-str #b "\x7f\x45\x4c\x46\x01\x01\x01\x00")',
         ),
+        (
+            '#uuid "81f35603-0408-4b3d-bbc0-462e3702747f"',
+            '(pr-str #uuid "81f35603-0408-4b3d-bbc0-462e3702747f")',
+        ),
         ('#"\\s"', '(pr-str #"\\s")'),
         (
             '#inst "2018-11-28T12:43:25.477000+00:00"',
@@ -294,4 +298,53 @@ def test_lrepr_round_trip_special_cases(lcompile: CompileFn):
     ],
 )
 def test_lstr(lcompile: CompileFn, s: str, code: str):
+    assert s == lcompile(code)
+
+
+@pytest.mark.parametrize(
+    "s,code",
+    [
+        ("true", "(str true)"),
+        ("false", "(str false)"),
+        ("", "(str nil)"),
+        ("4J", "(str 4J)"),
+        ("37.8J", "(str 37.8J)"),
+        ("37.8J", "(str 37.8J)"),
+        ("8837", "(str 8837)"),
+        ("0.64", "(str 0.64)"),
+        ("3.14", "(str 3.14M)"),
+        ("22/7", "(str 22/7)"),
+        ("##NaN", "(str ##NaN)"),
+        ("##Inf", "(str ##Inf)"),
+        ("##-Inf", "(str ##-Inf)"),
+        ("hi", '(str "hi")'),
+        ("Hello\nworld!", '(str "Hello\nworld!")'),
+        ('#b ""', '(str #b "")'),
+        (
+            r'#b "\x7fELF\x01\x01\x01\x00"',
+            r'(str #b "\x7f\x45\x4c\x46\x01\x01\x01\x00")',
+        ),
+        (
+            "81f35603-0408-4b3d-bbc0-462e3702747f",
+            '(str #uuid "81f35603-0408-4b3d-bbc0-462e3702747f")',
+        ),
+        ('#"\\s"', '(str #"\\s")'),
+        (
+            '#inst "2018-11-28T12:43:25.477000+00:00"',
+            '(str #inst "2018-11-28T12:43:25.477-00:00")',
+        ),
+        ('#py ["a" 1 false]', '(str #py ["a" 1 false])'),
+        ('#py ("a" 1 false)', '(str #py ("a" 1 false))'),
+        ('#py {"a" "b"}', '(str #py {"a" "b"})'),
+        ("#py #{}", "(str #py #{})"),
+        ("abc", '(str "abc")'),
+        ("false", "(str false)"),
+        ("123", "(str 123)"),
+        ('[:ab 2 "xyz"]', '(str [:ab 2 "xyz"])'),
+        ('#{"xyz"}', '(str #{"xyz"})'),
+        ('{"a" "b"}', '(str {"a" "b"})'),
+        ('{"a" ["b" :c 1 false]}', '(str {"a" ["b" :c 1 false]})'),
+    ],
+)
+def test_str(lcompile: CompileFn, s: str, code: str):
     assert s == lcompile(code)

--- a/tests/basilisp/lrepr_test.py
+++ b/tests/basilisp/lrepr_test.py
@@ -343,7 +343,10 @@ def test_lstr(lcompile: CompileFn, s: str, code: str):
         ('[:ab 2 "xyz"]', '(str [:ab 2 "xyz"])'),
         ('#{"xyz"}', '(str #{"xyz"})'),
         ('{"a" "b"}', '(str {"a" "b"})'),
-        ('{"a" ["b" :c 1 false]}', '(str {"a" ["b" :c 1 false]})'),
+        (
+            '{"a" ["b" :c 1 false ("x") {"y" "z"}]}',
+            '(str {"a" ["b" :c 1 false (seq ["x"]) {"y" "z"}]})',
+        ),
     ],
 )
 def test_str(lcompile: CompileFn, s: str, code: str):


### PR DESCRIPTION
Hi,

could you please consider patch to have the `str` function on seq string items surrounding them with quotation marks. It fixes #891 

The fix simply resets the `human_readable` kw argument for inner elements to False for seqs and maps.

I have included a `test_str` test in `lrepr_test.py` to test the same. This is based on `test_lstr` above it.

It appears to me as if `test_lstr` is inaccurately named. Despite being labeled `lstr`, it employes `pr-str` which differs from invoking `lstr` directly with its arguments, Therefore, I find naming it `test_lstr` a little misleading; it rather seems as to be only capturing the output of `pr`. I could be wrong though 😅 

Thanks