### PR TITLE
Improve on nrepl exception formating and logging interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ * Improved on the nREPL server exception messages by matching that of the REPL user friendly format (#968)
+
 ### Other
  * Run PyPy CI checks on Github Actions rather than CircleCI (#971)
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ repl:
 	@BASILISP_USE_DEV_LOGGER=true poetry run basilisp repl
 
 
+LOGLEVEL ?= INFO
+.PHONY: nrepl-server
+nrepl-server:
+	@BASILISP_USE_DEV_LOGGER=true BASILISP_LOGGING_LEVEL=$(LOGLEVEL) poetry run basilisp nrepl-server
+
 .PHONY: test
 test:
 	@rm -f .coverage*

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -20,16 +20,16 @@
      (.log logger basilisp.logconfig/TRACE (str/join " " [~@values]))))
 (defmacro ^:private debug [& values]
   `(when (.isEnabledFor logger logging/DEBUG)
-    (.debug logger (str/join " " [~@values]))))
+    (.log logger logging/DEBUG (str/join " " [~@values]))))
 (defmacro ^:private info [& values]
   `(when (.isEnabledFor logger logging/INFO)
-    (.info logger (str/join " " [~@values]))))
+    (.log logger logging/INFO (str/join " " [~@values]))))
 (defmacro ^:private warn [& values]
   `(when (.isEnabledFor logger logging/WARNING)
-     (.warning logger (str/join " " [~@values]))))
+     (.log logger logging/WARNING (str/join " " [~@values]))))
 (defmacro ^:private error [& values]
   `(when (.isEnabledFor logger logging/ERROR)
-     (.error logger (str/join " " [~@values]))))
+     (.log logger logging/ERROR (str/join " " [~@values]))))
 
 (definterface ^:private IStdOut
   ;; Pythonic interface for creating `sys/stdout` like File objects.
@@ -144,16 +144,7 @@
           (send-value request send-fn [result {:ns (str *ns*)}]))
         (catch python/Exception e
           (debug :eval-exception e)
-          (let [exc-type (condp instance? e
-                           basilisp.lang.reader/SyntaxError
-                           basilisp.lang.reader/SyntaxError
-
-                           basilisp.lang.compiler/CompilerException
-                           basilisp.lang.compiler/CompilerException
-
-                           python/Exception
-                           python/Exception)
-                msg (->> (basilisp.lang.exception/format_exception e exc-type (.-__traceback__ e))
+          (let [msg (->> (basilisp.lang.exception/format_exception e (type e) (.-__traceback__ e))
                          (str/join ""))]
             (handle-error send-fn (assoc request :ns (str *ns*)) msg)))
         (finally

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -4,7 +4,8 @@
   "A port of `nbb <https://github.com/babashka/nbb>`_ 's nREPL server implementation to Basilisp."
   (:require [basilisp.contrib.bencode :as bc]
             [basilisp.string :as str])
-  (:import logging
+  (:import basilisp.logconfig
+           logging
            socketserver
            sys
            traceback
@@ -14,18 +15,21 @@
   "The logger for this namespace."
   (logging/getLogger (namespace ::)))
 
+(defmacro ^:private trace [& values]
+  `(when (.isEnabledFor logger basilisp.logconfig/TRACE)
+     (.log logger basilisp.logconfig/TRACE (str/join " " [~@values]))))
 (defmacro ^:private debug [& values]
-  (when (.isEnabledFor logger logging/DEBUG)
-    `(.debug logger (str/join " " [~@values]))))
+  `(when (.isEnabledFor logger logging/DEBUG)
+    (.debug logger (str/join " " [~@values]))))
 (defmacro ^:private info [& values]
-  (when (.isEnabledFor logger logging/INFO)
-    `(.info logger (str/join " " [~@values]))))
+  `(when (.isEnabledFor logger logging/INFO)
+    (.info logger (str/join " " [~@values]))))
 (defmacro ^:private warn [& values]
-  (when (.isEnabledFor logger logging/WARNING))
-  `(.warning logger (str/join " " [~@values])))
+  `(when (.isEnabledFor logger logging/WARNING)
+     (.warning logger (str/join " " [~@values]))))
 (defmacro ^:private error [& values]
-  ;; we want error to always output to `sys/stderr` unfiltered.
-  `(.write sys/stderr (str ~(keyword (str *ns*) "error") " " (str/join " " [~@values]) \newline)))
+  `(when (.isEnabledFor logger logging/ERROR)
+     (.error logger (str/join " " [~@values]))))
 
 (definterface ^:private IStdOut
   ;; Pythonic interface for creating `sys/stdout` like File objects.
@@ -55,12 +59,12 @@
 
 (defn- log-request-mw [handler]
   (fn [request send-fn]
-    (info :request (dissoc request :client*))
+    (debug :request (dissoc request :client*))
     (handler request send-fn)))
 
 (defn- log-response-mw [handler]
   (fn [request response]
-    (info :response response)
+    (debug :response response)
     (handler request response)))
 
 (declare ops)
@@ -139,8 +143,19 @@
               result  (last results)]
           (send-value request send-fn [result {:ns (str *ns*)}]))
         (catch python/Exception e
-          (info :eval-exception e)
-          (handle-error send-fn (assoc request :ns (str *ns*)) e))
+          (debug :eval-exception e)
+          (let [exc-type (condp instance? e
+                           basilisp.lang.reader/SyntaxError
+                           basilisp.lang.reader/SyntaxError
+
+                           basilisp.lang.compiler/CompilerException
+                           basilisp.lang.compiler/CompilerException
+
+                           python/Exception
+                           python/Exception)
+                msg (->> (basilisp.lang.exception/format_exception e exc-type (.-__traceback__ e))
+                         (str/join ""))]
+            (handle-error send-fn (assoc request :ns (str *ns*)) msg)))
         (finally
           (swap! client* assoc :eval-ns *ns*)
           (send-fn request {"ns"     (str *ns*)
@@ -181,7 +196,7 @@
                                                                                   *resolver*
                                                                                   *data-readers*))))}
                                   (catch python/Exception e
-                                    (info :symbol-identify-reader-error :input symbol-str :exception e)
+                                    (debug :symbol-identify-reader-error :input symbol-str :exception e)
                                     {:error (str e)}))]
 
     (cond
@@ -253,7 +268,7 @@
             status   (if (and (nil? symname) (= mapping-type :eldoc) )
                        ["done" "no-eldoc"]
                        ["done"])]
-        (debug :lookup :sym sym-str :doc doc :args arglists)
+        (trace :lookup :sym sym-str :doc doc :args arglists)
         (send-fn request (assoc response :status status)))
       (catch python/Exception e
         (let [status (cond->
@@ -338,7 +353,7 @@
 
 (defn- make-send-fn [socket]
   (fn [_request response]
-    (debug :sending (:id _request) :response-keys (keys response))
+    (trace :sending (:id _request) :response-keys (keys response))
     (try
       (.sendall socket (bc/encode response))
       (catch python/TypeError e
@@ -388,7 +403,7 @@
                                          data)
                 [requests unprocessed] (bc/decode-all data {:keywordize-keys true
                                                             :string-fn       #(.decode % "utf-8")})]
-            (debug :requests requests)
+            (trace :requests requests)
             (when (not (str/blank? unprocessed))
               (reset! pending unprocessed))
             (doseq [request requests]

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -325,7 +325,9 @@
             {:id @id* :ns "xyz" :status ["done"]})
 
           (client-send! client {:id (id-inc!) :op "eval" :code "(/ 3 0)"})
-          (is (= {:id @id* :err "ZeroDivisionError('Fraction(3, 0)')"} (client-recv! client)))
+          (let [{:keys [id err]} (client-recv! client)]
+               (is (= id @id* ))
+               (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)")))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "xyz" ns))
@@ -337,8 +339,10 @@
           (client-send! client {:id (id-inc!) :op "eval" :code "(println :hey)\n(/ 4 0)"})
           (are [response] (= response (client-recv! client))
             {:id @id* :out ":hey"}
-            {:id @id* :out os/linesep}
-            {:id @id* :err "ZeroDivisionError('Fraction(4, 0)')"})
+            {:id @id* :out os/linesep})
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= @id* id))
+            (is (str/includes? err "ZeroDivisionError: Fraction(4, 0)")))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "xyz" ns))
@@ -347,15 +351,22 @@
           (are [response] (= response (client-recv! client))
             {:id @id* :ns "xyz" :status ["done"]})
 
-          (client-send! client {:id (id-inc!) :op "eval" :code "[*1 *2 *3 *e]"})
+          (client-send! client {:id (id-inc!) :op "eval" :code "[*1 *2 *3]"})
           (are [response] (= response (client-recv! client))
-            {:id @id* :ns "xyz" :value "[6 nil 4 ZeroDivisionError('Fraction(4, 0)')]"}
+            {:id @id* :ns "xyz" :value "[6 nil 4]"}
             {:id @id* :ns "xyz" :status ["done"]})
+
+          (client-send! client {:id (id-inc!) :op "eval" :code "*e"})
+          (let [{:keys [id value]} (client-recv! client)]
+            (is (= @id* id))
+            (is (str/includes? value "ZeroDivisionError: Fraction(4, 0)")))
+          (is (= {:id @id* :ns "xyz" :status ["done"]} (client-recv! client)))
 
           ;; error with :file
           (client-send! client {:id (id-inc!) :op "eval" :file "/hey/you.lpy" :code "1\n2\n(/ 5 0)"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :err "ZeroDivisionError('Fraction(5, 0)')"})
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= @id* id))
+            (is (str/includes? err "ZeroDivisionError: Fraction(5, 0)")))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "xyz" ns))
@@ -363,12 +374,14 @@
             (is (not= -1 (.find ex "File \"/hey/you.lpy\", line 3")) ex))
           (are [response] (= response (client-recv! client))
             {:id @id* :ns "xyz" :status ["done"]})
-
           ;; error conditions
           (client-send! client {:id (id-inc!) :op "eval" :code "(xyz"})
           (let [{:keys [id err]} (client-recv! client)]
             (is (= @id* id))
-            (is (str/starts-with? err "basilisp.lang.reader.SyntaxError")))
+            (is (= [""
+                    "  exception: <class 'basilisp.lang.reader.UnexpectedEOFError'>"
+                    "    message: Unexpected EOF in list" "       line: 1:4"]
+                   (str/split-lines err))))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "xyz" ns))
@@ -378,7 +391,15 @@
             {:id @id* :ns "xyz" :status ["done"]})
 
           (client-send! client {:id (id-inc!) :op "eval" :code "(+ 3 5)" :ns "not-there"})
-          (is (= {:id @id* :err "CompilerException(msg=\"unable to resolve symbol '+' in this context\", phase=<CompilerPhase.ANALYZING: :analyzing>, filename='<nREPL Input>', form=+, lisp_ast=None, py_ast=None)"} (client-recv! client)))
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= id @id*))
+            (is (= [""
+                    "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
+                    "      phase: :analyzing"
+                    "    message: unable to resolve symbol '+' in this context"
+                    "       form: +"
+                    "   location: <nREPL Input>:1"]
+                   (str/split-lines err))))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "not-there" ns))
@@ -402,7 +423,13 @@
 
         ;; bad namespace
         (client-send! client {:id 3 :op "eval" :code "(+ 3 5)" :ns "#,,"})
-        (is (= {:id 3 :err "CompilerException(msg=\"unable to resolve symbol '+' in this context\", phase=<CompilerPhase.ANALYZING: :analyzing>, filename='<nREPL Input>', form=+, lisp_ast=None, py_ast=None)"} (client-recv! client)))
+        (let [{:keys [id err]} (client-recv! client)]
+          (is (= 3 id))
+          (is (= [""
+                  "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
+                  "      phase: :analyzing" "    message: unable to resolve symbol '+' in this context"
+                  "       form: +" "   location: <nREPL Input>:1"]
+                 (str/split-lines err))))
         (let [{:keys [id ex status ns]} (client-recv! client)]
           (is (= 3 id))
           (is (= "#,," ns))
@@ -533,7 +560,9 @@
 
           (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
                                 :file-name "third.lpy" :file-path "/abc/third.lpy"})
-          (is (= {:id @id* :err "ZeroDivisionError('Fraction(3, 0)')"} (client-recv! client)))
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= @id* id))
+            (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))
             (is (= "abc.third" ns))

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -380,7 +380,8 @@
             (is (= @id* id))
             (is (= [""
                     "  exception: <class 'basilisp.lang.reader.UnexpectedEOFError'>"
-                    "    message: Unexpected EOF in list" "       line: 1:4"]
+                    "    message: Unexpected EOF in list"
+                    "       line: 1:4"]
                    (str/split-lines err))))
           (let [{:keys [id ex status ns]} (client-recv! client)]
             (is (= @id* id))


### PR DESCRIPTION
Hi,

could you please consider patch to improve on the nREPL server exception messages, inline with what has been done for the REPL recently. It addresses #968.

Tests updated to reflect the new exc messages.

I've also in-lined the logger functions to be  closer to the actual logging interface, and added a new target in the markefile for easier debugging.

Thanks