### PR TITLE
Fix bug with `cli run` failing on MS-Windows file paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fix a bug where `.` characters were not allowed in keyword names (#899)
  * Fix a bug where nested quotation marks were not escaped properly by various print functions and at the REPL (#894)
+ * Fixed a bug that caused a syntax error when presenting any filepath that includes the MS-Windows `\` file separator to the cli run command (#912)
 
 ### Other
  * Update Sphinx documentation theme (#909)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -49,7 +49,12 @@ def eval_str(s: str, ctx: compiler.CompilerContext, ns: runtime.Namespace, eof: 
 
 def eval_file(filename: str, ctx: compiler.CompilerContext, ns: runtime.Namespace):
     """Evaluate a file with the given name into a Python module AST node."""
-    return eval_str(f'(load-file "{filename}")', ctx, ns, eof=object())
+    if os.path.exists(filename):
+        return eval_str(
+            f'(load-file "{Path(filename).as_posix()}")', ctx, ns, eof=object()
+        )
+    else:
+        raise FileNotFoundError(f"Error: The file {filename} does not exist.")
 
 
 def eval_namespace(

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -253,11 +253,22 @@ class TestRun:
         result = run_cli(["run", "-c", self.cli_args_code, *args])
         assert ret == result.lisp_out
 
-    def test_run_file(self, isolated_filesystem, run_cli):
+    def test_run_file_rel(self, isolated_filesystem, run_cli):
         with open("test.lpy", mode="w") as f:
             f.write("(println (+ 1 2))")
         result = run_cli(["run", "test.lpy"])
         assert f"3{os.linesep}" == result.lisp_out
+
+    def test_run_file_abs(self, isolated_filesystem, run_cli):
+        with open("test.lpy", mode="w") as f:
+            f.write("(println (+ 1 3))")
+        full_path = os.path.abspath("test.lpy")
+        result = run_cli(["run", full_path])
+        assert f"4{os.linesep}" == result.lisp_out
+
+    def test_run_file_not_found(self, isolated_filesystem, run_cli):
+        with pytest.raises(FileNotFoundError):
+            run_cli(["run", "xyz.lpy"])
 
     def test_run_file_main_ns(self, isolated_filesystem, run_cli):
         with open("test.lpy", mode="w") as f:


### PR DESCRIPTION
Hi,

could you please review patch to convert cli run paths to posix. It fixes #912.

The path was passed verbatim to `load` and MS-Windows path separator chars `\` was treated as escape sequences.

The fix also checks if path refers to a real file, so that it avoids forming invalid `load` requests.

Tests updated.

Thanks