### PR TITLE
Separate Basilisp namespaces from python module hierarchy (#957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added several missing functions to `basilisp.core` (#956)
 
+### Changed
+ * Separate basilisp namespaces from python module hierarchy (#957)
+
 ## [v0.1.0]
 ### Added
  * Added `:end-line` and `:end-col` metadata to forms during compilation (#903)

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -145,10 +145,10 @@ Specifically, any file with a ``.pth`` extension located in any of the known ``s
    $ python
    Python 3.12.1 (main, Jan  3 2024, 10:01:43) [GCC 11.4.0] on linux
    Type "help", "copyright", "credits" or "license" for more information.
-   >>> import importlib; importlib.import_module("basilisp.core")
-   <module 'basilisp.core' (/home/chris/Projects/basilisp/src/basilisp/core.lpy)>
+   >>> import importlib; importlib.import_module("basilisp.core.basilisp_namespace")
+   <module 'basilisp.core.basilisp_namespace' (/home/chris/Projects/basilisp/src/basilisp/core.lpy)>
 
-This method also enables you to directly execute Basilisp scripts as Python modules using ``python -m {namespace}``.
+This method also enables you to directly execute Basilisp scripts as Python modules using ``python -m {namespace}.basilisp_namespace``.
 Basilisp namespaces run as a Python module directly via ``python -m`` are resolved within the context of the current ``sys.path`` of the active Python interpreter.
 
 .. code-block:: bash

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -18,7 +18,6 @@ from basilisp.lang import runtime as runtime
 from basilisp.lang import symbol as sym
 from basilisp.lang import vector as vec
 from basilisp.lang.exception import print_exception
-from basilisp.lang.util import munge
 from basilisp.prompt import get_prompter
 
 CLI_INPUT_FILE_PATH = "<CLI Input>"
@@ -82,7 +81,7 @@ def bootstrap_repl(ctx: compiler.CompilerContext, which_ns: str) -> types.Module
         ctx,
         ns,
     )
-    return importlib.import_module(REPL_NS)
+    return runtime.import_namespace(REPL_NS)
 
 
 def _to_bool(v: Optional[str]) -> Optional[bool]:
@@ -357,7 +356,7 @@ def nrepl_server(
 ) -> None:
     opts = compiler.compiler_opts()
     basilisp.init(opts)
-    nrepl_server_mod = importlib.import_module(munge(NREPL_SERVER_NS))
+    nrepl_server_mod = runtime.import_namespace(NREPL_SERVER_NS)
     nrepl_server_mod.start_server__BANG__(
         lmap.map(
             {

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -1,4 +1,3 @@
-import importlib.util
 import inspect
 import os
 import traceback
@@ -219,7 +218,7 @@ class BasilispFile(pytest.File):
 
     def _import_module(self) -> runtime.BasilispModule:
         modname = _get_fully_qualified_module_name(self.path)
-        module = importlib.import_module(modname)
+        module = runtime.import_namespace(modname)
         assert isinstance(module, runtime.BasilispModule)
         return module
 

--- a/src/basilisp/main.py
+++ b/src/basilisp/main.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import site
 from pathlib import Path
@@ -17,32 +16,36 @@ logger.addHandler(DEFAULT_HANDLER)
 
 
 def init(opts: Optional[CompilerOpts] = None) -> None:
-    """
-    Initialize the runtime environment for Basilisp code evaluation.
+    """Initialize the runtime environment for Basilisp code evaluation.
 
-    Basilisp only needs to be initialized once per Python VM invocation. Subsequent
-    imports of Basilisp namespaces will work using Python's standard ``import``
-    statement and :external:py:func:`importlib.import_module` function.
+    Basilisp only needs to be initialized once per Python VM
+    invocation. Subsequent imports of Basilisp namespaces will work using
+    Python's standard ``import`` statement and
+    :external:py:func:`importlib.import_module` function. (with appropriate
+    namespace module suffix)
 
     If you want to execute a Basilisp file which is stored in a well-formed package
     or module structure, you probably want to use :py:func:`bootstrap`.
+
     """
     runtime.init_ns_var()
     runtime.bootstrap_core(opts if opts is not None else compiler_opts())
     importer.hook_imports()
-    importlib.import_module("basilisp.core")
+    runtime.import_namespace("basilisp.core")
 
 
 def bootstrap(
     target: str, opts: Optional[CompilerOpts] = None
 ) -> None:  # pragma: no cover
-    """
-    Import a Basilisp namespace or function identified by ``target``. If a function
+    """Import a Basilisp namespace or function identified by ``target``. If a function
     reference is given, the function will be called with no arguments.
 
-    Basilisp only needs to be initialized once per Python VM invocation. Subsequent
-    imports of Basilisp namespaces will work using Python's standard ``import``
-    statement and :external:py:func:`importlib.import_module` function.
+    Basilisp only needs to be initialized once per Python VM
+    invocation. Subsequent imports of Basilisp namespaces will work using
+    Python's standard ``import`` statement and
+    :external:py:func:`importlib.import_module` function. (with appropriate
+    namespace module suffix)
+
 
     ``target`` must be a string naming a Basilisp namespace. Namespace references may
     be given exactly as they are found in Basilisp code. ``target`` may optionally
@@ -51,10 +54,11 @@ def bootstrap(
 
     ``opts`` is a mapping of compiler options that may be supplied for bootstrapping.
     This setting should be left alone unless you know what you are doing.
+
     """
     init(opts=opts)
     pkg_name, *rest = target.split(":", maxsplit=1)
-    mod = importlib.import_module(munge(pkg_name))
+    mod = runtime.import_namespace(pkg_name)
     if rest:
         fn_name = munge(rest[0])
         getattr(mod, fn_name)()

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1363,7 +1363,7 @@ class TestDefType:
                 (cls x y z))
               (__eq__ [this other]
                 (operator/eq
-                 [x y z] 
+                 [x y z]
                  [(.-x other) (.-y other) (.-z other)])))"""
             )
             assert Point(1, 2, 3) == Point.create(1, 2, 3)
@@ -5212,7 +5212,7 @@ class TestRequire:
     @pytest.fixture
     def _import_ns(self, ns: runtime.Namespace):
         def _import_ns_module(name: str):
-            ns_module = importlib.import_module(name)
+            ns_module = runtime.import_namespace(name)
             runtime.set_current_ns(ns.name)
             return ns_module
 

--- a/tests/basilisp/core_test.py
+++ b/tests/basilisp/core_test.py
@@ -29,7 +29,7 @@ def setup_module():
     runtime.print_generated_python = orig
 
 
-import basilisp.core as core  # isort:skip
+import basilisp.core.basilisp_namespace as core  # isort:skip
 
 TRUTHY_VALUES = [
     True,


### PR DESCRIPTION
- Fixes #957
- Add namespace suffix for Basilisp modules. currently it's `basilisp_namespace ` but it's not set in stone. This allows parent namespaces to require descendant namespaces. 
- Create a separate namespace for `__init__.lpy` files that relates to the true module name.
- Modules named the same as the namespace suffix are disallowed

