### PR TITLE
Minor documentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added `:end-line` and `:end-col` metadata to forms during compilation (#903)
+ * Added `basilisp.repl/source` to allow inspecting source code from the REPL (#205)
 
 ### Changed
  * Updated dozens of type annotations in the compiler to satisfy MyPy 1.11 (#910)
@@ -21,8 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where reader column offset numbering began at 1, rather than 0 (#905)
 
 ### Other
+ * Add REPL documentation module (#205)
  * Update Sphinx documentation theme (#909)
- * Fix a few minor documentation issues (#907)
+ * Fix a few minor documentation issues (#907, #???)
 
 ## [v0.1.0b2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
  * Add REPL documentation module (#205)
  * Update Sphinx documentation theme (#909)
- * Fix a few minor documentation issues (#907, #???)
+ * Update documentation to directly reference Python documentation and fix many other minor issues and misspellings (#907, #919)
 
 ## [v0.1.0b2]
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
+DOCSOURCEDIR = "./docs"
+DOCBUILDDIR = "./docs/_build"
+
 .PHONY: docs
 docs:
-	@poetry run sphinx-build -M html "./docs" "./docs/_build"
+	@poetry run sphinx-build -M html "$(DOCSOURCEDIR)" "$(DOCBUILDDIR)"
+
+
+.PHONY: livedocs
+livedocs:
+	@poetry run sphinx-autobuild "$(DOCSOURCEDIR)" "$(DOCBUILDDIR)" -b html
 
 
 .PHONY: format

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -92,7 +92,7 @@ Run Basilisp as an Application
 
 Python applications don't have nearly as many constraints on their entrypoints as do Java applications.
 Nevertheless, developers may have a clear entrypoint in mind when designing their application code.
-In such cases, it may be desirable to take advantage of the computed Python ``sys.path`` to invoke your entrypoint.
+In such cases, it may be desirable to take advantage of the computed Python :external:py:data:`sys.path` to invoke your entrypoint.
 To do so, you can use the ``basilisp run -n`` flag to invoke an namespace directly:
 
 .. code-block:: bash

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -216,6 +216,13 @@ References and Refs
 
 TBD
 
+.. _volatiles:
+
+Volatiles
+---------
+
+TBD
+
 .. _transducers:
 
 Transducers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ release = ""
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
+    "sphinx_copybutton",
     "basilisp.contrib.sphinx",
 ]
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,5 @@ sphinxcontrib-devhelp>=1.0.6,<2.0.0
 sphinxcontrib-htmlhelp>=2.0.5,<3.0.0
 sphinxcontrib-qthelp>=1.0.7,<2.0.0
 sphinxcontrib-serializinghtml>=1.1.10,<2.0.0
+sphinx-copybutton>=0.5.2,<1.0.0
+sphinxext-opengraph>=0.9.1,<1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ pytest-pycharm = "*"
 # to maintain consistent output during both development and publishing on
 # Read The Docs.
 sphinx = "^7.1.0"
+sphinx-autobuild = { version = "^2024.04.16", python = ">=3.9" }
+sphinx-copybutton = "^0.5.2"
+sphinxext-opengraph = "^v0.9.1"
 furo = "^2023.08.19"
 tox = "*"
 

--- a/src/basilisp/contrib/bencode.lpy
+++ b/src/basilisp/contrib/bencode.lpy
@@ -1,6 +1,7 @@
 ;; Decoding logic adapted from
 ;; https://github.com/babashka/nbb/blob/bca8b5017a06768eb35d02a2d6233ca9c6c2f692/src/nbb/impl/bencode.cljs
 (ns basilisp.contrib.bencode
+  "Support for bencode encoding and decoding."
   (:require
    [basilisp.string :as str]))
 
@@ -82,24 +83,24 @@
 
   ``encode`` supports encoding the following types:
 
-  - ``bytes``
-  - ``int``
-  - ``str``, which is first decided to UTF-8 ``bytes``
+  - :external:py:class:`bytes`
+  - :external:py:class:`int`
+  - :external:py:class:`str` , which is first decoded to UTF-8 ``bytes``
   - keywords and symbols, which are first converted to strings (including namespace,
     separated by '/') and then converted using the rules for ``str`` s
-  - Python ``list``
-  - ``tuple``
-  - Basilisp lists and vectors
-  - ``dict``
-  - maps
+  - :external:py:class:`list`
+  - :external:py:class:`tuple`
+  - :external:py:class:`dict`
+  - Basilisp lists, vectors, and maps
 
   Mapping type keys must one of: keywords, symbols, or strings.
 
   This function does not support ``float`` because the ``bencode`` specification does
   not support non-integer numerics.
 
-  Set types (including ``frozenset``, ``set``, or Basilisp's set types) are not
-  supported due to the requirement that lists retain their original element ordering."
+  Set types (including :external:py:class:`frozenset` , :external:py:class:`set`, or
+  Basilisp's set types) are not supported due to the requirement that lists retain
+  their original element ordering."
   [d]
   (to-bencode-encodeable* d))
 
@@ -111,11 +112,10 @@
   `(.index ~b ~c))
 
 (defn- slice
-  "Returns the slice of the ``bytes`` from the ``start`` index to
-  the end of the array or to the ``end`` index if provided. Returns
-  `nil` if the slice is empty.
+  "Returns the slice of the ``bytes`` from the ``start`` index to the end of the
+  array or to the ``end`` index if provided. Returns ``nil`` if the slice is empty.
 
-  Throw a `python/EOFError` exception if any of the indices are out
+  Throw a :external:py:exc:`python.EOFError` exception if any of the indices are out
   of bounds."
   ([bytes start]
    (if (< (len bytes) start)
@@ -178,13 +178,13 @@
 
 (defn decode
   "Decode the first value in the bencoded ``data`` bytes according to ``opts`` and
-  return a [decoded* rest*] vector.
+  return a ``[decoded* rest*]`` vector.
 
   The decoded* item in the vector is the decoded value of the first item in ``data``
   while rest* is the remaining unencoded values.
 
   If ``data`` cannot be decoded (e.g. is incomplete or an error occurred), it returns
-  a [nil ``data``] vector.
+  a ``[nil data]`` vector.
 
   ``opts`` is a map with the following optional supported keys.
 
@@ -207,12 +207,12 @@
         [nil data]))))
 
 (defn decode-all
-  "Decode all values in the bencoded ``data`` bytes and return them as
-  a [values* incomplete*] vector.
+  "Decode all values in the bencoded ``data`` bytes and return them as a
+  ``[values* incomplete*]`` vector.
 
-  The values* item is a collection of the ``data`` decoded values,
-  while incomplete* is the rest of the ``data`` bytes that could not
-  be decoded or nil.
+  The ``values*`` item is a collection of the ``data`` decoded values, while
+  ``incomplete*`` is the rest of the ``data`` bytes that could not be decoded
+  or ``nil``.
 
   ``opts`` is a map supporting the same keys as :lpy:fn:`decode`."
   ([data]

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -1,7 +1,7 @@
 ;; adapted from
 ;; https://github.com/babashka/nbb/blob/bca8b5017a06768eb35d02a2d6233ca9c6c2f692/src/nbb/impl/nrepl_server.cljs
 (ns basilisp.contrib.nrepl-server
-  "A port of `nbb <https://github.com/babashka/nbb>`_'s nREPL server implementation to basilisp."
+  "A port of `nbb <https://github.com/babashka/nbb>`_ 's nREPL server implementation to Basilisp."
   (:require [basilisp.contrib.bencode :as bc]
             [basilisp.string :as str])
   (:import logging
@@ -104,20 +104,19 @@
                       "ns" ns})))
 
 (defn- do-handle-eval
-  "Evaluate the ``request`` ``code`` of ``file`` in the ``ns`` namespace
-  according to the current state of the ``client*`` and sends its
-  result with ``send-fn``.
+  "Evaluate the ``request`` ``code`` of ``file`` in the ``ns`` namespace according
+  to the current state of the ``client*`` and sends its result with ``send-fn``.
 
-  The result sent is either the last evaluated value or exception,
-  followed by the \"done\" status.
+  The result sent is either the last evaluated value or exception, followed by
+  the \"done\" status.
 
-  If ``ns`` is not provided, then it uses the ``client``'s :eval-ns as
-  the evaluation namespace. The latter is updated with the current
-  namespace after evaluation is completed.
+  If ``ns`` is not provided, then it uses the ``client``'s ``:eval-ns`` as the
+  evaluation namespace. The latter is updated with the current namespace after
+  evaluation is completed.
 
-  It binds the `*1`, `*2`, `*3` and `*e` variables for evaluation from
-  the corresponding ones found in ``client*``, and updates the latter
-  according to the result."
+  It binds the ``*1``, ``*2``, ``*3`` and ``*e`` variables for evaluation from
+  the corresponding ones found in ``client*``, and updates the latter according
+  to the result."
   [{:keys [client* code ns file _column _line] :as request} send-fn]
   (let [{:keys [*1 *2 *3 *e eval-ns]} @client*
         out-stream                    (StreamOutFn #(send-fn request {"out" %}))
@@ -163,22 +162,17 @@
   (throw (python/NotImplementedError)))
 
 (defn- symbol-identify
-  "Return a vector of information about ``symbol-str`` as might be
-  resolved in ``resolve-ns``.
+  "Return a vector of information about ``symbol-str`` as might be resolved
+  in ``resolve-ns``.
 
-  The returned vector can be one of
+  The returned vector can be one of:
 
-  [:keyword KEYWORD] the ``symbol-str`` is this KEYWORD.
-
-  [:nil FORM] the ``symbol-str`` is this nil FORM.
-
-  [:special-form FORM] the ``symbol-str`` this special FORM.
-
-  [:var VAR] the ``symbol-str`` is this VAR.
-
-  [:error ERROR] there was this ERROR when trying to parse ``symbol-str``.
-
-  [:other FORM] the ``symbol-str`` is of yet to be categorized FORM."
+  - ``[:keyword KEYWORD]`` the ``symbol-str`` is this ``KEYWORD``
+  - ``[:nil FORM]`` the ``symbol-str`` is this nil ``FORM``
+  - ``[:special-form FORM]`` the ``symbol-str`` this special ``FORM``
+  - ``[:var VAR]`` the ``symbol-str`` is this ``VAR``
+  - ``[:error ERROR]`` there was this ``ERROR`` when trying to parse ``symbol-str``
+  - ``[:other FORM]`` the ``symbol-str`` is of yet to be categorized ``FORM``."
   [resolve-ns symbol-str]
   (let [reader               (io/StringIO symbol-str)
         {:keys [form error]} (try {:form (binding [*ns* resolve-ns]
@@ -219,9 +213,8 @@
        (str/join \newline)))
 
 (defn- handle-lookup
-  "Look up :sym (CIDER) or :symbol (calva) from ``request`` in
-  ``ns`` (or if not provided :eval-ns from ``client*``) and pass
-  results to ``send-fn``.
+  "Look up ``:sym`` (CIDER) or ``:symbol`` (calva) from ``request`` in ``ns``
+  (or if not provided ``:eval-ns`` from ``client*``) and pass results to ``send-fn``.
 
   Serves both :eldoc and :info ``request`` :op's."
   [{:keys [ns client*] :as request} send-fn]
@@ -270,8 +263,8 @@
            {"status" status "ex" (str e)}))))))
 
 (defn- handle-load-file
-  "Evaluate code in ``file`` from ``file-path`` and sends the result
-  using the ``send-fn``."
+  "Evaluate code in ``file`` from ``file-path`` and sends the result using the
+  ``send-fn``."
   [{:keys [file _file-name file-path] :as request} send-fn]
   (do-handle-eval (assoc request
                          :file (or file-path "<unspecified filepath>")
@@ -279,12 +272,10 @@
                   send-fn))
 
 (defn- handle-complete
-  "Calculates the name completion candidates for ``prefix`` (or
-  ``req-symbol``) in namespace ``ns`` for ``client*`` and sends the
-  completions using ``send-fn``.
+  "Calculates the name completion candidates for ``prefix`` (or ``req-symbol``) in
+  namespace ``ns`` for ``client*`` and sends the completions using ``send-fn``.
 
-  If ``ns`` is not provided, then the ``client*`` :eval-ns is used
-  instead."
+  If ``ns`` is not provided, then the ``client*`` :eval-ns is used instead."
   [{:keys [client* ns prefix] req-symbol :symbol :as request} send-fn]
   (let [prefix            (or prefix req-symbol)
         {:keys [eval-ns]} @client*
@@ -317,17 +308,17 @@
                       "status" ["done"]})))
 
 (def ops
-  "A list of operations supported by the nrepl server."
-  {:eval handle-eval
-   :describe handle-describe
-   :info handle-lookup
-   :eldoc handle-lookup
-   :clone handle-clone
-   :close handle-close
+  "A list of operations supported by the nREPL server."
+  {:eval      handle-eval
+   :describe  handle-describe
+   :info      handle-lookup
+   :eldoc     handle-lookup
+   :clone     handle-clone
+   :close     handle-close
+   :load-file handle-load-file
+   :complete  handle-complete
    ;; :macroexpand handle-macroexpand
    ;; :classpath handle-classpath
-   :load-file handle-load-file
-   :complete handle-complete
    })
 
 (defn- handle-request [{:keys [op] :as request} send-fn]
@@ -358,10 +349,9 @@
 (defn- on-connect [tcp-req-handler opts]
   "Serve a new nREPL connection as found in ``tcp-req-handler`` according to ``opts``.
 
-  ``opts`` is a map of options with the following optional keys.
+  ``opts`` is a map of options with the following optional keys:
 
-  :recv-buffer-size The buffer size to using for incoming nREPL
-  messages."
+  - ``:recv-buffer-size`` The buffer size to using for incoming nREPL messages."
   (let [{:keys [recv-buffer-size]
          :or {recv-buffer-size 1024}} opts
         socket                        (.-request tcp-req-handler)
@@ -405,32 +395,32 @@
         (error (traceback/format-exc))))))
 
 (defn server-make
-  "Create and return a `socketserver/TCPServer` serving nREPL clients
-  according to ``opts`` at 127.0.0.1 at a random available port.
+  "Create and return a :external:py:class:`socketserver.TCPServer` serving nREPL
+  clients according to ``opts``.
 
-  See `ops` for the operation supported by the server.
+  See :lpy:var:`ops` for the operations supported by the server.
 
-  The nREPL starts at the `user` namespace and binds `*1`, `*2`, `*3`
+  The nREPL starts at the ``user`` namespace and binds `*1`, `*2`, `*3`
   and `*e` to the ultimate, penultimate, antepenultimate evaluation
   result and last exception message respectively.
 
-  ``opts`` is a map of options with the following optional keys
+  ``opts`` is a map of options with the following optional keys:
 
-  :host The host address to bind to, defaults to 127.0.0.1.
-
-  :port The port number to listen to, defaults to 0 which means to
-  pickup a random available port.
+   :keyword ``:host``: The host address to bind to, defaults to ``127.0.0.1``
+   :keyword ``:port``: The port number to listen to, defaults to ``0`` which means
+       to pickup a random available port.
 
   See :lpy:fn:`on-connect` for additionally supported ``opts`` keys.
 
-  Known limitations:
+  .. warning::
 
-  1. All client connections share the same environment at the moment,
-  which is the env that the server runs in. This could change in the
-  future to isolate the clients interactions from each other.
+     All client connections share the same environment at the moment, which is the
+     env that the server runs in. This could change in the future to isolate the
+     clients interactions from each other.
 
-  2. The session uuids are ignored and only created to satisfy the
-  initial clone op."
+  .. note::
+
+     The session UUIDs are ignored and only created to satisfy the initial clone op."
   [opts]
   (let [{:keys [host port] :or {host "127.0.0.1" port 0}} opts
         handler (python/type (name (gensym "nREPLTCPHandler")) (python/tuple [socketserver/StreamRequestHandler])
@@ -438,27 +428,30 @@
     (socketserver/ThreadingTCPServer (python/tuple [host port]) handler)))
 
 (def ^:private nrepl-server-signature
-  "The de facto signature nrepl started message that is used by IDEs to
-  identify the host and port number the server is running on."
+  "The de facto signature nrepl started message that is used by IDEs to identify the
+  host and port number the server is running on."
   "nREPL server started on port %s on host %s - nrepl://%s:%s")
 
 (defn start-server!
-  "Create an nREPL server with :lpy:fn:`server-make` (of which see)
-  according to ``opts`` if given, and serve clients for ever.
+  "Create an nREPL server with :lpy:fn:`server-make` according to ``opts`` and
+  serve clients forever.
 
-  It prints out the `nrepl-server-signature` message at startup for
+  It prints out the :lpy:var:`nrepl-server-signature` message at startup for
   IDEs to pickup the host number to connect to.
 
-  ``opts`` is a map of options with the following optional keys
+  ``opts`` is a map of options with the following optional keys:
 
-  :nrepl-port-file The file to write the port number to, it defaults
-  to .nrepl-port.
+   :keyword ``:host``: The host address to bind to, defaults to ``127.0.0.1``
+   :keyword ``:port``: The port number to listen to, defaults to ``0`` which means
+       to pickup a random available port.
+   :keyword ``:nrepl-port-file``: The file to write the port number to, it defaults
+       to .nrepl-port.
+   :keyword ``:server*``: An atom to hold the server reference as returned from
+       :lpy:fn:`server-make` , useful for testing.
 
-  :server* An atom to hold the server reference as returned from
-  :lpy:fn:`server-make`, useful for testing.
+  .. seealso::
 
-  also see :lpy:fn:`server-make` for additionally supported
-  ``opts`` keys."
+     :lpy:fn:`server-make`"
   ([]
    (start-server! {}))
   ([opts]

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -1213,20 +1213,21 @@
   (instance? basilisp.lang.interfaces/IAssociative x))
 
 (defn ^:inline bytes?
-  "Return ``true`` if ``x`` is a byte array (the Python ``bytearray`` type).
+  "Return ``true`` if ``x`` is a byte array (the Python :external:py:class:`bytearray`
+  type).
 
   Note that Python supplies byte string and byte array objects in its standard library.
   This function complies with Clojure's standard library in returning true iff ``x`` is
-  a Python ``bytearray``\\. To check if an object is a Python ``bytes``\\, use
-  :lpy:fn:`byte-string?` ."
+  a Python ``bytearray``\\. To check if an object is a Python
+  :external:py:class:`bytes`\\, use :lpy:fn:`byte-string?` ."
   [x]
   (instance? python/bytearray x))
 
 (defn ^:inline byte-string?
-  "Return ``true`` if ``x`` is a byte string (the Python ``bytes`` type).
+  "Return ``true`` if ``x`` is a byte string (the Python :external:py:class:`bytes` type).
 
   Note that Python supplies byte string and byte array objects in its standard library.
-  To check if an object is a Python ``bytearray``, use ``bytes?``\\."
+  To check if an object is a Python :external:py:class:`bytearray`, use ``bytes?``\\."
   [x]
   (instance? python/bytes x))
 
@@ -1257,7 +1258,7 @@
   (instance? basilisp.lang.interfaces/ICounted x))
 
 (defn ^:no-inline decimal?
-  "Return ``true`` if ``x`` is a ``Decimal``\\."
+  "Return ``true`` if ``x`` is a :external:py:class:`decimal.Decimal`\\."
   [x]
   (instance? decimal/Decimal x))
 
@@ -1278,7 +1279,7 @@
   [x]
   (operator/is- x false))
 
-(def ^{:doc "Return ``true`` if ``o`` is a float.
+(def ^{:doc "Return ``true`` if ``o`` is a :external:py:class:`float`\\.
 
              Same as :lpy:fn:`float?`. Python does not distinguish between single and
              double precision floating point numbers, so all floating points are called
@@ -1316,7 +1317,7 @@
   [x]
   (math/isinf x))
 
-(def ^{:doc "Return ``true`` if ``x`` is an integer.
+(def ^{:doc "Return ``true`` if ``x`` is an :external:py:class`int`\\.
 
              Note that unlike Clojure, Basilisp uses Python integers and there is no
              distinction between standard and fixed-precision integers."}
@@ -1379,27 +1380,27 @@
   (and (integer? x) (pos? x)))
 
 (defn ^:inline py-dict?
-  "Return ``true`` if ``x`` is a Python ``dict``\\."
+  "Return ``true`` if ``x`` is a Python :external:py:class:`dict`\\."
   [x]
   (instance? python/dict x))
 
 (defn ^:inline py-frozenset?
-  "Return ``true`` if ``x`` is a Python ``frozenset``\\."
+  "Return ``true`` if ``x`` is a Python :external:py:class:`frozenset`\\."
   [x]
   (instance? python/frozenset x))
 
 (defn ^:inline py-list?
-  "Return ``true`` if ``x`` is a Python ``list``\\."
+  "Return ``true`` if ``x`` is a Python :external:py:class:`list`\\."
   [x]
   (instance? python/list x))
 
 (defn ^:inline py-set?
-  "Return ``true`` if ``x`` is a Python ``set``\\."
+  "Return ``true`` if ``x`` is a Python :external:py:class:`set`\\."
   [x]
   (instance? python/set x))
 
 (defn ^:inline py-tuple?
-  "Return ``true`` if ``x`` is a Python ``tuple``\\."
+  "Return ``true`` if ``x`` is a Python :external:py:class:`tuple`\\."
   [x]
   (instance? python/tuple x))
 
@@ -1424,7 +1425,7 @@
   (instance? basilisp.lang.queue/PersistentQueue x))
 
 (defn ^:no-inline ratio?
-  "Return ``true`` if ``x`` is a ``Fraction``\\."
+  "Return ``true`` if ``x`` is a :external:py:class:`fractions.Fraction`\\."
   [x]
   (instance? fractions/Fraction x))
 
@@ -1474,12 +1475,12 @@
   (operator/is- x true))
 
 (defn ^:no-inline uuid?
-  "Return ``true`` if ``x`` is a UUID."
+  "Return ``true`` if ``x`` is a :external:py:class:`uuid.UUID`."
   [x]
   (instance? uuid/UUID x))
 
 (defn uuid-like?
-  "Return ``true`` if ``x`` is coercible to a UUID.
+  "Return ``true`` if ``x`` is coercible to a :external:py:class:`uuid.UUID`.
 
   Python's UUID constructor supports byte sequences in big- and little-endian byte
   orders. This function checks only for big-endian bytes."
@@ -1553,7 +1554,7 @@
 ;;;;;;;;;;;;;;;;;;;
 
 (defn bigdec
-  "Coerce ``x`` to a Python ``decimal.Decimal``\\."
+  "Coerce ``x`` to a Python :external:py:class:`decimal.Decimal`\\."
   [x]
   (decimal/Decimal x))
 
@@ -1561,7 +1562,8 @@
   "Coerce ``x`` to an integer.
 
   Python's builtin ``int`` type is arbitrary precision, so there is no difference
-  between ``bigint``\\, ``biginteger``\\, and Python's builtin ``int``\\."
+  between ``bigint``\\, ``biginteger``\\, and Python's builtin
+  :external:py:class:`int`\\."
   [x]
   (python/int x))
 
@@ -1569,7 +1571,8 @@
   "Coerce ``x`` to an integer.
 
   Python's builtin ``int`` type is arbitrary precision, so there is no difference
-  between ``bigint``\\, ``biginteger``\\, and Python's builtin ``int``\\."
+  between ``bigint``\\, ``biginteger``\\, and Python's builtin
+  :external:py:class:`int`\\."
   [x]
   (python/int x))
 
@@ -1588,7 +1591,7 @@
        (python/ValueError (str "cannot coerce " (python/repr x) " to byte"))))))
 
 (defn byte-string
-  "Coerce ``x`` to a byte string (Python ``bytes`` object).
+  "Coerce ``x`` to a byte string (Python :external:py:class:`bytes` object).
 
   Arguments shall be interpreted exactly as with that object's constructor."
   ([x]
@@ -1601,8 +1604,8 @@
 (defn char
   "Coerce ``x`` to a string of length 1.
 
-  Natural integers are treated as ordinals and passed to Python's ``chr``. Strings of
-  length 1 are returned as such. Other types will result in a ``ValueError``\\."
+  Natural integers are treated as ordinals and passed to Python's :external:py:func:`chr`.
+  Strings of length 1 are returned as such. Other types will result in a ``ValueError``\\."
   [x]
   (cond
     (instance? python/int x) (python/chr x)
@@ -1614,36 +1617,38 @@
 (defn ^:inline double
   "Coerce ``x`` to a float.
 
-  Python does not differentiate between ``float`` and ``double``. Python ``float`` s are
-  double precision."
+  Python does not differentiate between ``float`` and ``double``. Python
+  :external:py:class:`float`\\s are double precision."
   [x]
   (python/float x))
 
 (defn ^:inline float
-  "Coerce ``x`` to a float.
+  "Coerce ``x`` to a :external:py:class:`float`\\.
 
   If ``x`` is string, it is parsed as a floating point number."
   [x]
   (python/float x))
 
 (defn ^:inline int
-  "Coerce ``x`` to an integer.
+  "Coerce ``x`` to an :external:py:class:`int`\\.
 
   If ``x`` is string, it is parsed as a base 10 number."
   [x]
   (python/int x))
 
 (defn ^:inline long
-  "Coerce ``x`` to an integer.
+  "Coerce ``x`` to an :external:py:class:`int`\\.
 
-  Python does not support `long` types, so the value is coerced to an integer."
+  Python does not support `long` types, so the value is coerced to an integer as by
+  :lpy:fn:`int`\\."
   [x]
   (python/int x))
 
 (defn ^:inline short
-  "Coerce ``x`` to an integer.
+  "Coerce ``x`` to an :external:py:class:`int`\\.
 
-  Python does not support `short` types, so the value is coerced to an integer."
+  Python does not support `short` types, so the value is coerced to an integer as by
+  :lpy:fn:`int`\\."
   [x]
   (python/int x))
 
@@ -1672,7 +1677,7 @@
 
 (defcopy unchecked-add
   "Same as :lpy:fn:`+`. Python integers are unlimited precision, so unchecked
-  arithmetic is onlyprovided for compatibility with platforms without unlimited
+  arithmetic is only provided for compatibility with platforms without unlimited
   precision integers."
   +)
 (defcopy unchecked-add-int
@@ -3255,7 +3260,8 @@
           (rest args)))
 
 (defn sort-by
-  "Return a sorted sequence of the elements from ``coll`` using the ``cmp`` comparator on (``keyfn`` item)\\.
+  "Return a sorted sequence of the elements from ``coll`` using the ``cmp`` comparator
+  on (``keyfn`` item)\\.
 
   The :lpy:fn:`compare` fn is used in if ``cmp`` is not provided."
   ([keyfn coll]
@@ -4100,8 +4106,8 @@
 ;;;;;;;;;;;;;;;;;;;;
 
 (defn file-seq
-  "Return a seq of ``pathlib.Path`` objects for all files and subdirectories of
-  ``dir``\\."
+  "Return a seq of :external:py:class:`pathlib.Path` objects for all files and
+  subdirectories of ``dir``\\."
   [dir]
   (-> (pathlib/Path dir)
       (.resolve)
@@ -4116,33 +4122,33 @@
   "The current value of *standard in* used by Basilisp.
 
   Note that binding a new value to this Var will not affect *Python* code (which
-  generally respects ``sys.stdin``), though all Basilisp code should respect the
-  value."
+  generally respects :external:py:data:`sys.stdin`\\), though all Basilisp code should
+  respect the value."
   sys/stdin)
 
 (def ^:dynamic *out*
   "The current value of *standard out* used by Basilisp.
 
   Note that binding a new value to this Var will not affect *Python* code (which
-  generally respects ``sys.stdout``), though all Basilisp code should respect the
-  value."
+  generally respects :external:py:data:`sys.stdout`\\), though all Basilisp code should
+  respect the value."
   sys/stdout)
 
 (def ^:dynamic *err*
   "The current value of *standard error* used by Basilisp.
 
   Note that binding a new value to this Var will not affect *Python* code (which
-  generally respects ``sys.stderr``), though all Basilisp code should respect the
-  value."
+  generally respects :external:py:data:`sys.stderr`\\), though all Basilisp code should
+  respect the value."
   sys/stderr)
 
 (def ^:dynamic *print-sep* " ")
 
 (def ^:dynamic *flush-on-newline*
-  "Indicates whether the `:lpy:fn:prn` and `:lpy:fn:println` functions
-  should flush the output stream after the last newline is written.
+  "Indicates whether the :lpy:fn:`prn` and :lpy:fn:`println` functions should flush the
+  output stream after the last newline is written.
 
-  Defaults to true."
+  Defaults to ``true``\\."
   true)
 
 (defn ^:inline repr
@@ -4162,8 +4168,8 @@
   nil)
 
 (defmacro with-in-str
-  "Evaluate body with :lpy:var:`*in*` bound to a ``io.StringIO`` instance containing
-  the string ``s``\\."
+  "Evaluate body with :lpy:var:`*in*` bound to a :external:py:class:`io.StringIO`
+  instance containing the string ``s``\\."
   [s & body]
   `(binding [*in* (io/StringIO ~s)]
      ~@body))
@@ -4361,9 +4367,10 @@
   Callers may bind a map of readers to :lpy:var:`*data-readers*` to customize the data
   readers used reading this string.
 
-  The stream must satisfy the interface of ``io.TextIOBase``\\, but does not require any
-  pushback capabilities. The default ``basilisp.lang.reader.StreamReader`` can wrap any
-  object implementing ``TextIOBase`` and provide pushback capabilities."
+  The stream must satisfy the interface of :external:py:class:`io.TextIOBase`\\, but
+  does not require any pushback capabilities. The default
+  ``basilisp.lang.reader.StreamReader`` can wrap any object implementing ``TextIOBase``
+  and provide pushback capabilities."
   ([]
    (read *in*))
   ([stream]
@@ -4401,7 +4408,8 @@
                                                    namespace))))
 
 (defn load-reader
-  "Read and evaluate the set of forms in the ``io.TextIOBase`` instance ``reader``.
+  "Read and evaluate the set of forms in the :external:py:class:`io.TextIOBase` instance
+  ``reader``.
 
   Most often this is useful if you want to split your namespace across multiple source
   files. :lpy:fn:`require` will try to force you into a namespace-per-file paradigm
@@ -4441,7 +4449,7 @@
   "Resolve load ``path`` relative to the current namespace, or, if it
   begins with \"/\", relative to the syspath, and return it.
 
-  Throw a ``python/FileNotFoundError`` if the ``path`` cannot be resolved."
+  Throw a :external:py:exc:`FileNotFoundError` if the ``path`` cannot be resolved."
   [path]
   (let [path-rel (if (.startswith path "/")
                    path
@@ -5081,12 +5089,12 @@
 ;;;;;;;;;;;;;;;;;;;;;
 
 (defn re-pattern
-  "Return a new ``re.Pattern`` instance."
+  "Return a new :external:py:class:`re.Pattern` instance."
   [s]
   (re/compile s))
 
 (defn re-find
-  "Returns the first match of a string to a pattern using ``re.search``\\.
+  "Returns the first match of a string to a pattern using :external:py:func:`re.search`\\.
 
   If the string matches the pattern exactly and there are no match groups, return the
   string. Otherwise, return a vector with the string in the first position and the
@@ -5100,7 +5108,7 @@
           (vec (cons (.group match 0) groups)))))))
 
 (defn re-matches
-  "Returns a match of a string to a pattern using ``re.fullmatch``\\.
+  "Returns a match of a string to a pattern using :external:py:func:`re.fullmatch`\\.
 
   If the string matches the pattern exactly and there are no match groups, return the
   string. Otherwise, return a vector with the string in the first position and the
@@ -5123,7 +5131,8 @@
                      (lazy-re-seq (rest iter))))))))
 
 (defn re-seq
-  "Returns a lazy sequence of matches of a string to a pattern using ``re.finditer``\\.
+  "Returns a lazy sequence of matches of a string to a pattern using
+  :external:py:func:`re.finditer`\\.
 
   If the string matches the pattern exactly and there are no match groups, return the
   string. Otherwise, return a vector with the string in the first position and the
@@ -5900,13 +5909,10 @@
 
 (defn parse-double
   "Parse the string argument ``s`` as a floating point number as by Python's
-  builtin |float|_ function, returning the float if the string contains one,
-  or ``nil`` otherwise.
+  builtin :external:py:class:`float` function, returning the float if the string
+  contains one, or ``nil`` otherwise.
 
-  This function will throw a ``TypeError`` for non-string types.
-
-  .. |float| replace:: ``float``
-  .. _float: https://docs.python.org/3/library/functions.html#float"
+  This function will throw a ``TypeError`` for non-string types."
   [s]
   (if (string? s)
     (try
@@ -5916,13 +5922,10 @@
 
 (defn parse-long
   "Parse the string argument ``s`` as an integer (base 10) as by Python's builtin
-  |int|_ function, returning the integer if the string contains one, or ``nil``
-  otherwise.
+  :external:py:class:`int` function, returning the integer if the string contains one,
+  or ``nil`` otherwise.
 
-  This function will throw a ``TypeError`` for non-string types.
-
-  .. |int| replace:: ``int``
-  .. _int: https://docs.python.org/3/library/functions.html#int"
+  This function will throw a ``TypeError`` for non-string types."
   [s]
   (if (string? s)
     (try
@@ -5931,8 +5934,8 @@
     (throw (parsing-error s))))
 
 (defn parse-boolean
-  "Parse the string argument ``s`` as either boolean ``true`` or ``false``
-  returning the boolean if the string contains one, or ``nil`` otherwise.
+  "Parse the string argument ``s`` as either boolean ``true`` or ``false`` returning the
+  boolean if the string contains one, or ``nil`` otherwise.
 
   This function will throw a ``TypeError`` for non-string types."
   [s]
@@ -5941,13 +5944,10 @@
     (throw (parsing-error s))))
 
 (defn parse-uuid
-  "Parse the string argument ``s`` as a UUID as by Python's |uuid.UUID|_\\,
-  returning the UUID if the string contains one, or ``nil`` otherwise.
+  "Parse the string argument ``s`` as a :external:py:class:`uuid.UUID`, returning the
+  UUID if the string contains one, or ``nil`` otherwise.
 
-  This function will throw a ``TypeError`` for non-string types.
-
-  .. |uuid.UUID| replace:: ``uuid.UUID``
-  .. _uuid.UUID: https://docs.python.org/3/library/uuid.html"
+  This function will throw a ``TypeError`` for non-string types."
   [s]
   (if (string? s)
     (try
@@ -5960,8 +5960,10 @@
 ;;;;;;;;;;;;;;;;
 
 (defmulti munge
-  "Munge the input value into a Python-safe string. Converts keywords and
-  symbols into strings as by `name` prior to munging. Returns a string."
+  "Munge the input value into a Python-safe string. Converts keywords and symbols into
+  strings as by :lpy:fn:`name` prior to munging.
+
+  Returns a string."
   python/type)
 
 (defmethod munge basilisp.lang.keyword/Keyword
@@ -6081,9 +6083,9 @@
   implementation of an interface (perhaps via :lpy:fn:`deftype`) and supply
   implementations for all of the abstract methods.
 
-  The generated interface derives from Python's ``abc.ABC`` and all method definitions
-  are declared as ``abc.abstractmethod`` s and thus must be implemented by a concrete
-  type.
+  The generated interface derives from Python's :external:py:class:`abc.ABC` and all
+  method definitions are declared as :external:py:func:`abc.abstractmethod` s and thus
+  must be implemented by a concrete type.
 
   Interfaces created by ``definterface`` cannot be declared as properties, class
   methods, or static methods, as with :lpy:fn:`deftype`."
@@ -6159,8 +6161,8 @@
   macros).
 
   Despite their differences from interfaces, Protocols do also generate a standard
-  Python interface type (deriving from ``abc.ABC``) which is used for efficient dispatch
-  for implementing types.
+  Python interface type (deriving from :external:py:class:`abc.ABC`) which is used for
+  efficient dispatch for implementing types.
 
   Method signatures are in the form::
 

--- a/src/basilisp/json.lpy
+++ b/src/basilisp/json.lpy
@@ -111,15 +111,17 @@
   serialized as JSON arrays. Keywords and symbols are serialized as strings with
   their namespace (if they have one). Python scalar types are serialized as their
   corresponding JSON types (string, integer, float, boolean, and ``nil``). Instants
-  (Python ``datetime`` s) and the related Python ``date`` and ``time`` types are
-  serialized as ISO 8601 date strings. Decimals are serialized as stringified
-  floats. Fractions are serialized as stringified ratios (numerator and
-  denominator). UUIDs are serialized as their canonical hex string format.
+  (Python :external:py:class:`datetime.datetime` ) and the related Python
+  :external:py:class:`datetime.date` and :external:py:class:`datetime.time` types are
+  serialized as ISO 8601 date strings. Decimals are serialized as stringified floats.
+  :external:py:class:`fractions.Fraction` s are serialized as stringified ratios
+  (numerator and denominator). :external:py:class:`uuid.UUID` s are serialized as
+  their canonical hex string format.
 
   Support for other data structures can be added by extending the
   :lpy:proto:`JSONEncodeable` Protocol. That protocol includes one method which must
-  return a Python data type which can be understood by Python's builtin ``json``
-  module.
+  return a Python data type which can be understood by Python's builtin
+  :external:py:mod:`json` module.
 
   The encoder supports a few options which may be specified as key/value pairs:
 
@@ -151,15 +153,17 @@
   serialized as JSON arrays. Keywords and symbols are serialized as strings with
   their namespace (if they have one). Python scalar types are serialized as their
   corresponding JSON types (string, integer, float, boolean, and ``nil``). Instants
-  (Python ``datetime`` s) and the related Python ``date`` and ``time`` types are
-  serialized as ISO 8601 date strings. Decimals are serialized as stringified
-  floats. Fractions are serialized as stringified ratios (numerator and
-  denominator). UUIDs are serialized as their canonical hex string format.
+  (Python :external:py:class:`datetime.datetime` ) and the related Python
+  :external:py:class:`datetime.date` and :external:py:class:`datetime.time` types
+  are serialized as ISO 8601 date strings. :external:py:class:`decimal.Decimal` s
+  are serialized as stringified floats. :external:py:class:`fractions.Fraction` s
+  are serialized as stringified ratios (numerator and denominator).
+  :external:py:class:`uuid.UUID` s are serialized as their canonical hex string format.
 
   Support for other data structures can be added by extending the
   :lpy:proto:`JSONEncodeable` Protocol. That protocol includes one method which must
-  return a Python data type which can be understood by Python's builtin ``json``
-  module.
+  return a Python data type which can be understood by Python's builtin
+  :external:py:mod:`json` module.
 
   The options for ``write-str`` are the same as for those of :lpy:fn:`write`."
   [o & {:as opts}]


### PR DESCRIPTION
 * Added [`sphinx-autobuild`](https://github.com/sphinx-doc/sphinx-autobuild) to improve documentation development flow
 * Added [`sphinx-copybutton`](https://github.com/executablebooks/sphinx-copybutton) and [`sphinxext-opengraph`](https://github.com/wpilibsuite/sphinxext-opengraph) extension to the Read the Docs build
 * Updating tons of references across the entire codebase to the official Python documentation using [`intersphinx`](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) (added in #909)