### PR TITLE
Fix issue with syntax quoting reader var macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix an issue where `concat` on maps was iterating over the keys instead of the key/value pairs (#871)
  * Fix a bug where the compiler would throw an exception partially macroexpanding forms with `recur` forms provided as arguments (#856)
  * Fix a bug where the original `(var ...)` form is not retained during analysis, causing it to be lost in calls to `macroexpand` (#888)
+ * Fix issue with the reader var macro failing in syntax quote when unquoting a symbol, e.g. `(#'~symbol) (#889)
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -1527,7 +1527,11 @@ def _read_reader_macro(ctx: ReaderContext) -> LispReaderForm:  # noqa: MC0001
         return _read_namespaced_map(ctx)
     elif token == "'":
         ctx.reader.advance()
-        s = _read_sym(ctx)
+        token_next = ctx.reader.peek()
+        if token_next == "~":
+            s = _read_unquote(ctx)
+        else:
+            s = _read_sym(ctx)
         return llist.l(_VAR, s)
     elif token == '"':
         return _read_regex(ctx)

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -970,6 +970,30 @@ def test_syntax_quoted(test_ns: str, ns: runtime.Namespace):
         ),
     ) == read_str_first("`(~'my-symbol)"), "Do not resolve unquoted quoted syms"
 
+    assert llist.l(
+        reader._SEQ,
+        llist.l(
+            reader._CONCAT,
+            llist.l(
+                reader._LIST,
+                llist.l(
+                    reader._SEQ,
+                    llist.l(
+                        reader._CONCAT,
+                        llist.l(
+                            reader._LIST,
+                            llist.l(sym.symbol("quote"), sym.symbol("var")),
+                        ),
+                        llist.l(
+                            reader._LIST,
+                            llist.l(sym.symbol("quote"), sym.symbol("a-symbol")),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ) == read_str_first("`(#'~'a-symbol)"), "Reader var macro works with unquote"
+
     assert llist.l(sym.symbol("quote"), sym.symbol("&")) == read_str_first(
         "`&"
     ), "do not resolve the not namespaced ampersand"


### PR DESCRIPTION
Hi,

could you please consider fix for the issue with using the reader var macro in syntax quotes. It fixes #889 

I've also added a test.

Thanks