### PR TITLE
Don't obscure exceptions occuring during inlining in macroexpansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ * Exceptions occurring during inlining during macroexpansion are no longer obscured by the outer macroexpansion exception (#1013) 
 
 ## [v0.2.0]
 ### Added

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2639,7 +2639,7 @@ def _invoke_ast(form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext) -
                 return __handle_macroexpanded_ast(form, expanded, ctx)
             except Exception as e:
                 if isinstance(e, CompilerException) and (  # pylint: disable=no-member
-                    e.phase == CompilerPhase.MACROEXPANSION
+                    e.phase in {CompilerPhase.MACROEXPANSION, CompilerPhase.INLINING}
                 ):
                     # Do not chain macroexpansion exceptions since they don't
                     # actually add anything of value over the cause exception


### PR DESCRIPTION
Fixes #1013 