### PR TITLE
Allow artificial abstractness to take precedence over true abstractness for `deftype*` and `reify*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  * Improved on the nREPL server exception messages by matching that of the REPL user friendly format (#968)
+ * Types created via `deftype` and `reify` may declare supertypes as abstract (taking precedence over true `abc.ABC` types) and specify their member list using `^:abstract-members` metadata (#942)
 
 ### Removed
  * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976) 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1243,6 +1243,7 @@ Types may also optionally implement 0 or more Python `"dunder" methods <https://
    The best approximation is :external:py:class:`abc.ABC`, although this type is merely advisory and many libraries and applications eschew its use.
 
    For the cases where a host type is not defined as an ``abc.ABC`` instance, users can override the compiler check by setting the ``^:abstract`` meta key on the interface type symbol passed to the ``deftype`` form.
+   This is called "artificial abstractness" and it takes precedence over true abstract base classes via ``abc.ABC``.
    For example, take :external:py:class:`argparse.Action` which is required to be implemented for customizing :external:py:mod:`argparse` actions, but which is not defined as an ``abc.ABC``:
 
    .. code-block::
@@ -1252,6 +1253,23 @@ Types may also optionally implement 0 or more Python `"dunder" methods <https://
       (reify
         ^:abstract argparse/Action
         (__call__ [this parser namespace values option-string]
+          ;; ...
+          ))
+
+   Python libraries may also include implicit (documentation-only) abstract methods on their ``abc.ABC`` types.
+   Thus, it is sometimes necessary to annotate a base class using ``^{:abstract-members #{...}}`` to designate any methods which should be considered abstract in the base class since the compiler cannot check them for you.
+   Take for example :external:py:class:`io.IOBase` which does not declare ``read`` or ``write`` (or in fact *any* members at all in its ``__abstractmethods__`` set!) as part of the interface, but the documentation specifies that they should be considered part of the interface.
+   Below, we tell the compiler it is artificially abstract and that ``read`` is a member.
+
+   .. code-block::
+
+      (import io)
+
+      (reify
+        ^:abstract
+        ^{:abstract-members #{:read}}
+        io/TextIOBase
+        (read [n]
           ;; ...
           ))
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1743,7 +1743,7 @@ class _TypeAbstractness:
     supertype_already_weakref: bool
 
 
-def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-locals
+def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-locals,too-many-statements
     ctx: AnalyzerContext,
     special_form: sym.Symbol,
     fields: Iterable[str],

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1699,9 +1699,12 @@ def __get_artificially_abstract_members(
     ) is None:
         return set()
 
-    if not isinstance(declared_abstract_members, lset.PersistentSet):
+    if (
+        not isinstance(declared_abstract_members, lset.PersistentSet)
+        or len(declared_abstract_members) == 0
+    ):
         raise ctx.AnalyzerException(
-            f"{special_form} artificially abstract members",
+            f"{special_form} artificially abstract members must be a set of keywords",
             form=interface.form,
         )
 
@@ -1881,7 +1884,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
     if unverifiably_abstract:
         logger.warning(
             f"Unable to verify abstractness for {special_form} supertype(s): "
-            f"{', '.join(unverifiably_abstract)}"
+            f"{', '.join(str(e.var) for e in unverifiably_abstract)}"
         )
     else:
         extra_methods = member_names - all_interface_methods - OBJECT_DUNDER_METHODS

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -1878,7 +1878,12 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
 
     # We cannot compute if there are extra methods defined if there are any
     # unverifiably abstract bases, so we just skip this check.
-    if not unverifiably_abstract:
+    if unverifiably_abstract:
+        logger.warning(
+            f"Unable to verify abstractness for {special_form} supertype(s): "
+            f"{', '.join(unverifiably_abstract)}"
+        )
+    else:
         extra_methods = member_names - all_interface_methods - OBJECT_DUNDER_METHODS
         if extra_methods and not extra_methods.issubset(
             artificially_abstract_base_members

--- a/src/basilisp/lang/compiler/constants.py
+++ b/src/basilisp/lang/compiler/constants.py
@@ -33,6 +33,7 @@ AMPERSAND = sym.symbol("&")
 DEFAULT_COMPILER_FILE_PATH = "NO_SOURCE_PATH"
 
 SYM_ABSTRACT_META_KEY = kw.keyword("abstract")
+SYM_ABSTRACT_MEMBERS_META_KEY = kw.keyword("abstract-members")
 SYM_ASYNC_META_KEY = kw.keyword("async")
 SYM_KWARGS_META_KEY = kw.keyword("kwargs")
 SYM_PRIVATE_META_KEY = kw.keyword("private")

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -433,6 +433,7 @@ def _class_ast(  # pylint: disable=too-many-arguments
     artificially_abstract_bases: Iterable[ast.expr] = (),
     is_frozen: bool = True,
     use_slots: bool = True,
+    use_weakref_slot: bool = True,
 ) -> ast.ClassDef:
     """Return a Python class definition for `deftype` and `reify` special forms."""
     return ast_ClassDef(
@@ -489,6 +490,15 @@ def _class_ast(  # pylint: disable=too-many-arguments
                         keywords=[
                             ast.keyword(arg="eq", value=ast.Constant(False)),
                             ast.keyword(arg="slots", value=ast.Constant(use_slots)),
+                            *(
+                                []
+                                if use_weakref_slot
+                                else [
+                                    ast.keyword(
+                                        arg="weakref_slot", value=ast.Constant(False)
+                                    )
+                                ]
+                            ),
                         ],
                     ),
                 ],
@@ -1489,6 +1499,7 @@ def _deftype_to_py_ast(  # pylint: disable=too-many-locals
                             artificially_abstract_bases=artificially_abstract_bases,
                             is_frozen=node.is_frozen,
                             use_slots=True,
+                            use_weakref_slot=node.use_weakref_slot,
                         ),
                         ast.Call(
                             func=_INTERN_VAR_FN_NAME,
@@ -2708,6 +2719,7 @@ def _reify_to_py_ast(
                             artificially_abstract_bases=artificially_abstract_bases,
                             is_frozen=True,
                             use_slots=True,
+                            use_weakref_slot=node.use_weakref_slot,
                         )
                     ],
                 )

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -428,6 +428,7 @@ class DefType(Node[SpecialForm]):
     verified_abstract: bool = False
     artificially_abstract: IPersistentSet[DefTypeBase] = lset.PersistentSet.empty()
     is_frozen: bool = True
+    use_weakref_slot: bool = True
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(FIELDS, MEMBERS)
     op: NodeOp = NodeOp.DEFTYPE
@@ -823,6 +824,7 @@ class Reify(Node[SpecialForm]):
     env: NodeEnv
     verified_abstract: bool = False
     artificially_abstract: IPersistentSet[DefTypeBase] = lset.PersistentSet.empty()
+    use_weakref_slot: bool = True
     meta: NodeMeta = None
     children: Sequence[kw.Keyword] = vec.v(MEMBERS)
     op: NodeOp = NodeOp.REIFY

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -4627,11 +4627,114 @@ class TestReify:
                 ),
             ],
         )
-        def test_reify_disallows_extra_methods_if_not_in_aa_super_type(
+        def test_reify_disallows_extra_methods_if_not_in_a_super_type(
             self, lcompile: CompileFn, code: str, ExceptionType
         ):
             with pytest.raises(ExceptionType):
                 lcompile(code)
+
+        @pytest.mark.parametrize(
+            "code,ExceptionType",
+            [
+                (
+                    """
+                    (import* io)
+                    (reify* :implements [^:abstract ^{:abstract-members '(:read)} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (import* io)
+                    (reify* :implements [^:abstract ^{:abstract-members [:read]} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (import* io)
+                    (reify* :implements [^:abstract ^{:abstract-members #py [:read]} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+            ],
+        )
+        def test_reify_abstract_members_must_be_a_set(
+            self, lcompile: CompileFn, code: str, ExceptionType
+        ):
+            with pytest.raises(ExceptionType):
+                lcompile(code)
+
+        def test_reify_abstract_members_must_have_elements(self, lcompile: CompileFn):
+            with pytest.raises(compiler.CompilerException):
+                lcompile(
+                    """
+                    (import* io)
+                    (reify* :implements [^:abstract ^{:abstract-members #{}} io/IOBase]
+                      (read [this v]))
+                    """
+                )
+
+        def test_reify_abstract_should_not_have_namespaces(
+            self, lcompile: CompileFn, assert_matching_logs
+        ):
+            lcompile(
+                """
+                (import* io)
+                (reify* :implements [^:abstract ^{:abstract-members #{:io/read}} io/IOBase]
+                  (read [this v]))
+                """
+            )
+            assert_matching_logs(
+                "basilisp.lang.compiler.analyzer",
+                logging.WARNING,
+                "Unexpected namespace for artificially abstract member to reify*",
+            )
+
+        def test_reify_abstract_members_names_must_be_str_keyword_or_symbol(
+            self,
+            lcompile: CompileFn,
+        ):
+            with pytest.raises(compiler.CompilerException):
+                lcompile(
+                    """
+                    (import* io)
+                    (reify* :implements [^:abstract ^{:abstract-members #{1 :read}} io/IOBase]
+                      (read [this v]))
+                    """,
+                )
+
+        @pytest.mark.parametrize(
+            "code",
+            [
+                """
+                (import* io)
+                (reify* :implements [^:abstract ^{:abstract-members #{:read :write}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+                """
+                (import* io)
+                (reify* :implements [^:abstract ^{:abstract-members #{read write}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+                """
+                (import* io)
+                (reify* :implements [^:abstract ^{:abstract-members #{"read" "write"}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+            ],
+        )
+        def test_reify_abstract_members_must_be_a_set(
+            self,
+            lcompile: CompileFn,
+            code: str,
+        ):
+            instance = lcompile(code)
+            assert instance.read is not None
+            assert instance.write is not None
 
     class TestReifyMember:
         @pytest.mark.parametrize(

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1115,6 +1115,118 @@ class TestDefType:
             with pytest.raises(ExceptionType):
                 lcompile(code)
 
+        @pytest.mark.parametrize(
+            "code,ExceptionType",
+            [
+                (
+                    """
+                    (import* io)
+                    (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members '(:read)} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (import* io)
+                    (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members [:read]} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+                (
+                    """
+                    (import* io)
+                    (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members #py [:read]} io/IOBase]
+                      (read [this v]))""",
+                    compiler.CompilerException,
+                ),
+            ],
+        )
+        def test_deftype_abstract_members_must_be_a_set(
+            self, lcompile: CompileFn, code: str, ExceptionType
+        ):
+            with pytest.raises(ExceptionType):
+                lcompile(code)
+
+        def test_deftype_abstract_members_must_have_elements(self, lcompile: CompileFn):
+            with pytest.raises(compiler.CompilerException):
+                lcompile(
+                    """
+                    (import* io)
+                    (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members #{}} io/IOBase]
+                      (read [this v]))
+                    """
+                )
+
+        def test_deftype_abstract_should_not_have_namespaces(
+            self, lcompile: CompileFn, assert_matching_logs
+        ):
+            lcompile(
+                """
+                (import* io)
+                (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members #{:io/read}} io/IOBase]
+                  (read [this v]))
+                """
+            )
+            assert_matching_logs(
+                "basilisp.lang.compiler.analyzer",
+                logging.WARNING,
+                "Unexpected namespace for artificially abstract member to deftype*",
+            )
+
+        def test_deftype_abstract_members_names_must_be_str_keyword_or_symbol(
+            self,
+            lcompile: CompileFn,
+        ):
+            with pytest.raises(compiler.CompilerException):
+                lcompile(
+                    """
+                    (import* io)
+                    (deftype* SomeReader []
+                      :implements [^:abstract ^{:abstract-members #{1 :read}} io/IOBase]
+                      (read [this v]))
+                    """,
+                )
+
+        @pytest.mark.parametrize(
+            "code",
+            [
+                """
+                (import* io)
+                (deftype* SomeReader []
+                  :implements [^:abstract ^{:abstract-members #{:read :write}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+                """
+                (import* io)
+                (deftype* SomeReader []
+                  :implements [^:abstract ^{:abstract-members #{read write}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+                """
+                (import* io)
+                (deftype* SomeReader []
+                  :implements [^:abstract ^{:abstract-members #{"read" "write"}} io/IOBase]
+                  (read [this n])
+                  (write [this v]))
+                """,
+            ],
+        )
+        def test_deftype_artificially_abstract_members(
+            self,
+            lcompile: CompileFn,
+            code: str,
+        ):
+            instance = lcompile(code)
+            assert instance.read is not None
+            assert instance.write is not None
+
     class TestDefTypeFields:
         def test_deftype_fields(self, lcompile: CompileFn):
             Point = lcompile("(deftype* Point [x y z])")
@@ -4727,7 +4839,7 @@ class TestReify:
                 """,
             ],
         )
-        def test_reify_abstract_members_must_be_a_set(
+        def test_reify_artificially_abstract_members(
             self,
             lcompile: CompileFn,
             code: str,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ allowlist_externals = poetry
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
 setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true
-    COVERAGE_CORE=sysmon
 deps =
     coverage[toml]
     pytest >=7.0.0,<9.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ allowlist_externals = poetry
 parallel_show_output = {env:TOX_SHOW_OUTPUT:true}
 setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true
+    COVERAGE_CORE=sysmon
 deps =
     coverage[toml]
     pytest >=7.0.0,<9.0.0


### PR DESCRIPTION
Fixes #942 