### PR TITLE
Remove `python-dateutil` and `readerwriterlock` dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Improved on the nREPL server exception messages by matching that of the REPL user friendly format (#968)
 
 ### Removed
- * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#??/) 
+ * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976) 
 
 ### Other
  * Run PyPy CI checks on Github Actions rather than CircleCI (#971)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * Improved on the nREPL server exception messages by matching that of the REPL user friendly format (#968)
 
+### Removed
+ * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#??/) 
+
 ### Other
  * Run PyPy CI checks on Github Actions rather than CircleCI (#971)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,15 +33,13 @@ include = ["README.md", "LICENSE"]
 python = "^3.8"
 attrs = ">=20.2.0"
 immutables = ">=0.20,<1.0.0"
-prompt-toolkit = "^3.0.0"
+prompt-toolkit = ">=3.0.0,<4.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"
-python-dateutil = "^2.8.1"
-readerwriterlock = "^1.0.8"
-typing-extensions = "^4.7.0"
+typing-extensions = ">=4.7.0,<5.0.0"
 
 astor = { version = "^0.8.1", python = "<3.9", optional = true }
-pytest = { version = "^7.0.0", optional = true }
-pygments = { version = "^2.9.0", optional = true }
+pytest = { version = ">=7.0.0,<9.0.0", optional = true }
+pygments = { version = ">=2.9.0,<3.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = ">=24.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docutils = [
 ]
 isort = "*"
 pygments = "*"
-pytest = "^7.0.0"
+pytest = ">=7.0.0,<9.0.0"
 pytest-pycharm = "*"
 # Ensure the Sphinx version remains synchronized with docs/requirements.txt
 # to maintain consistent output during both development and publishing on

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -37,8 +37,6 @@ from typing import (
     cast,
 )
 
-from readerwriterlock.rwlock import RWLockFair
-
 from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist
 from basilisp.lang import map as lmap
@@ -266,7 +264,7 @@ class Var(RefBase):
         self._is_bound = False
         self._tl = None
         self._meta = meta
-        self._lock = RWLockFair()
+        self._lock = threading.RLock()
         self._watches = lmap.PersistentMap.empty()
         self._validator = None
 
@@ -300,7 +298,7 @@ class Var(RefBase):
         return self._dynamic
 
     def set_dynamic(self, dynamic: bool) -> None:
-        with self._lock.gen_wlock():
+        with self._lock:
             if dynamic == self._dynamic:
                 return
 
@@ -328,18 +326,18 @@ class Var(RefBase):
 
     @property
     def root(self):
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._root
 
     def bind_root(self, val) -> None:
         """Atomically update the root binding of this Var to val."""
-        with self._lock.gen_wlock():
+        with self._lock:
             self._set_root(val)
 
     def alter_root(self, f, *args) -> None:
         """Atomically alter the root binding of this Var to the result of calling
         f with the existing root value and any additional arguments."""
-        with self._lock.gen_wlock():
+        with self._lock:
             self._set_root(f(self._root, *args))
 
     def push_bindings(self, val):
@@ -366,7 +364,7 @@ class Var(RefBase):
 
         For non-dynamic Vars, this will just be the root. For dynamic Vars, this will
         be any thread-local binding if one is defined. Otherwise, the root value."""
-        with self._lock.gen_rlock():
+        with self._lock:
             if self._dynamic:
                 assert self._tl is not None
                 if len(self._tl.bindings) > 0:
@@ -378,7 +376,7 @@ class Var(RefBase):
 
         If the Var is not dynamic, this is equivalent to binding the root value. If the
         Var is dynamic, this will set the thread-local bindings for the Var."""
-        with self._lock.gen_wlock():
+        with self._lock:
             if self._dynamic:
                 assert self._tl is not None
                 self._validate(v)
@@ -585,7 +583,7 @@ class Namespace(ReferenceBase):
         self._module = Maybe(module).or_else(lambda: _new_module(name.as_python_sym()))
 
         self._meta: Optional[IPersistentMap] = None
-        self._lock = RWLockFair()
+        self._lock = threading.RLock()
 
         self._aliases: NamespaceMap = lmap.PersistentMap.empty()
         self._imports: ModuleMap = lmap.map(
@@ -621,20 +619,20 @@ class Namespace(ReferenceBase):
     def aliases(self) -> NamespaceMap:
         """A mapping between a symbolic alias and another Namespace. The
         fully qualified name of a namespace is also an alias for itself."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._aliases
 
     @property
     def imports(self) -> ModuleMap:
         """A mapping of names to Python modules imported into the current
         namespace."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._imports
 
     @property
     def import_aliases(self) -> AliasMap:
         """A mapping of a symbolic alias and a Python module name."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._import_aliases
 
     @property
@@ -642,7 +640,7 @@ class Namespace(ReferenceBase):
         """A mapping between a symbolic name and a Var. The Var may point to
         code, data, or nothing, if it is unbound. Vars in `interns` are
         interned in _this_ namespace."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._interns
 
     @property
@@ -650,7 +648,7 @@ class Namespace(ReferenceBase):
         """A mapping between a symbolic name and a Var. Vars in refers are
         interned in another namespace and are only referred to without an
         alias in this namespace."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._refers
 
     def __repr__(self):
@@ -681,7 +679,7 @@ class Namespace(ReferenceBase):
 
     def add_alias(self, namespace: "Namespace", *aliases: sym.Symbol) -> None:
         """Add Symbol aliases for the given Namespace."""
-        with self._lock.gen_wlock():
+        with self._lock:
             new_m = self._aliases
             for alias in aliases:
                 new_m = new_m.assoc(alias, namespace)
@@ -689,12 +687,12 @@ class Namespace(ReferenceBase):
 
     def get_alias(self, alias: sym.Symbol) -> "Optional[Namespace]":
         """Get the Namespace aliased by Symbol or None if it does not exist."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._aliases.val_at(alias, None)
 
     def remove_alias(self, alias: sym.Symbol) -> None:
         """Remove the Namespace aliased by Symbol. Return None."""
-        with self._lock.gen_wlock():
+        with self._lock:
             self._aliases = self._aliases.dissoc(alias)
 
     def intern(self, sym: sym.Symbol, var: Var, force: bool = False) -> Var:
@@ -702,20 +700,20 @@ class Namespace(ReferenceBase):
         If the Symbol already maps to a Var, this method _will not overwrite_
         the existing Var mapping unless the force keyword argument is given
         and is True."""
-        with self._lock.gen_wlock():
+        with self._lock:
             old_var = self._interns.val_at(sym, None)
             if old_var is None or force:
                 self._interns = self._interns.assoc(sym, var)
             return self._interns.val_at(sym)
 
     def unmap(self, sym: sym.Symbol) -> None:
-        with self._lock.gen_wlock():
+        with self._lock:
             self._interns = self._interns.dissoc(sym)
 
     def find(self, sym: sym.Symbol) -> Optional[Var]:
         """Find Vars mapped by the given Symbol input or None if no Vars are
         mapped by that Symbol."""
-        with self._lock.gen_rlock():
+        with self._lock:
             v = self._interns.val_at(sym, None)
             if v is None:
                 return self._refers.val_at(sym, None)
@@ -724,7 +722,7 @@ class Namespace(ReferenceBase):
     def add_import(self, sym: sym.Symbol, module: Module, *aliases: sym.Symbol) -> None:
         """Add the Symbol as an imported Symbol in this Namespace. If aliases are given,
         the aliases will be applied to the"""
-        with self._lock.gen_wlock():
+        with self._lock:
             self._imports = self._imports.assoc(sym, module)
             if aliases:
                 m = self._import_aliases
@@ -738,7 +736,7 @@ class Namespace(ReferenceBase):
 
         First try to resolve a module directly with the given name. If no module
         can be resolved, attempt to resolve the module using import aliases."""
-        with self._lock.gen_rlock():
+        with self._lock:
             mod = self._imports.val_at(sym, None)
             if mod is None:
                 alias = self._import_aliases.get(sym, None)
@@ -750,17 +748,17 @@ class Namespace(ReferenceBase):
     def add_refer(self, sym: sym.Symbol, var: Var) -> None:
         """Refer var in this namespace under the name sym."""
         if not var.is_private:
-            with self._lock.gen_wlock():
+            with self._lock:
                 self._refers = self._refers.assoc(sym, var)
 
     def get_refer(self, sym: sym.Symbol) -> Optional[Var]:
         """Get the Var referred by Symbol or None if it does not exist."""
-        with self._lock.gen_rlock():
+        with self._lock:
             return self._refers.val_at(sym, None)
 
     def refer_all(self, other_ns: "Namespace") -> None:
         """Refer all the Vars in the other namespace."""
-        with self._lock.gen_wlock():
+        with self._lock:
             final_refers = self._refers
             for s, var in other_ns.interns.items():
                 if not var.is_private:

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -8,8 +8,6 @@ from decimal import Decimal
 from fractions import Fraction
 from typing import Iterable, Match, Pattern, Type
 
-from dateutil import parser as dateparser
-
 from basilisp.lang import atom as atom
 
 _DOUBLE_DOT = ".."
@@ -259,7 +257,7 @@ def fraction(numerator: int, denominator: int) -> Fraction:
 
 def inst_from_str(inst_str: str) -> datetime.datetime:
     """Create a datetime instance from an RFC 3339 formatted date string."""
-    return dateparser.parse(inst_str)
+    return datetime.datetime.fromisoformat(inst_str)
 
 
 def regex_from_str(regex_str: str) -> Pattern:

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import decimal
 import importlib
 import inspect
@@ -15,7 +16,6 @@ from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 
 import pytest
-from dateutil import parser as dateparser
 
 from basilisp.lang import compiler as compiler
 from basilisp.lang import keyword as kw
@@ -324,8 +324,12 @@ class TestLiterals:
         assert Fraction("22/7") == lcompile("22/7")
 
     def test_inst(self, lcompile: CompileFn):
-        assert dateparser.parse("2018-01-18T03:26:57.296-00:00") == lcompile(
-            '#inst "2018-01-18T03:26:57.296-00:00"'
+        assert (
+            datetime.datetime.fromisoformat("2018-01-18T03:26:57.296-00:00")
+            == lcompile('#inst "2018-01-18T03:26:57.296-00:00"')
+            == datetime.datetime(
+                2018, 1, 18, 3, 26, 57, 296000, tzinfo=datetime.timezone.utc
+            )
         )
 
     def test_queue(self, lcompile: CompileFn):
@@ -3983,8 +3987,12 @@ class TestQuote:
         assert lcompile('\'#{:a 2 "str"}') == lset.s(kw.keyword("a"), 2, "str")
 
     def test_quoted_inst(self, lcompile: CompileFn):
-        assert dateparser.parse("2018-01-18T03:26:57.296-00:00") == lcompile(
-            '(quote #inst "2018-01-18T03:26:57.296-00:00")'
+        assert (
+            datetime.datetime.fromisoformat("2018-01-18T03:26:57.296-00:00")
+            == lcompile('(quote #inst "2018-01-18T03:26:57.296-00:00")')
+            == datetime.datetime(
+                2018, 1, 18, 3, 26, 57, 296000, tzinfo=datetime.timezone.utc
+            )
         )
 
     def test_regex(self, lcompile: CompileFn):

--- a/tests/basilisp/lrepr_test.py
+++ b/tests/basilisp/lrepr_test.py
@@ -1,10 +1,10 @@
+import datetime
 import math
 import re
 import uuid
 from fractions import Fraction
 
 import pytest
-from dateutil import parser as dateparser
 
 from basilisp.lang import keyword as kw
 from tests.basilisp.helpers import CompileFn
@@ -227,7 +227,7 @@ def test_lrepr(lcompile: CompileFn, repr: str, code: str):
         ),
         (re.compile(r"\s"), '(read-string (pr-str #"\\s"))'),
         (
-            dateparser.parse("2018-11-28T12:43:25.477000+00:00"),
+            datetime.datetime.fromisoformat("2018-11-28T12:43:25.477000+00:00"),
             '(read-string (pr-str #inst "2018-11-28T12:43:25.477-00:00"))',
         ),
         ({}, "(read-string (pr-str #py {}))"),

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import math
 import os
@@ -1646,9 +1647,13 @@ def test_fraction_literal():
 
 
 def test_inst_reader_literal():
-    assert read_str_first(
-        '#inst "2018-01-18T03:26:57.296-00:00"'
-    ) == langutil.inst_from_str("2018-01-18T03:26:57.296-00:00")
+    assert (
+        read_str_first('#inst "2018-01-18T03:26:57.296-00:00"')
+        == langutil.inst_from_str("2018-01-18T03:26:57.296-00:00")
+        == datetime.datetime(
+            2018, 1, 18, 3, 26, 57, 296000, tzinfo=datetime.timezone.utc
+        )
+    )
 
     with pytest.raises(reader.SyntaxError):
         read_str_first('#inst "I am a little teapot short and stout"')

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
     BASILISP_DO_NOT_CACHE_NAMESPACES = true
 deps =
     coverage[toml]
-    pytest >=7.0.0,<8.0.0
+    pytest >=7.0.0,<9.0.0
     pytest-xdist >=3.6.1,<4.0.0
     pygments
 commands =


### PR DESCRIPTION
Remove some lightly used dependencies and replacing them with stdlib replacements: 
 - `python-dateutil` was only used for parsing `#inst "..."` tags, which was already supported via `datetime.datetime.fromisoformat`, so removing it for now.
 - `readerwriterlock` was intended to be a reader-preferring lock for things like Atoms, but it's not been updated in some time and probably wasn't making much of a difference to begin with since Python still has a GIL.