### PR TITLE
Fixed issue with `basilisp.core/time` failing outside of core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fixed inconsistent behavior with `basilisp.core/with` when the `body` contains more than one form (#981)
+ * Fixed an issue with `basilisp.core/time` failing when called outside of the core ns (#991)
 
 ### Removed
  * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4021,7 +4021,8 @@
        (fn []
          ~@body))))
 
-(defn ^:private perf-counter
+(defn perf-counter
+  "Implementation detail of :lpy:fn:`time`."
   []
   (py-time/perf-counter))
 
@@ -4029,11 +4030,11 @@
   "Time the execution of ``expr``\\. Return the result of ``expr`` and print the time
   execution took in milliseconds."
   [expr]
-  `(let [start (#'perf-counter)]
+  `(let [start (perf-counter)]
      (try
        (do ~expr)
        (finally
-         (println (* 1000 (- (#'perf-counter) start)) "msecs")))))
+         (println (* 1000 (- (perf-counter) start)) "msecs")))))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Threading Macros ;;

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4029,11 +4029,11 @@
   "Time the execution of ``expr``\\. Return the result of ``expr`` and print the time
   execution took in milliseconds."
   [expr]
-  `(let [start (perf-counter)]
+  `(let [start (#'perf-counter)]
      (try
-       ~expr
+       (do ~expr)
        (finally
-         (println (* 1000 (- (perf-counter) start)) "msecs")))))
+         (println (* 1000 (- (#'perf-counter) start)) "msecs")))))
 
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Threading Macros ;;

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -1,6 +1,7 @@
 (ns tests.basilisp.test-core-macros
   (:import contextlib inspect os socket tempfile)
   (:require
+   [basilisp.string :as str]
    [basilisp.test :refer [deftest is testing]]))
 
 (deftest defn-test
@@ -487,6 +488,9 @@
     (is (thrown? python/FloatingPointError
                  (with [sock (socket/socket socket/AF_INET socket/SOCK_STREAM)]
                        (throw python/FloatingPointError))))))
+
+(deftest time-test
+  (is (str/includes? (with-out-str (time 123)) "msecs")))
 
 (deftest if-let-test
   (is (= :a (if-let [a :a] a :b)))


### PR DESCRIPTION
Hi,

can you please consider patch to address an issue with `basilisp.core/time` failing when called outside of the core ns. It fixes #991.

Added test for the same.

I've also wrapped the `expr` in a `do` block so that it can't interfere with the out `try block` thanks.

Thanks