### PR TITLE
Make lazy sequences collections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added `:end-line` and `:end-col` metadata to forms during compilation (#903)
  * Added `basilisp.repl/source` to allow inspecting source code from the REPL (#205)
+ * Added `conj` 1 and 0 arities (#954)
 
 ### Changed
  * Updated dozens of type annotations in the compiler to satisfy MyPy 1.11 (#910)
  * Update the `StreamReader` methods to stop using the term "token" to refer to individual UTF-8 characters (#915)
  * Update the list of Python dunder methods which are allowed to be implemented for all `deftype*` and `reify*` types (#943)
+ * ISeq now inherits from IPersistentCollection so `coll?`, `empty`, and `conj` can now be used with sequences (#954)
 
 ### Fixed
  * Fix a bug where `.` characters were not allowed in keyword names (#899)
@@ -61,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `basilisp.lang.compiler.exception.CompilerException` would nearly always suppress line information in it's `data` map (#845)
  * Fix a bug where the function returned by `partial` retained the meta, arities, and `with_meta` method of the wrapped function rather than creating new ones (#847)
  * Fix a bug where exceptions arising while reading reader conditional forms did not include line and column information (#854)
- * Fix a bug where names `def`'ed without reader metadata would cause the compiler to throw an exception (#850) 
+ * Fix a bug where names `def`'ed without reader metadata would cause the compiler to throw an exception (#850)
  * Fix an issue where `concat` on maps was iterating over the keys instead of the key/value pairs (#871)
  * Fix a bug where the compiler would throw an exception partially macroexpanding forms with `recur` forms provided as arguments (#856)
  * Fix a bug where the original `(var ...)` form is not retained during analysis, causing it to be lost in calls to `macroexpand` (#888)
@@ -103,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix issue with keywords not testing for membership in sets when used as a function (#762)
  * Fix an issue for executing Basilisp scripts via a shebang where certain platforms may not support more than one argument in the shebang line (#764)
  * Fix issue with keywords throwing `TypeError` when used as a function on vectors (#770)
- * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777) 
+ * Fix an issue where the constructors of types created by `deftype` and `defrecord` could not be called if they contained `-` characters (#777)
  * Fix issue with the variadic ampersand operator treated as a binding in macros (#772)
  * Fix a bug the variadic arg symbol was not correctly bound to `nil` when no variadic arguments were provided (#801)
  * Fix a bug where the quotient of very large numbers was incorrect (#822)
@@ -473,7 +475,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed a bug where comment literals were not be fully removed from reader outputs (#196)
  * Fixed a bug where comment literals caused syntax errors inside collection literals (#196)
  * Imported namespaces no longer create extra namespaces bound to munged Python module names (#216)
- * Fixed a bug where `import*`s would not work within other forms 
+ * Fixed a bug where `import*`s would not work within other forms
  * Fixed a bug where the Basilisp import hook could be added to `sys.meta_path` multiple times (#213)
  * Fixed a bug where keywords could not be used in function position (#174)
  * Fixed a bug where macro symbols were not resolved using the same heuristics as other symbols (#183)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -299,9 +299,11 @@
                different positions depending on the type of ``coll``\\. ``conj`` returns
                the same type as ``coll``\\. If ``coll`` is ``nil``\\, return a list with
                ``xs`` conjoined."
-    :arglists '([coll x] [coll x & xs])}
+    :arglists '([] [coll] [coll x] [coll x & xs])}
   conj
   (fn conj
+    ([] [])
+    ([coll] coll)
     ([coll x]
      (basilisp.lang.runtime/conj coll x))
     ([coll x & xs]

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -614,7 +614,7 @@ def seq_equals(s1: Union["ISeq", ISequential], s2: Any) -> bool:
     return True
 
 
-class ISeq(ILispObject, ISeqable[T]):
+class ISeq(ILispObject, IPersistentCollection[T]):
     """``ISeq`` types represent a potentially infinite sequence of elements.
 
     .. seealso::
@@ -667,7 +667,7 @@ class ISeq(ILispObject, ISeqable[T]):
         raise NotImplementedError()
 
     @abstractmethod
-    def cons(self, elem: T) -> "ISeq[T]":
+    def cons(self, *elem: T) -> "ISeq[T]":
         raise NotImplementedError()
 
     def seq(self) -> "Optional[ISeq[T]]":

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -3,7 +3,6 @@ import threading
 from typing import Callable, Iterable, Optional, TypeVar, overload
 
 from basilisp.lang.interfaces import (
-    IPersistentCollection,
     IPersistentMap,
     ISeq,
     ISeqable,
@@ -14,7 +13,7 @@ from basilisp.util import Maybe
 
 T = TypeVar("T")
 
-class _EmptySequence(IWithMeta, ISequential, ISeq[T], IPersistentCollection):
+class _EmptySequence(IWithMeta, ISequential, ISeq[T]):
     __slots__ = ("_meta",)
 
     def __init__(self, meta: Optional[IPersistentMap] = None):
@@ -48,8 +47,8 @@ class _EmptySequence(IWithMeta, ISequential, ISeq[T], IPersistentCollection):
     def rest(self) -> ISeq[T]:
         return self
 
-    def cons(self, *elems: T) -> ISeq[T]:
-        l = self
+    def cons(self, *elems: T) -> ISeq[T]: # type: ignore[override]
+        l: ISeq = self
         for elem in elems:
             l = Cons(elem, l)
         return l
@@ -61,7 +60,7 @@ class _EmptySequence(IWithMeta, ISequential, ISeq[T], IPersistentCollection):
 EMPTY: ISeq = _EmptySequence()
 
 
-class Cons(ISeq[T], ISequential, IWithMeta, IPersistentCollection):
+class Cons(ISeq[T], ISequential, IWithMeta):
     __slots__ = ("_first", "_rest", "_meta")
 
     def __init__(
@@ -107,7 +106,7 @@ class Cons(ISeq[T], ISequential, IWithMeta, IPersistentCollection):
 LazySeqGenerator = Callable[[], Optional[ISeq[T]]]
 
 
-class LazySeq(IWithMeta, ISequential, ISeq[T], IPersistentCollection):
+class LazySeq(IWithMeta, ISequential, ISeq[T]):
     """LazySeqs are wrappers for delaying sequence computation. Create a LazySeq
     with a function that can either return None or a Seq. If a Seq is returned,
     the LazySeq is a proxy to that Seq.
@@ -205,8 +204,8 @@ class LazySeq(IWithMeta, ISequential, ISeq[T], IPersistentCollection):
         except AttributeError:
             return EMPTY
 
-    def cons(self, *elems: T) -> ISeq[T]:
-        l = self
+    def cons(self, *elems: T) -> ISeq[T]: # type: ignore[override]
+        l: ISeq = self
         for elem in elems:
             l = Cons(elem, l)
         return l

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -13,6 +13,7 @@ from basilisp.util import Maybe
 
 T = TypeVar("T")
 
+
 class _EmptySequence(IWithMeta, ISequential, ISeq[T]):
     __slots__ = ("_meta",)
 
@@ -47,7 +48,7 @@ class _EmptySequence(IWithMeta, ISequential, ISeq[T]):
     def rest(self) -> ISeq[T]:
         return self
 
-    def cons(self, *elems: T) -> ISeq[T]: # type: ignore[override]
+    def cons(self, *elems: T) -> ISeq[T]:  # type: ignore[override]
         l: ISeq = self
         for elem in elems:
             l = Cons(elem, l)
@@ -56,6 +57,7 @@ class _EmptySequence(IWithMeta, ISequential, ISeq[T]):
     @staticmethod
     def empty():
         return EMPTY
+
 
 EMPTY: ISeq = _EmptySequence()
 
@@ -204,7 +206,7 @@ class LazySeq(IWithMeta, ISequential, ISeq[T]):
         except AttributeError:
             return EMPTY
 
-    def cons(self, *elems: T) -> ISeq[T]: # type: ignore[override]
+    def cons(self, *elems: T) -> ISeq[T]:  # type: ignore[override]
         l: ISeq = self
         for elem in elems:
             l = Cons(elem, l)

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -663,6 +663,7 @@
       (cons nil (lazy-seq))
       (cons nil (empty (lazy-seq)))
       (empty (cons nil (lazy-seq)))))
+
   (testing "conj"
     (are [expected form] (= expected form)
       '()          (lazy-seq)
@@ -671,6 +672,7 @@
       '(0 1 2)     (conj (conj (lazy-seq '(2)) 1) 0)
       '(1 2 3)     (conj (lazy-seq) 3 2 1)
       '(0 1 2 3 4) (conj (lazy-seq '(1 2 3 4)) 0)))
+
   (testing "corecursion"
     ;; here we're just generally checking that we don't blow the stack, so
     ;; 50 is an arbitrarily chosen limit which hopefully tests that adequately

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -656,6 +656,21 @@
    (iterate inc 2)))
 
 (deftest lazy-seq-test
+  (testing "is collection"
+    (are [x] (coll? x)
+      (lazy-seq)
+      (empty (lazy-seq))
+      (cons nil (lazy-seq))
+      (cons nil (empty (lazy-seq)))
+      (empty (cons nil (lazy-seq)))))
+  (testing "conj"
+    (are [expected form] (= expected form)
+      '()          (lazy-seq)
+      '()          (conj (lazy-seq))
+      '(0 1 2)     (conj (lazy-seq '(2)) 1 0)
+      '(0 1 2)     (conj (conj (lazy-seq '(2)) 1) 0)
+      '(1 2 3)     (conj (lazy-seq) 3 2 1)
+      '(0 1 2 3 4) (conj (lazy-seq '(1 2 3 4)) 0)))
   (testing "corecursion"
     ;; here we're just generally checking that we don't blow the stack, so
     ;; 50 is an arbitrarily chosen limit which hopefully tests that adequately


### PR DESCRIPTION
-  `ISeq` now inherits from `IPersistentCollection` so that `coll?`, `empty`, and `conj` now work for sequences.

- Added trivial arities for `conj` as in Clojure

These changes match the behaviour of Clojure types and functions