### PR TITLE
Fix issue with `test/is` expected value misreporting on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fixed an issue where attempting to run a namespace from the CLI could fail in certain cases (#957)
  * Fixed an issue with `keep` and `keep-indexed` two-arity forms not preserving the transformed values (#962)
+ * Fixed an issue with `basilisp.test/is` where the expected value was misreported on failure of non `(= ...)` expr (#965)
 
 ## [v0.1.0]
 ### Added

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -184,7 +184,7 @@
                 :message      ~msg
                 :expr         (quote ~expr)
                 :actual       computed#
-                :expected     computed#
+                :expected     (list (symbol "not") computed#)
                 :line         ~line-num
                 :type         :failure}))))
 

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -19,6 +19,8 @@ class TestTestrunner:
           (testing "is assertions"
             (is true)
             (is false)
+            (is (some #{5} #{6 7}))
+            (is (some #{7} #{6 7}))
             (is (= "string" "string"))
             (is (thrown? basilisp.lang.exception/ExceptionInfo (throw (ex-info "Exception" {}))))
             (is (thrown? basilisp.lang.exception/ExceptionInfo (throw (python/Exception))))
@@ -66,7 +68,7 @@ class TestTestrunner:
                 "FAIL in (assertion-test) (test_testrunner.lpy:8)",
                 "     is assertions :: Test failure: false",
                 "",
-                "    expected: false",
+                "    expected: (not false)",
                 "      actual: false",
             ],
             consecutive=True,
@@ -74,7 +76,18 @@ class TestTestrunner:
 
         run_result.stdout.fnmatch_lines(
             [
-                "FAIL in (assertion-test) (test_testrunner.lpy:11)",
+                "FAIL in (assertion-test) (test_testrunner.lpy:9)",
+                "     is assertions :: Test failure: (some #{5} #{6 7})",
+                "",
+                "    expected: (not nil)",
+                "      actual: nil",
+            ],
+            consecutive=True,
+        )
+
+        run_result.stdout.fnmatch_lines(
+            [
+                "FAIL in (assertion-test) (test_testrunner.lpy:13)",
                 "     is assertions :: Expected <class 'basilisp.lang.exception.ExceptionInfo'>; got <class 'Exception'> instead",
                 "",
                 "    expected: <class 'basilisp.lang.exception.ExceptionInfo'>",
@@ -85,7 +98,7 @@ class TestTestrunner:
 
         run_result.stdout.fnmatch_lines(
             [
-                "FAIL in (assertion-test) (test_testrunner.lpy:17)",
+                "FAIL in (assertion-test) (test_testrunner.lpy:19)",
                 "     is assertions :: Regex pattern did not match",
                 "",
                 '    expected: #"Known exception"',
@@ -128,19 +141,19 @@ class TestTestrunner:
     def test_error_repr(self, run_result: pytest.RunResult):
         if sys.version_info < (3, 11):
             expected = [
-                "ERROR in (assertion-test) (test_testrunner.lpy:12)",
+                "ERROR in (assertion-test) (test_testrunner.lpy:14)",
                 "",
                 "Traceback (most recent call last):",
-                '  File "*test_testrunner.lpy", line 12, in assertion_test',
+                '  File "*test_testrunner.lpy", line 14, in assertion_test',
                 '    (is (throw (ex-info "Uncaught exception" {})))',
                 "basilisp.lang.exception.ExceptionInfo: Uncaught exception {}",
             ]
         else:
             expected = [
-                "ERROR in (assertion-test) (test_testrunner.lpy:12)",
+                "ERROR in (assertion-test) (test_testrunner.lpy:14)",
                 "",
                 "Traceback (most recent call last):",
-                '  File "*test_testrunner.lpy", line 12, in assertion_test',
+                '  File "*test_testrunner.lpy", line 14, in assertion_test',
                 '    (is (throw (ex-info "Uncaught exception" {})))',
                 "basilisp.lang.exception.ExceptionInfo: Uncaught exception {}",
             ]
@@ -154,7 +167,7 @@ class TestTestrunner:
             [
                 "ERROR in (error-test) (test_testrunner.lpy)",
                 "Traceback (most recent call last):",
-                '  File "*test_testrunner.lpy", line 33, in error_test',
+                '  File "*test_testrunner.lpy", line 35, in error_test',
                 "    (throw",
                 "basilisp.lang.exception.ExceptionInfo: This test will count as an error. {}",
             ]


### PR DESCRIPTION
Hi,

could you please consider patch to correct the reporting on the expected outcome of `basilisp.test/is` when expr falls in the :default handling.  It fixes #965.

I've included a test case for a function call expr, even though there was a case for `(is false)` which I've also updated.

Thanks