### PR TITLE
Add custom data readers #924

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
  * Added the `CollReduce` and `KVReduce` protocols in `basilisp.core.protocols` and implemented `reduce` in terms of those protocols (#927)
+ * Added support for custom data readers (#924)
+ * Added `*default-data-reader-fn*` (#924)
  * Added `basilisp.pprint/print-table` function (#983)
  * Added `basilisp.core/read-all` function (#986)
 

--- a/docs/reader.rst
+++ b/docs/reader.rst
@@ -481,7 +481,7 @@ It will search in :external:py:attr:`sys.path` for files named ``data_readers.lp
 
 It will also search for any :external:py:class:`importlib.metadata.EntryPoint` in the group ``basilisp_data_readers`` group.
 Entry points must refer to a map of data readers.
-This can be customized with the ``BASILISP_DATA_READERS_ENTRY_POINT_GROUPS`` environment variable.
+This can be disabled by setting the ``BASILISP_USE_DATA_READERS_ENTRY_POINT`` environment variable to ``false``.
 
 .. _default_data_reader_fn:
 

--- a/docs/reader.rst
+++ b/docs/reader.rst
@@ -465,6 +465,32 @@ Python literals use the matching syntax to the corresponding Python data type, w
 * ``#py {}`` produces a Python `dict <https://docs.python.org/3/library/stdtypes.html#dict>`_ type.
 * ``#py #{}`` produces a Python `set <https://docs.python.org/3/library/stdtypes.html#set>`_ type.
 
+.. _custom_data_readers:
+
+Custom Data Readers
+^^^^^^^^^^^^^^^^^^^
+
+`Like Clojure <https://clojure.org/reference/reader#tagged_literals>`_ , data readers can be changed by binding  :lpy:var:`*data-readers*`.
+
+When Basilisp starts it can load data readers from multiple sources.
+
+It will search in :external:py:attr:`sys.path` for files named ``data_readers.lpy`` or else ``data_readers.cljc``; each which must contain a mapping of qualified symbol tags to qualified symbols of function vars.
+
+.. code-block:: clojure
+    {my/tag my.namespace/tag-handler}
+
+It will also search for any :external:py:class:`importlib.metadata.EntryPoint` in the group ``basilisp_data_readers`` group.
+Entry points must refer to a map of data readers.
+This can be customized with the ``BASILISP_DATA_READERS_ENTRY_POINT_GROUPS`` environment variable.
+
+.. _default_data_reader_fn:
+
+Default Data Reader Function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By default, an exception will be raised if the reader encounters a tag that it doesn't have a data reader for.
+This can be customised by binding :lpy:var:`*default-data-readers-fn*`.
+It should be a function which is a function that takes two arguments, the tag symbol, and the value form.
+
 .. _reader_special_chars:
 
 Special Characters

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -263,12 +263,12 @@ def _add_runtime_arg_group(parser: argparse.ArgumentParser) -> None:
             "BASILISP_USE_DATA_READERS_ENTRY_POINT", parent=argparse._StoreAction
         ),
         nargs="?",
-        const=_to_bool(os.getenv("BASILISP_DATA_READERS_ENTRY_POINTS", "true")),
+        const=_to_bool(os.getenv("BASILISP_USE_DATA_READERS_ENTRY_POINT", "true")),
         type=_to_bool,
         help=(
             "If true, Load data readers from importlib entry points in the "
             '"basilisp_data_readers" group. (env: '
-            "BASILISP_DATA_READERS_ENTRY_POINTS; default: true)"
+            "BASILISP_USE_DATA_READERS_ENTRY_POINT; default: true)"
         ),
     )
 

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -260,7 +260,7 @@ def _add_runtime_arg_group(parser: argparse.ArgumentParser) -> None:
     group.add_argument(
         "--data-readers-entry-points",
         action=_set_envvar_action(
-            "BASILISP_DATA_READERS_ENTRY_POINTS", parent=argparse._StoreAction
+            "BASILISP_USE_DATA_READERS_ENTRY_POINT", parent=argparse._StoreAction
         ),
         nargs="?",
         const=_to_bool(os.getenv("BASILISP_DATA_READERS_ENTRY_POINTS", "true")),

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -250,6 +250,29 @@ def _add_debug_arg_group(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_runtime_arg_group(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group(
+        "runtime arguments",
+        description=(
+            "The runtime arguments below affect reader and execution time features."
+        ),
+    )
+    group.add_argument(
+        "--data-readers-entry-points",
+        action=_set_envvar_action(
+            "BASILISP_DATA_READERS_ENTRY_POINTS", parent=argparse._StoreAction
+        ),
+        nargs="?",
+        const=_to_bool(os.getenv("BASILISP_DATA_READERS_ENTRY_POINTS", "true")),
+        type=_to_bool,
+        help=(
+            "If true, Load data readers from importlib entry points in the "
+            '"basilisp_data_readers" group. (env: '
+            "BASILISP_DATA_READERS_ENTRY_POINTS; default: true)"
+        ),
+    )
+
+
 Handler = Callable[[argparse.ArgumentParser, argparse.Namespace], None]
 
 
@@ -384,6 +407,8 @@ def _add_nrepl_server_subcommand(parser: argparse.ArgumentParser) -> None:
         default=".nrepl-port",
         help='the file path where the server port number is output to, defaults to ".nrepl-port".',
     )
+    _add_runtime_arg_group(parser)
+    _add_debug_arg_group(parser)
 
 
 def repl(
@@ -478,6 +503,7 @@ def _add_repl_subcommand(parser: argparse.ArgumentParser) -> None:
         help="default namespace to use for the REPL",
     )
     _add_compiler_arg_group(parser)
+    _add_runtime_arg_group(parser)
     _add_debug_arg_group(parser)
 
 
@@ -588,6 +614,7 @@ def _add_run_subcommand(parser: argparse.ArgumentParser) -> None:
         help="command line args made accessible to the script as basilisp.core/*command-line-args*",
     )
     _add_compiler_arg_group(parser)
+    _add_runtime_arg_group(parser)
     _add_debug_arg_group(parser)
 
 
@@ -612,6 +639,8 @@ def test(
 )
 def _add_test_subcommand(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("args", nargs=-1)
+    _add_runtime_arg_group(parser)
+    _add_debug_arg_group(parser)
 
 
 def version(_, __) -> None:

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -7071,8 +7071,8 @@
   [entry-point mta]
   (make-custom-data-readers (.load entry-point)
                             (assoc mta
-                                   :entry-point/name (.-name entry-point)
-                                   :entry-point/group (.-group entry-point))))
+                                   :basilisp.entry-point/name (.-name entry-point)
+                                   :basilisp.entry-point/group (.-group entry-point))))
 
 (defmethod make-custom-data-readers pathlib/Path
   [file mta]

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -7087,7 +7087,7 @@
 (defn- data-readers-entry-points []
   (when (#{"true" "t" "1" "yes" "y"} (.lower
                                       (os/getenv
-                                       "BASILISP_DATA_READERS_ENTRY_POINTS"
+                                       "BASILISP_USE_DATA_READERS_ENTRY_POINT"
                                        "true")))
     (#?@(:lpy39-  [get (.entry_points importlib/metadata)]
          :lpy310+ [.entry_points importlib/metadata ** :group])

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4400,9 +4400,9 @@
   [fmt & args]
   (print (apply format fmt args)))
 
-;;;;;;;;;;;;;;;;;;;;
-;; REPL Utilities ;;
-;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Reading and Loading ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def
   ^{:doc "The default data readers used in reader macros. Overriding or
@@ -4427,6 +4427,14 @@
     :dynamic true}
   *resolver*
   basilisp.lang.runtime/resolve-alias)
+
+(def ^{:doc "When no data reader is found for a tag and ``*default-data-reader-fn*``
+            is non-``nil``, it will be called with two arguments, the tag and the value.
+            If ``*default-data-reader-fn*`` is ``nil`` (the default), raise a
+            ``basilisp.lang.compiler.SyntaxError``."
+       :dynamic true}
+  *default-data-reader-fn*
+  nil)
 
 (defn- read-iterator
   [opts x]
@@ -4457,8 +4465,9 @@
   "Read the next form from the ``stream``\\. If no stream is specified, uses the value
   currently bound to :lpy:var:`*in*`.
 
-  Callers may bind a map of readers to :lpy:var:`*data-readers*` to customize the data
-  readers used reading this string.
+  Callers may bind a map of readers to :lpy:var:`*data-readers*` or a default data
+  reader function to :lpy:var::`*default-data-reader-fn*` to customize the data
+  readers used reading this string
 
   The stream must satisfy the interface of :external:py:class:`io.TextIOBase`\\, but
   does not require any pushback capabilities. The default
@@ -4477,8 +4486,9 @@
    "Eagerly read all forms from the ``stream``\\. If no stream is specified, uses the
   value currently bound to :lpy:var:`*in*`.
 
-  Callers may bind a map of readers to :lpy:var:`*data-readers*` to customize
-  the data readers used reading this string
+  Callers may bind a map of readers to :lpy:var:`*data-readers*` or a default data
+  reader function to :lpy:var::`*default-data-reader-fn*` to customize the data
+  readers used reading this string
 
   The stream must satisfy the interface of :external:py:class:`io.TextIOBase`\\, but
   does not require any pushback capabilities. The default
@@ -7023,6 +7033,94 @@
   (with-open [writer (apply basilisp.io/writer f opts)]
     (.write writer content)
     nil))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Custom Data Readers ;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmulti ^:private make-custom-data-readers
+  (fn [obj metadata] (type obj)))
+
+(defmethod make-custom-data-readers :default
+  [obj mta]
+  (throw (ex-info "Not a valid data-reader map" (assoc mta :object obj))))
+
+(defmethod make-custom-data-readers basilisp.lang.interfaces/IPersistentMap
+  [mappings mta]
+  (reduce (fn [m [k v]]
+            (let [v' (if (qualified-symbol? v)
+                       (intern (create-ns (symbol (namespace v)))
+                               (symbol (name v)))
+                       v)]
+              (cond
+                (not (qualified-symbol? k))
+                (throw
+                 (ex-info "Invalid tag in data-readers. Expected qualified symbol."
+                          (merge mta {:form k})))
+
+                (not (ifn? v'))
+                (throw (ex-info "Invalid reader function in data-readers"
+                                (merge mta {:form v})))
+
+                :else
+                (assoc m (with-meta k mta) v'))))
+          mappings
+          mappings))
+
+(defmethod make-custom-data-readers importlib.metadata/EntryPoint
+  [entry-point mta]
+  (make-custom-data-readers (.load entry-point)
+                            (assoc mta
+                                   :entry-point/name (.-name entry-point)
+                                   :entry-point/group (.-group entry-point))))
+
+(defmethod make-custom-data-readers pathlib/Path
+  [file mta]
+  (make-custom-data-readers
+   (with-open [rdr (basilisp.io/reader file)]
+     (read (if (.endswith (name file) "cljc")
+             {:eof nil :read-cond :allow}
+             {:eof nil})
+           rdr))
+   (assoc mta :file (str file))))
+
+(defn- data-readers-entry-points []
+  (when (#{"true" "t" "1" "yes" "y"} (.lower
+                                      (os/getenv
+                                       "BASILISP_DATA_READERS_ENTRY_POINTS"
+                                       "true")))
+    (#?@(:lpy39-  [get (.entry_points importlib/metadata)]
+         :lpy310+ [.entry_points importlib/metadata ** :group])
+     "basilisp_data_readers")))
+
+(defn- data-readers-files []
+  (->> sys/path
+       (mapcat file-seq)
+       (filter (comp #{"data_readers.lpy" "data_readers.cljc"} name))
+       (group-by #(.-parent %))
+       vals
+       ;; Only load one data readers file per directory and prefer
+       ;; `data_readers.lpy` to `data_readers.cljc`
+       (map #(first (sort-by name > %)))))
+
+(defn- load-data-readers []
+  (alter-var-root
+   #'*data-readers*
+   (fn [mappings additional-mappings]
+     (reduce (fn [m [k v]]
+               (if (not= (get m k v) v)
+                 (throw (ex-info "Conflicting data-reader mapping"
+                                 (merge (meta k) {:conflict k, :mappings m})))
+                 (assoc m k v)))
+             mappings
+             additional-mappings))
+   ;; Can't use `read` when altering `*data-readers*` so do reads ahead of time
+   (->> (concat (data-readers-files)
+                (data-readers-entry-points))
+        (mapcat #(make-custom-data-readers % nil))
+        doall)))
+
+(load-data-readers)
 
 ;;;;;;;;;;;;;;;;;
 ;; Transducers ;;

--- a/src/basilisp/test/fixtures.lpy
+++ b/src/basilisp/test/fixtures.lpy
@@ -39,7 +39,8 @@
       (finally (set! (.-path sys) original)))))
 
 (defn reset-environment
-  "Test fixture to reset environment variables back to their original state."
+  "Test fixture to reset :external:py:data:`os.environ` back to its original state
+  after a test run."
   []
   (let [original (into {} (.items os/environ))]
     (try

--- a/src/basilisp/test/fixtures.lpy
+++ b/src/basilisp/test/fixtures.lpy
@@ -30,7 +30,8 @@
          (finally (set! ~attr original#))))))
 
 (defn reset-path
-  "Test fixture to reset the system path back to it's original state."
+  "Test fixture to reset :external:py:data:`sys.path` back to its original state
+  after a test run."
   []
   (let [original (.copy sys/path)]
     (try

--- a/src/basilisp/test/fixtures.lpy
+++ b/src/basilisp/test/fixtures.lpy
@@ -1,6 +1,7 @@
 (ns basilisp.test.fixtures
   "Built-in fixtures which may be useful in Basilisp tests."
   (:import
+   os
    tempfile))
 
 (def ^:dynamic *tempdir*
@@ -16,3 +17,36 @@
   (with-open [d (tempfile/TemporaryDirectory)]
     (binding [*tempdir* d]
       (yield))))
+
+(defmacro reset-attribute
+  "Test fixture to reset an attribute back to the value it referenced
+  before the fixture was applied. Note: if the original value has
+  mutated these mutations will not be undo."
+  [attr]
+  `(fn []
+     (let [original# ~attr]
+       (try
+         (yield)
+         (finally (set! ~attr original#))))))
+
+(defn reset-path
+  "Test fixture to reset the system path back to it's original state."
+  []
+  (let [original (.copy sys/path)]
+    (try
+      (yield)
+      (finally (set! (.-path sys) original)))))
+
+(defn reset-environment
+  "Test fixture to reset environment variables back to their original state."
+  []
+  (let [original (into {} (.items os/environ))]
+    (try
+      (yield)
+      (finally
+        (doseq [[env v] (into {} (.items os/environ))]
+          (if (contains? original env)
+            (let [ov (get original env)]
+              (when (not= ov v)
+                (.update os/environ {env ov})))
+            (.pop os/environ env)))))))

--- a/tests/basilisp/test_data_readers.lpy
+++ b/tests/basilisp/test_data_readers.lpy
@@ -136,7 +136,7 @@
                            [(entry-point "do_not_load"
                                          "basilisp_data_readers"
                                          #'fail-data-readers)])))
-    (.update os/environ {"BASILISP_DATA_READERS_ENTRY_POINTS" "false"})
+    (.update os/environ {"BASILISP_USE_DATA_READERS_ENTRY_POINT" "false"})
     (let [data-readers *data-readers*]
       (#'basilisp.core/load-data-readers)
       (is (= data-readers *data-readers*)))))

--- a/tests/basilisp/test_data_readers.lpy
+++ b/tests/basilisp/test_data_readers.lpy
@@ -1,0 +1,163 @@
+(ns tests.basilisp.test-data-readers
+  (:import os
+           [basilisp.lang.reader :as reader])
+  (:require
+   [basilisp.test :as test :refer [deftest are is testing]]
+   [basilisp.test.fixtures :as fixtures :refer [*tempdir*]]))
+
+(defn make-path-file
+  [path text]
+  (assert *tempdir* "Missing tempdir fixture")
+  (let [path (if (string? path) [path] path)
+        dir  (apply (.-join os/path) *tempdir*
+                    (butlast path))
+        file (.join os/path dir (last path))]
+    (os/makedirs dir ** :exist_ok true)
+    (with-open [wtr (python/open file ** :mode "w")]
+      (.write wtr text))))
+
+(defn path-files-fixture
+  []
+  (assert *tempdir* "Missing tempdir fixture")
+  (.insert sys/path 0 *tempdir*)
+  (yield))
+
+(defn reset-data-readers-fixture
+  []
+  (let [original *data-readers*]
+    (try
+      (yield)
+      (finally
+        (alter-var-root #'*data-readers* (constantly original))))))
+
+(test/use-fixtures :each
+  fixtures/tempdir
+  fixtures/reset-path
+  fixtures/reset-environment
+  (fixtures/reset-attribute (.-entry_points importlib/metadata))
+  path-files-fixture
+  reset-data-readers-fixture)
+
+(def custom-data-reader list)
+
+(deftest load-data-readers-from-path-test
+  (testing "top level"
+    (make-path-file "data_readers.lpy"
+                    (pr-str {'test/test `custom-data-reader}))
+    (#'basilisp.core/load-data-readers)
+    (is (= #'custom-data-reader (get *data-readers* 'test/test)))
+    (is (= '(x) (read-string "#test/test x"))))
+
+  (testing "from module"
+    (make-path-file ["my_module" "data_readers.lpy"]
+                    (pr-str {'test/test2 `custom-data-reader}))
+    (#'basilisp.core/load-data-readers)
+    (is (= #'custom-data-reader (get *data-readers* 'test/test2)))
+    (is (= '(x) (read-string "#test/test2 x"))))
+
+  (testing "from submodule"
+    (make-path-file ["my_module" "submodule" "data_readers.lpy"]
+                    (pr-str {'test/test3 `custom-data-reader}))
+    (#'basilisp.core/load-data-readers)
+    (is (= #'custom-data-reader (get *data-readers* 'test/test3)))
+    (is (= '(x) (read-string "#test/test3 x"))))
+
+  (testing "from cljc file"
+    (make-path-file ["from_cljc" "data_readers.cljc"]
+                    (pr-str {'test/test4 `custom-data-reader}))
+    (#'basilisp.core/load-data-readers)
+    (is (= #'custom-data-reader (get *data-readers* 'test/test4)))
+    (is (= '(x) (read-string "#test/test4 x"))))
+
+  (testing "prefer lpy to cljc"
+    (make-path-file ["prefer_lpy_to_cljc" "data_readers.lpy"]
+                    (pr-str {'test/test5 `custom-data-reader}))
+    (make-path-file ["prefer_lpy_to_cljc" "data_readers.cljc"]
+                    (pr-str {'test/test5 (constantly :fail)}))
+    (#'basilisp.core/load-data-readers)
+    (is (= #'custom-data-reader (get *data-readers* 'test/test3)))
+    (is (= '(x) (read-string "#test/test5 x"))))
+
+  (testing "does not load clj file"
+    (make-path-file ["from_clj" "data_readers.clj"]
+                    (pr-str {'test/fail `custom-data-reader}))
+    (#'basilisp.core/load-data-readers)
+    (is (not (contains? *data-readers* 'test/fail)))
+    (is (thrown? reader/SyntaxError (read-string "#test/fail x")))))
+
+(def data-readers
+  {'test/test (fn [x] (vector x))})
+
+(def other-data-readers
+  {'test/test2 'basilisp.core/list})
+
+(def fail-data-readers
+  {'test/fail (constantly :fail)})
+
+(defn entry-point
+  [entry-point-name group var]
+  (importlib.metadata/EntryPoint entry-point-name
+                                 (str (-> var namespace str munge)
+                                      ":"
+                                      (-> var name str munge))
+                                 group))
+
+(defn set-entry-points!
+  [m]
+  (set! (.-entry_points importlib/metadata)
+        #?(:lpy39-  (fn [] m)
+           :lpy310+
+           ^{:kwargs :collect}
+           (fn [{:keys [group]}] (get m group)))))
+
+(deftest load-data-readers-from-entry-points-test
+  (testing "load from \"basilisp_data_readers\" group"
+    (set-entry-points!
+     {"basilisp_data_readers" [(entry-point "test"
+                                            "basilisp_data_readers"
+                                            #'data-readers)]})
+    (#'basilisp.core/load-data-readers)
+    (is (= (get data-readers 'test/test) (get *data-readers* 'test/test)))
+    (is (= '[x] (read-string "#test/test x"))))
+
+  (testing "do not load from other groups"
+    (set-entry-points!
+     {"other_group" [(entry-point "do_not_load"
+                                  "other_group"
+                                  #'fail-data-readers)]})
+    (#'basilisp.core/load-data-readers)
+    (is (not (contains? *data-readers* 'test/fail))))
+
+  (testing "load nothing if disabled"
+    (set-entry-points! (reify
+                         basilisp.lang.interfaces/ILookup
+                         (val-at [k v not-found]
+                           (is (not (any? k)))
+                           [(entry-point "do_not_load"
+                                         "basilisp_data_readers"
+                                         #'fail-data-readers)])))
+    (.update os/environ {"BASILISP_DATA_READERS_ENTRY_POINTS" "false"})
+    (let [data-readers *data-readers*]
+      (#'basilisp.core/load-data-readers)
+      (is (= data-readers *data-readers*)))))
+
+(deftest load-data-readers-exceptional-cases-test
+  (testing "data readers must be a map"
+    (make-path-file "data_readers.lpy" (pr-str nil))
+    (is (thrown-with-msg? basilisp.lang.exception/ExceptionInfo
+                          #"Not a valid data-reader map"
+                          (#'basilisp.core/load-data-readers))))
+
+  (testing "tags must be namespaced"
+    (make-path-file "data_readers.lpy" (pr-str {'fail `vector}))
+    (is (thrown-with-msg?
+         basilisp.lang.exception/ExceptionInfo
+         #"Invalid tag in data-readers. Expected qualified symbol."
+         (#'basilisp.core/load-data-readers))))
+
+  (testing "tags cannot conflict"
+    (make-path-file "data_readers.lpy" (pr-str {'test/test `vector}))
+    (make-path-file ["other" "data_readers.lpy"] (pr-str {'test/test `list}))
+    (is (thrown-with-msg? basilisp.lang.exception/ExceptionInfo
+                          #"Conflicting data-reader mapping"
+                          (#'basilisp.core/load-data-readers)))))

--- a/tests/basilisp/test_data_readers.lpy
+++ b/tests/basilisp/test_data_readers.lpy
@@ -34,7 +34,7 @@
   fixtures/tempdir
   fixtures/reset-path
   fixtures/reset-environment
-  (fixtures/reset-attribute (.-entry_points importlib/metadata))
+  (fixtures/reset-attribute (.-entry-points importlib/metadata))
   path-files-fixture
   reset-data-readers-fixture)
 


### PR DESCRIPTION
Fixes #924 

Hello,

I managed to get the custom data readers feature implemented. Let me know if you have any question or would like to see any changes.

Core Changes:

- Added custom data readers, from files on the path as well as entry points.
- Entry point groups can be customized or disabled with cli arguments
- Added `*default-data-reader-fn*`
- Changed the reader to allow any tag values like in Clojure, but restrict tags from loaded data readers to only qualified symbols.
- Updated documentation with new features

Other Changes:

- Changed load functions to return the result of the last form evaluated as in Clojure. I was touching this function anyway and noticed the discrepancy.
- Added `basilisp.core/read-seq`; it allows other namespaces to stop depending on `basilisp.lang.reader` directly.
- Added `basilisp.contrib.pytest.fixtures` namespace with a `pytest.MonkeyPatch` test fixture to support testing this feature.
- Added cli arguments to some subcommands that I noticed were missing.