### PR TITLE
Fixed inconsistent behaviour with basilisp.core/with body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Types created via `deftype` and `reify` may declare supertypes as abstract (taking precedence over true `abc.ABC` types) and specify their member list using `^:abstract-members` metadata (#942)
 
 ### Fixed
- * Fixed inconsistent behavior with `basilisp.core\with` when the `body` contains more than one form (#981) 
+ * Fixed inconsistent behavior with `basilisp.core/with` when the `body` contains more than one form (#981)
 
 ### Removed
  * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Improved on the nREPL server exception messages by matching that of the REPL user friendly format (#968)
  * Types created via `deftype` and `reify` may declare supertypes as abstract (taking precedence over true `abc.ABC` types) and specify their member list using `^:abstract-members` metadata (#942)
 
+### Fixed
+ * Fixed inconsistent behavior with `basilisp.core\with` when the `body` contains more than one form (#981) 
+
 ### Removed
  * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976) 
 

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3778,7 +3778,7 @@
                         [(concat
                           (list 'with (vec (nthrest bindings 2)))
                           body)]
-                        body)]
+                        (list (concat '(do) body)))]
            res#)
          (catch python/Exception e#
            (vreset! hit-except# true)

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1,5 +1,5 @@
 (ns tests.basilisp.test-core-macros
-  (:import inspect os socket tempfile)
+  (:import contextlib inspect os socket tempfile)
   (:require
    [basilisp.test :refer [deftest is testing]]))
 
@@ -470,6 +470,18 @@
         (finally
           (os/close fh)
           (os/unlink filename)))))
+
+  (testing "with multiple body forms"
+    (let [v* (volatile! nil)]
+      (is (= 2 (with [_ (contextlib/nullcontext)]
+                     (vreset! v* 5) (vswap! v* inc) 2)))
+      (is (= 6 @v*)))
+
+    (let [v* (volatile! nil)]
+      (is (= 3 (with [_ (contextlib/nullcontext)
+                      _ (contextlib/nullcontext)]
+                     (vreset! v* 6) (vswap! v* inc) 3)))
+      (is (= 7 @v*))))
 
   (testing "exceptions"
     (is (thrown? python/FloatingPointError


### PR DESCRIPTION
Hi,

could you please consider patch to fix the inconsistent behaviour of the `basilisp.core/with` `body` argument. It fixes #981.

Tests added.

Thanks