### PR TITLE
Fix issue accessing prop with interop matching builtin name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where the original `(var ...)` form is not retained during analysis, causing it to be lost in calls to `macroexpand` (#888)
  * Fix issue with the reader var macro failing in syntax quote when unquoting a symbol, e.g. `(#'~symbol) (#889)
  * Fix issue where `(str seq)` was printing seq string items without quotation marks (#891)
+ * Fix issue where interop failed to access property name matching a builtins name (#896)
 
 ## [v0.1.0b1]
 ### Added

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -3247,7 +3247,7 @@ def _interop_prop_to_py_ast(
     return GeneratedPyAST(
         node=ast.Attribute(
             value=target_ast.node,
-            attr=munge(node.field),
+            attr=munge(node.field, True),
             ctx=ast.Store() if is_assigning else ast.Load(),
         ),
         dependencies=target_ast.dependencies,

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -3332,6 +3332,13 @@ class TestPythonInterop:
         assert "sym" == lcompile("(.-name 'some.ns/sym)")
         assert "sym" == lcompile("(.- 'some.ns/sym name)")
         assert "sym" == lcompile("(. 'some.ns/sym -name)")
+        assert 5 == lcompile(
+            '(.-abc (python/type "ip-test" (python/tuple) #py {"abc" 5}))'
+        )
+        # when prop name matches a bultins name
+        assert 6 == lcompile(
+            '(.-str (python/type "ip-test" (python/tuple) #py {"str" 6}))'
+        )
 
         with pytest.raises(AttributeError):
             lcompile("(.-fake 'some.ns/sym)")


### PR DESCRIPTION
Hi,

can you please review patch to fix issue with accessing interop properties when they match a builtins name. It fixes #896.

This seems like a simple fix to simply to ignore munging builtins names when accessing interop properties, it does not seem we want it to apply here.

I've also added a test.

Thanks