### PR TITLE
Coerce booleans using Basilisp's rules, not Python's rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where the core functions `symbol` and `keyword` would not accept non-string data types (#911)
  * Fix a bug where the compiler would emit warnings on when a Var was redef'ed even if that Var was initially defined with `^:redef` metadata (#916)
  * Fix a bug where reader column offset numbering began at 1, rather than 0 (#905)
+ * Fix a bug where `basilisp.core/boolean` was returning the boolean coercions like Python rather than like Basilisp (#928)
 
 ### Other
  * Add several sections to Concepts documentation module (#666)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -478,7 +478,7 @@
     (recur (rest s))
     (first s)))
 
-(defn  ^:inline nil?
+(defn ^:inline nil?
   "Return ``true`` if ``x`` is ``nil``\\, otherwise ``false``\\."
   [x]
   (operator/is- x nil))
@@ -1578,9 +1578,14 @@
   (python/int x))
 
 (defn ^:inline boolean
-  "Coerce ``x`` to a boolean."
+  "Coerce ``x`` to a boolean.
+
+  Only ``false`` and ``nil`` are logical false and will return ``false``\\. All
+  other values will return ``true``\\."
   [x]
-  (python/bool x))
+  (if (or (nil? x) (false? x))
+    false
+    true))
 
 (defn byte
   "Coerce ``x`` to a byte."
@@ -2088,6 +2093,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn bounded-count
+  "Return the count (as by :lpy:fn:`count`) of any ``coll`` for which ``counted?``
+  returns ``true``, otherwise return the lesser of ``n`` and the length of
+  ``coll``\\."
   [n coll]
   (if (counted? coll)
     (count coll)

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -126,6 +126,36 @@
           (is (= v1 v2))
           (is (= {:tag vector} (meta v2))))))))
 
+(deftest boolean-test
+  (testing "logical false values"
+    (are [v] (false? (boolean v))
+      false
+      nil))
+
+  (testing "logical true values"
+    (are [v] (true? (boolean v))
+      true
+      1
+      0
+      -1
+      1.0
+      0.0
+      -1.0
+      ""
+      "false"
+      []
+      [false]
+      #{}
+      #{false}
+      {}
+      {false false}
+      '()
+      '(false false)
+      :kw
+      :ns/kw
+      'sym
+      'ns/sym)))
+
 (deftest compare-test
   (testing "nil"
     (are [res x y] (= res (compare x y))


### PR DESCRIPTION
Fixes #928 