### PR TITLE
Fix thread-safety for sequences wrapping Python Iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `basilisp.core/boolean` was returning the boolean coercions like Python rather than like Basilisp (#928)
  * Fix a bug where Basilisp vectors were not callable (#932)
  * Fix a bug where `basilisp.lang.seq.LazySeq` instances were not thread-safe (#934)
- * Fix a bug where `basilisp.lang.seq._Sequence` instances were not thread-safe (#936)
+ * Fix a bug where Seqs wrapping Python Iterable instances were not thread-safe (#936)
 
 ### Other
  * Add several sections to Concepts documentation module (#666)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `basilisp.core/boolean` was returning the boolean coercions like Python rather than like Basilisp (#928)
  * Fix a bug where Basilisp vectors were not callable (#932)
  * Fix a bug where `basilisp.lang.seq.LazySeq` instances were not thread-safe (#934)
+ * Fix a bug where `basilisp.lang.seq._Sequence` instances were not thread-safe (#936)
 
 ### Other
  * Add several sections to Concepts documentation module (#666)

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -134,8 +134,12 @@ def test_rest():
     assert lseq.EMPTY is runtime.rest(llist.l())
     assert lseq.EMPTY is runtime.rest(llist.l(1))
     assert llist.l(2, 3) == runtime.rest(llist.l(1, 2, 3))
-    assert lseq.EMPTY is runtime.rest(vec.v(1).seq())
-    assert lseq.EMPTY is runtime.rest(vec.v(1))
+    v1 = runtime.rest(vec.v(1).seq())
+    assert lseq.EMPTY == v1
+    assert v1.is_empty
+    v2 = runtime.rest(vec.v(1))
+    assert lseq.EMPTY == v2
+    assert v2.is_empty
     assert llist.l(2, 3) == runtime.rest(vec.v(1, 2, 3))
 
 
@@ -236,7 +240,8 @@ def test_to_seq():
 
 def test_concat():
     s1 = runtime.concat()
-    assert lseq.EMPTY is s1
+    assert lseq.EMPTY == s1
+    assert s1.is_empty
 
     s1 = runtime.concat(llist.PersistentList.empty(), llist.PersistentList.empty())
     assert lseq.EMPTY == s1

--- a/tests/basilisp/seq_test.py
+++ b/tests/basilisp/seq_test.py
@@ -6,7 +6,7 @@ from basilisp.lang import vector as vec
 
 
 def test_to_sequence():
-    assert lseq.EMPTY is lseq.sequence([])
+    assert lseq.EMPTY == lseq.sequence([])
     assert lseq.sequence([]).is_empty
     assert llist.l(None) == lseq.sequence([None])
     assert not lseq.sequence([None]).is_empty
@@ -34,7 +34,8 @@ def test_lazy_sequence():
     s = lseq.LazySeq(lambda: lseq.sequence([1]))
     assert not s.is_empty
     assert 1 == s.first
-    assert lseq.EMPTY is s.rest
+    assert lseq.EMPTY == s.rest
+    assert s.rest.is_empty
     assert s.is_realized
     assert not s.is_empty, "LazySeq has been realized and is not empty"
 
@@ -64,7 +65,8 @@ def test_lazy_sequence():
     t = r.rest
     assert not t.is_empty
     assert 3 == t.first
-    assert lseq.EMPTY is t.rest
+    assert lseq.EMPTY == t.rest
+    assert t.rest.is_empty
     assert t.is_realized
     assert not t.is_empty, "LazySeq has been realized and is not empty"
 
@@ -77,7 +79,8 @@ def test_empty_sequence():
     assert None is empty.first
     assert empty.rest == empty
     assert llist.l(1) == empty.cons(1)
-    assert lseq.EMPTY is empty
+    assert lseq.EMPTY == empty
+    assert empty.is_empty
     assert True is bool(lseq.sequence([]))
 
 
@@ -85,7 +88,8 @@ def test_sequence():
     s = lseq.sequence([1])
     assert not s.is_empty
     assert 1 == s.first
-    assert lseq.EMPTY is s.rest
+    assert lseq.EMPTY == s.rest
+    assert s.rest.is_empty
     assert llist.l(2, 1) == s.cons(2)
     assert [1, 2, 3] == [e for e in lseq.sequence([1, 2, 3])]
     assert llist.l(1, 2, 3) == lseq.sequence([1, 2, 3])


### PR DESCRIPTION
Fixes #936 
Another fix related to #934 