### PR TITLE
Don't obscure inlining cause exceptions

### DIFF
--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -2662,6 +2662,10 @@ def _invoke_ast(form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext) -
                 expanded = inline_fn(*form.rest)
                 return __handle_macroexpanded_ast(form, expanded, ctx)
             except Exception as e:
+                if isinstance(e, CompilerException) and (  # pylint: disable=no-member
+                    e.phase == CompilerPhase.INLINING
+                ):
+                    raise
                 raise CompilerException(
                     "error occurred during inlining",
                     filename=ctx.filename,


### PR DESCRIPTION
Fixes #1013 (second case I missed the first time around)