### PR TITLE
Allow `.` characters in keyword names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Fix a bug where `.` characters were not allowed in keyword names (#899)
 
 ## [v0.1.0b2]
 ### Added

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -1044,9 +1044,6 @@ def _read_kw(ctx: ReaderContext) -> kw.Keyword:
         should_autoresolve = False
 
     ns, name = _read_namespaced(ctx)
-    if "." in name:
-        raise ctx.syntax_error("Found '.' in keyword name")
-
     if should_autoresolve:
         current_ns = get_current_ns()
         if ns is not None:

--- a/tests/basilisp/prompt_test.py
+++ b/tests/basilisp/prompt_test.py
@@ -250,7 +250,6 @@ class TestKeyBindings:
             "\\fakeescape",
             "#?@(:clj [:a :b :c])",
             "ns.of..a/badsymbol",
-            ":bad.keyword",
         ],
     )
     def test_syntax_error(

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -422,6 +422,7 @@ class TestKeyword:
             ("kw", ":kw"),
             ("kebab-kw", ":kebab-kw"),
             ("underscore_kw", ":underscore_kw"),
+            ("dotted.kw", ":dotted.kw"),
             ("kw?", ":kw?"),
             ("+", ":+"),
             ("?", ":?"),
@@ -460,7 +461,7 @@ class TestKeyword:
         assert kw.keyword(k, ns=ns) == read_str_first(raw)
 
     @pytest.mark.parametrize(
-        "v", ["://", ":ns//kw", ":some/ns/sym", ":ns/sym/", ":/kw", ":dotted.kw"]
+        "v", ["://", ":ns//kw", ":some/ns/sym", ":ns/sym/", ":/kw"]
     )
     def test_illegal_symbol(self, v: str):
         with pytest.raises(reader.SyntaxError):

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ deps =
     sphinx
 commands =
     pylint src/
-    ruff src/
+    ruff check src/
 
 [testenv:safety]
 deps = safety

--- a/tox.ini
+++ b/tox.ini
@@ -60,4 +60,4 @@ commands =
 [testenv:safety]
 deps = safety
 commands =
-    safety check -i 40291 -i 67599
+    safety check -i 40291 -i 67599 -i 70612


### PR DESCRIPTION
Fixes #899 