### PR TITLE
keyword function return default in error cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fixed inconsistent behavior with `basilisp.core/with` when the `body` contains more than one form (#981)
  * Fixed an issue with `basilisp.core/time` failing when called outside of the core ns (#991)
  * Fixed an issue with `basilisp.core/promise` where a thread waiting for a value from another thread might not wake up immediately upon delivery (#983).
+ * Fixed using keyword as a function not returning the default value in some cases (#997)
 
 ### Removed
  * Removed `python-dateutil` and `readerwriterlock` as dependencies, switching to standard library components instead (#976)

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -72,7 +72,7 @@ class Keyword(ILispObject, INamed):
         try:
             return m.val_at(self, default)
         except (AttributeError, TypeError):
-            return None
+            return default
 
     def __reduce__(self):
         return keyword_from_hash, (self._hash, self._name, self._ns)

--- a/tests/basilisp/keyword_test.py
+++ b/tests/basilisp/keyword_test.py
@@ -64,6 +64,9 @@ def test_keyword_as_function():
     assert None is kw(lset.s(1))
     assert "hi" is kw(lset.s(1), default="hi")
 
+    assert 1 is kw(None, 1)
+    assert None is kw(None, None)
+
     assert None is kw(lvector.v(1))
 
 


### PR DESCRIPTION
Fixes #997 

Quick fix. I noticed that using a keyword as a function with `nil` as the collection always returns `nil` rather than the default. 

This demonstrates the bug:
```clojure
(:foo nil :bar)

;; Expected 
=> :bar

;;Actual
=> nil
```