### PR TITLE
Fix a bug where Basilisp would error running a namespace from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added several missing functions to `basilisp.core` (#956)
 
+### Fixed
+ * Fixed an issue where attempting to run a namespace from the CLI could fail in certain cases (#957)
+
 ## [v0.1.0]
 ### Added
  * Added `:end-line` and `:end-col` metadata to forms during compilation (#903)
@@ -31,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where Basilisp vectors were not callable (#932)
  * Fix a bug where `basilisp.lang.seq.LazySeq` instances were not thread-safe (#934)
  * Fix a bug where Seqs wrapping Python Iterable instances were not thread-safe (#936)
- * Fix several bugs where code was being executed from a string with interpolated variables, which could've allowed for code (#938)
+ * Fix several bugs where code was being executed from a string with interpolated variables, which could've allowed for code injection (#938)
  * Fix a bug where record types and data readers whose fully qualified name started with a "b" could not be read (#947)
 
 ### Other

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -60,14 +60,6 @@ def eval_file(filename: str, ctx: compiler.CompilerContext, ns: runtime.Namespac
         raise FileNotFoundError(f"Error: The file {filename} does not exist.")
 
 
-def eval_namespace(
-    namespace: str, ctx: compiler.CompilerContext, ns: runtime.Namespace
-):
-    """Evaluate a file with the given name into a Python module AST node."""
-    path = "/" + "/".join(namespace.split("."))
-    return compiler.load(path, ctx, ns)
-
-
 def bootstrap_repl(ctx: compiler.CompilerContext, which_ns: str) -> types.ModuleType:
     """Bootstrap the REPL with a few useful vars and returned the bootstrapped
     module so it's functions can be used by the REPL command."""
@@ -499,7 +491,7 @@ def run(
             parser.error(
                 "argument --in-ns: not allowed with argument -n/--load-namespace"
             )
-        in_ns = target
+        in_ns = runtime.REPL_DEFAULT_NS
     else:
         in_ns = target if args.in_ns is not None else runtime.REPL_DEFAULT_NS
 
@@ -540,7 +532,7 @@ def run(
             assert main_ns_var is not None
             main_ns_var.bind_root(sym.symbol(target))
 
-            eval_namespace(target, ctx, ns)
+            importlib.import_module(munge(target))
         elif target == STDIN_FILE_NAME:
             eval_stream(io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8"), ctx, ns)
         else:

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import platform
 import re
+import secrets
 import stat
 import subprocess
 import tempfile
@@ -286,40 +287,85 @@ class TestRun:
         assert ret == result.lisp_out
 
     @pytest.fixture
-    def namespace_file(self, monkeypatch, tmp_path: pathlib.Path) -> pathlib.Path:
-        parent = tmp_path / "package"
+    def namespace_name(self) -> str:
+        return f"package.core{secrets.token_hex(4)}"
+
+    @pytest.fixture
+    def namespace_file(
+        self, monkeypatch, tmp_path: pathlib.Path, namespace_name: str
+    ) -> pathlib.Path:
+        parent_ns, child_ns = namespace_name.split(".", maxsplit=1)
+        parent = tmp_path / parent_ns
         parent.mkdir()
-        nsfile = parent / "core.lpy"
+        nsfile = parent / f"{child_ns}.lpy"
         nsfile.touch()
         monkeypatch.syspath_prepend(str(tmp_path))
         yield nsfile
 
     def test_cannot_run_namespace_with_in_ns_arg(
-        self, run_cli, namespace_file: pathlib.Path
+        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
     ):
         namespace_file.write_text("(println (+ 1 2))")
         with pytest.raises(SystemExit):
-            run_cli(["run", "--in-ns", "otherpackage.core", "-n", "package.core"])
+            run_cli(["run", "--in-ns", "otherpackage.core", "-n", namespace_name])
 
-    def test_run_namespace(self, run_cli, namespace_file: pathlib.Path):
+    def test_run_namespace(
+        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
+    ):
         namespace_file.write_text("(println (+ 1 2))")
-        result = run_cli(["run", "-n", "package.core"])
+        result = run_cli(["run", "-n", namespace_name])
         assert f"3{os.linesep}" == result.lisp_out
 
-    def test_run_namespace_main_ns(self, run_cli, namespace_file: pathlib.Path):
+    def test_run_namespace_main_ns(
+        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
+    ):
         namespace_file.write_text(
-            "(ns package.core) (println (name *ns*)) (println *main-ns*)"
+            f"(ns {namespace_name}) (println (name *ns*)) (println *main-ns*)"
         )
-        result = run_cli(["run", "-n", "package.core"])
-        assert f"package.core{os.linesep}package.core{os.linesep}" == result.lisp_out
+        result = run_cli(["run", "-n", namespace_name])
+        assert (
+            f"{namespace_name}{os.linesep}{namespace_name}{os.linesep}"
+            == result.lisp_out
+        )
 
     @pytest.mark.parametrize("args,ret", cli_args_params)
     def test_run_namespace_with_args(
-        self, run_cli, namespace_file: pathlib.Path, args: List[str], ret: str
+        self,
+        run_cli,
+        namespace_name: str,
+        namespace_file: pathlib.Path,
+        args: List[str],
+        ret: str,
     ):
         namespace_file.write_text(self.cli_args_code)
-        result = run_cli(["run", "-n", "package.core", *args])
+        result = run_cli(["run", "-n", namespace_name, *args])
         assert ret == result.lisp_out
+
+    def test_run_namespace_with_subnamespace(
+        self, run_cli, monkeypatch, tmp_path: pathlib.Path
+    ):
+        ns_name = f"parent{secrets.token_hex(4)}"
+        child = "child"
+
+        parent_ns_dir = tmp_path / ns_name
+        parent_ns_dir.mkdir()
+
+        parent_ns_file = tmp_path / f"{ns_name}.lpy"
+        parent_ns_file.touch()
+        parent_ns_file.write_text(
+            f'(ns {ns_name} (:require [{ns_name}.{child}])) (python/print "loading:" *ns*)'
+        )
+
+        child_ns_file = parent_ns_dir / f"{child}.lpy"
+        child_ns_file.touch()
+        child_ns_file.write_text(
+            f'(ns {ns_name}.{child}) (python/print "loading:" *ns*)'
+        )
+
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        result = run_cli(["run", "-n", ns_name])
+        assert f"loading: {ns_name}.{child}\nloading: {ns_name}\n" == result.out
 
     def test_run_stdin(self, run_cli):
         result = run_cli(["run", "-"], input="(println (+ 1 2))")

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -312,7 +312,7 @@ class TestRun:
     def test_run_namespace(
         self, run_cli, namespace_name: str, namespace_file: pathlib.Path
     ):
-        namespace_file.write_text("(println (+ 1 2))")
+        namespace_file.write_text(f"(ns {namespace_name}) (println (+ 1 2))")
         result = run_cli(["run", "-n", namespace_name])
         assert f"3{os.linesep}" == result.lisp_out
 
@@ -337,7 +337,7 @@ class TestRun:
         args: List[str],
         ret: str,
     ):
-        namespace_file.write_text(self.cli_args_code)
+        namespace_file.write_text(f"(ns {namespace_name}) {self.cli_args_code}")
         result = run_cli(["run", "-n", namespace_name, *args])
         assert ret == result.lisp_out
 


### PR DESCRIPTION
This PR does provide a solution to the immediate problem described in #957 which prevents running namespaces from the CLI in many cases, however it does not address the larger Clojure compatibility issue outlined in the ticket.