### PR TITLE
Pass nREPL client evaled code's line and col nums to the reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `defrecord`/`deftype` constructors could not be used in the type's methods. (#1025)
  * Fix a bug where `keys` and `vals` would fail for records (#1030)
  * Fix a bug where operations on records created by `defrecord` failed for fields whose Python-safe names were mangled by the Python compiler (#1029)
+ * Fix incorrect line numbers for compiler exceptions in nREPL when evaluating forms in loaded files (#1037)
 
 ## [v0.2.1]
 ### Changed

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -138,8 +138,8 @@
       (try
         (let [result (last
                       (for [form (read-seq (cond-> {}
-                                             line (assoc :line_num line)
-                                             column (assoc :column_num column))
+                                             line   (assoc :init-line   line)
+                                             column (assoc :init-column column))
                                            (io/StringIO code))]
                         (basilisp.lang.compiler/compile-and-exec-form form
                                                                       ctx

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -106,8 +106,11 @@
                       "ns"     ns})))
 
 (defn- do-handle-eval
-  "Evaluate the ``request`` ``code`` of ``file`` in the ``ns`` namespace according
-  to the current state of the ``client*`` and sends its result with ``send-fn``.
+  "Evaluate the ``request`` ``code`` of ``file`` in the ``ns`` namespace
+  according to the current state of the ``client*`` and sends its
+  result with ``send-fn``. If ``line`` and/or ``column`` are provided,
+  they indicate the line and column numbers withing the ``file`` where
+  ``code`` is located.
 
   The result sent is either the last evaluated value or exception, followed by
   the \"done\" status.
@@ -119,7 +122,7 @@
   It binds the ``*1``, ``*2``, ``*3`` and ``*e`` variables for evaluation from
   the corresponding ones found in ``client*``, and updates the latter according
   to the result."
-  [{:keys [client* code ns file _column _line] :as request} send-fn]
+  [{:keys [client* code ns file column line] :as request} send-fn]
   (let [{:keys [*1 *2 *3 *e eval-ns]} @client*
         out-stream                    (StreamOutFn #(send-fn request {"out" %}))
         ctx                           (basilisp.lang.compiler.CompilerContext. (or file "<nREPL Input>"))
@@ -134,7 +137,10 @@
               *e    *e]
       (try
         (let [result (last
-                      (for [form (read-seq (io/StringIO code))]
+                      (for [form (read-seq (cond-> {}
+                                             line (assoc :line_num line)
+                                             column (assoc :column_num column))
+                                           (io/StringIO code))]
                         (basilisp.lang.compiler/compile-and-exec-form form
                                                                       ctx
                                                                       *ns*)))]

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4478,11 +4478,12 @@
 
   ``opts`` may include, among other things, the following keys:
 
-  :keyword ``:line_num``: An optional starting line number in the
-  broader context where the `stream` is located.
-
-  :keyword ``:column_num``: An optional starting column number in the
-  broader context where the `stream` is located."
+  :keyword ``:init-line``:  optional initial line number for reader metadata;
+      helpful for contextualizing errors for chunks of code read from a
+      larger source document.
+  :keyword ``:init-col``: optional initial column number for reader metadata;
+      helpful for contextualizing errors for chunks of code read from a
+      larger source document."
   ([stream]
    (read-seq {} stream))
   ([opts stream]
@@ -4496,8 +4497,8 @@
                  (not= :preserve (:read-cond opts))
                  *default-data-reader-fn*
                  **
-                 :line_num (:line_num opts)
-                 :column_num (:column_num opts))))))
+                 :init-line (:init-line opts)
+                 :init-column (:init-column opts))))))
 
 (defn read-string
   "Read a string of Basilisp code.

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4481,7 +4481,7 @@
   :keyword ``:init-line``:  optional initial line number for reader metadata;
       helpful for contextualizing errors for chunks of code read from a
       larger source document.
-  :keyword ``:init-col``: optional initial column number for reader metadata;
+  :keyword ``:init-column``: optional initial column number for reader metadata;
       helpful for contextualizing errors for chunks of code read from a
       larger source document."
   ([stream]

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4474,7 +4474,15 @@
   The stream must satisfy the interface of :external:py:class:`io.TextIOBase`\\, but
   does not require any pushback capabilities. The default
   ``basilisp.lang.reader.StreamReader`` can wrap any object implementing ``TextIOBase``
-  and provide pushback capabilities."
+  and provide pushback capabilities.
+
+  ``opts`` may include, among other things, the following keys:
+
+  :keyword ``:line_num``: An optional starting line number in the
+  broader context where the `stream` is located.
+
+  :keyword ``:column_num``: An optional starting column number in the
+  broader context where the `stream` is located."
   ([stream]
    (read-seq {} stream))
   ([opts stream]
@@ -4486,7 +4494,10 @@
                  (= (:eof opts) :eofthrow)
                  (:features opts)
                  (not= :preserve (:read-cond opts))
-                 *default-data-reader-fn*)))))
+                 *default-data-reader-fn*
+                 **
+                 :line_num (:line_num opts)
+                 :column_num (:column_num opts))))))
 
 (defn read-string
   "Read a string of Basilisp code.

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -227,19 +227,19 @@ class StreamReader:
         self,
         stream: io.TextIOBase,
         pushback_depth: int = 5,
-        line_num: Optional[int] = None,
-        column_num: Optional[int] = None,
+        init_line: Optional[int] = None,
+        init_column: Optional[int] = None,
     ) -> None:
-        """`line_num` and `column_num` refer to where the `stream`
+        """`init_line` and `init_column` refer to where the `stream`
         starts in the broader context, defaulting to 1 and 0
         respectively if not provided."""
-        line_num = line_num if line_num is not None else 1
-        column_num = column_num if column_num is not None else 0
+        init_line = init_line if init_line is not None else 1
+        init_column = init_column if init_column is not None else 0
         self._stream = stream
         self._pushback_depth = pushback_depth
         self._idx = -2
-        self._line = collections.deque([line_num], pushback_depth)
-        self._col = collections.deque([column_num], pushback_depth)
+        self._line = collections.deque([init_line], pushback_depth)
+        self._col = collections.deque([init_column], pushback_depth)
         self._buffer = collections.deque([self._stream.read(1)], pushback_depth)
 
         # Load up an extra character
@@ -1707,13 +1707,14 @@ def read(  # pylint: disable=too-many-arguments
     features: Optional[IPersistentSet[kw.Keyword]] = None,
     process_reader_cond: bool = True,
     default_data_reader_fn: Optional[DefaultDataReaderFn] = None,
-    line_num: Optional[int] = None,
-    column_num: Optional[int] = None,
+    init_line: Optional[int] = None,
+    init_column: Optional[int] = None,
 ) -> Iterable[RawReaderForm]:
     """Read the contents of a stream as a Lisp expression.
 
-    The optional `line_num` and `column_num` specify where the
-    `stream` starts in the broader context, if not from the start.
+    The optional `init_line` and `init_column` specify where the
+    `stream` location metadata starts in the broader context, if not
+    from the start.
 
     Callers may optionally specify a namespace resolver, which will be used
     to adjudicate the fully-qualified name of symbols appearing inside of
@@ -1733,7 +1734,7 @@ def read(  # pylint: disable=too-many-arguments
     are provided.
 
     The caller is responsible for closing the input stream."""
-    reader = StreamReader(stream, line_num=line_num, column_num=column_num)
+    reader = StreamReader(stream, init_line=init_line, init_column=init_column)
     ctx = ReaderContext(
         reader,
         resolver=resolver,
@@ -1768,13 +1769,14 @@ def read_str(  # pylint: disable=too-many-arguments
     features: Optional[IPersistentSet[kw.Keyword]] = None,
     process_reader_cond: bool = True,
     default_data_reader_fn: Optional[DefaultDataReaderFn] = None,
-    line_num: Optional[int] = None,
-    column_num: Optional[int] = None,
+    init_line: Optional[int] = None,
+    init_column: Optional[int] = None,
 ) -> Iterable[RawReaderForm]:
     """Read the contents of a string as a Lisp expression.
 
-    The optional `line_num` and `column_num` specify where the
-    `stream` starts in the broader context, if not from the beginning.
+    The optional `init_line` and `init_column` specify where the
+    `stream` location metadata starts in the broader context, if not
+    from the beginning.
 
     Keyword arguments to this function have the same meanings as those of
     basilisp.lang.reader.read."""
@@ -1788,8 +1790,8 @@ def read_str(  # pylint: disable=too-many-arguments
             features=features,
             process_reader_cond=process_reader_cond,
             default_data_reader_fn=default_data_reader_fn,
-            line_num=line_num,
-            column_num=column_num,
+            init_line=init_line,
+            init_column=init_column,
         )
 
 

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -519,22 +519,11 @@
 (deftest nrepl-server-load-file
   (testing "basic"
 
-    (with [tmpfile (tempfile/NamedTemporaryFile
-                          **
-                          ;; This allows the nREPL server to open the file independently
-                          ;; while it remains open in this test.
-                          :delete-on-close false)]
-
-
-          (with-server {}
-            (with-connect client
-              (let [id* (atom 0)
-                    id-inc! #(swap! id* inc)]
-                (client-send! client {:id (id-inc!) :op "clone"})
-                (let [{:keys [status]} (client-recv! client)]
-                  (is (= ["done"] status)))
-                (let [filename (.-name tmpfile)]
-                  (.write tmpfile #b "(ns abc.xyz (:require [clojure.string :as str])
+    ;; procreate a load test file that is also going to be accessed by
+    ;; the server.
+    (let [[fd filename] (tempfile/mkstemp)]
+      (try
+        (spit filename "(ns abc.xyz (:require [clojure.string :as str])
 (:import [sys :as s]))
 (defn afn []
   (str/lower-case \"ABC\"))
@@ -543,89 +532,99 @@
   (xyz))
 
 (afn)")
-                  (.flush tmpfile)
 
-                  (client-send! client {:id (id-inc!) :op "load-file"
-                                        :ns "user" :file "(ns abc.xyz (:require [clojure.string :as str]) (:import [sys :as s])) (defn afn []  (str/lower-case \"ABC\")) \n(comment\n (abc)\n (xyz)\n)\n (afn)"
-                                        :file-name "xyz.lpy" :file-path filename})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.xyz" :value "\"abc\""}
-                    {:id @id* :ns "abc.xyz" :status ["done"]})
-
-
-                  (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.xyz" :value "\"sys\""}
-                    {:id @id* :ns "abc.xyz" :status ["done"]})
-
-                  (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.other" :value "abc.other"}
-                    {:id @id* :ns "abc.other" :status ["done"]})
-                  (client-send! client {:id (id-inc!) :op "load-file"
-                                        :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
-                                        :file-name "other.lpy" :file-path "/abc/other.lpy"})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.other" :value "9"}
-                    {:id @id* :ns "abc.other" :status ["done"]})
-
-                  (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.other" :value "55"}
-                    {:id @id* :ns "abc.other" :status ["done"]})
-
-                  (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.other" :value "\"abc\""}
-                    {:id @id* :ns "abc.other" :status ["done"]})
-
-                  (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
-                                        :file filename
-                                        :line 6 :column 2})
-                  (let [{:keys [id err]} (client-recv! client)]
-                    (is (= @id* id))
-                    (is (= [""
-                            "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
-                            "      phase: :analyzing"
-                            "    message: unable to resolve symbol 'abc' in this context"
-                            "       form: abc"
-                            (str "   location: " filename ":6")
-                            "    context:"
-                            ""
-                            " 2   | (:import [sys :as s]))"
-                            " 3   | (defn afn []"
-                            " 4   |   (str/lower-case \"ABC\"))"
-                            " 5   | (comment"
-                            " 6 > |   (abc)"
-                            " 7   |   (xyz))"
-                            " 8   | "
-                            " 9   | (afn)"]
-                           (-> err
-                               ;; remove ansi control chars
-                               (str/replace #"\\x1B[@-_][0-?]*[ -/]*[@-~]" "")
-                               (str/split-lines)))))
-                  (let [{:keys [id ex status ns]} (client-recv! client)]
-                    (is (= @id* id))
-                    (is (= "abc.xyz" ns))
-                    (is (= ["eval-error"] status))
-                    (is (str/starts-with? ex "Traceback (most recent call last):")))
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.xyz" :status ["done"]})
+        (with-server {}
+          (with-connect client
+            (let [id* (atom 0)
+                  id-inc! #(swap! id* inc)]
+              (client-send! client {:id (id-inc!) :op "clone"})
+              (let [{:keys [status]} (client-recv! client)]
+                (is (= ["done"] status)))
+              (client-send! client {:id (id-inc!) :op "load-file"
+                                    :ns "user" :file (slurp filename)
+                                    :file-name "xyz.lpy" :file-path filename})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.xyz" :value "\"abc\""}
+                {:id @id* :ns "abc.xyz" :status ["done"]})
 
 
-                  (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
-                                        :file-name "third.lpy" :file-path "/abc/third.lpy"})
-                  (let [{:keys [id err]} (client-recv! client)]
-                    (is (= @id* id))
-                    (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
-                  (let [{:keys [id ex status ns]} (client-recv! client)]
-                    (is (= @id* id))
-                    (is (= "abc.third" ns))
-                    (is (= ["eval-error"] status))
-                    (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
-                    (is (str/starts-with? ex "Traceback (most recent call last):")))
-                  (are [response] (= response (client-recv! client))
-                    {:id @id* :ns "abc.third" :status ["done"]}))))))
+              (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.xyz" :value "\"sys\""}
+                {:id @id* :ns "abc.xyz" :status ["done"]})
+
+              (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.other" :value "abc.other"}
+                {:id @id* :ns "abc.other" :status ["done"]})
+              (client-send! client {:id (id-inc!) :op "load-file"
+                                    :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
+                                    :file-name "other.lpy" :file-path "/abc/other.lpy"})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.other" :value "9"}
+                {:id @id* :ns "abc.other" :status ["done"]})
+
+              (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.other" :value "55"}
+                {:id @id* :ns "abc.other" :status ["done"]})
+
+              (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.other" :value "\"abc\""}
+                {:id @id* :ns "abc.other" :status ["done"]})
+
+              (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
+                                    :file filename
+                                    :line 6 :column 2})
+              (let [{:keys [id err]} (client-recv! client)]
+                (is (= @id* id))
+                (is (= [""
+                        "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
+                        "      phase: :analyzing"
+                        "    message: unable to resolve symbol 'abc' in this context"
+                        "       form: abc"
+                        (str "   location: " filename ":6")
+                        "    context:"
+                        ""
+                        " 2   | (:import [sys :as s]))"
+                        " 3   | (defn afn []"
+                        " 4   |   (str/lower-case \"ABC\"))"
+                        " 5   | (comment"
+                        " 6 > |   (abc)"
+                        " 7   |   (xyz))"
+                        " 8   | "
+                        " 9   | (afn)"]
+                       (-> err
+                           ;; remove ansi control chars
+                           (str/replace #"\\x1B[@-_][0-?]*[ -/]*[@-~]" "")
+                           (str/split-lines)))))
+              (let [{:keys [id ex status ns]} (client-recv! client)]
+                (is (= @id* id))
+                (is (= "abc.xyz" ns))
+                (is (= ["eval-error"] status))
+                (is (str/starts-with? ex "Traceback (most recent call last):")))
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.xyz" :status ["done"]})
+
+
+              (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
+                                    :file-name "third.lpy" :file-path "/abc/third.lpy"})
+              (let [{:keys [id err]} (client-recv! client)]
+                (is (= @id* id))
+                (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
+              (let [{:keys [id ex status ns]} (client-recv! client)]
+                (is (= @id* id))
+                (is (= "abc.third" ns))
+                (is (= ["eval-error"] status))
+                (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
+                (is (str/starts-with? ex "Traceback (most recent call last):")))
+              (are [response] (= response (client-recv! client))
+                {:id @id* :ns "abc.third" :status ["done"]}))))
+
+        (finally
+          (os/close fd)
+          (os/unlink filename))))
 
     (testing "no file"
       (with-server {}

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -5,13 +5,16 @@
    [basilisp.contrib.nrepl-server :as nr]
    [basilisp.set :as set]
    [basilisp.string :as str :refer [starts-with?]]
-   [basilisp.test :refer [deftest are is testing]])
+   [basilisp.test :refer [deftest are is testing use-fixtures]]
+   [basilisp.test.fixtures :as fixtures :refer [*tempdir*]])
   (:import
    os
    socket
    tempfile
    threading
    time))
+
+(use-fixtures :each fixtures/tempdir)
 
 (def ^:dynamic *nrepl-port*
   "The port the :lpy:py:`with-server` is bound to."
@@ -519,11 +522,16 @@
 (deftest nrepl-server-load-file
   (testing "basic"
 
-    ;; procreate a load test file that is also going to be accessed by
-    ;; the server.
-    (let [[fd filename] (tempfile/mkstemp)]
-      (try
-        (spit filename "(ns abc.xyz (:require [clojure.string :as str])
+    (with-server {}
+      (with-connect client
+        (let [id* (atom 0)
+              id-inc! #(swap! id* inc)
+              filename (str (bio/path *tempdir* "load-file-test.lpy"))]
+          (client-send! client {:id (id-inc!) :op "clone"})
+          (let [{:keys [status]} (client-recv! client)]
+            (is (= ["done"] status)))
+
+          (spit filename "(ns abc.xyz (:require [clojure.string :as str])
 (:import [sys :as s]))
 (defn afn []
   (str/lower-case \"ABC\"))
@@ -533,109 +541,98 @@
 
 (afn)")
 
-        (with-server {}
-          (with-connect client
-            (let [id* (atom 0)
-                  id-inc! #(swap! id* inc)]
-              (client-send! client {:id (id-inc!) :op "clone"})
-              (let [{:keys [status]} (client-recv! client)]
-                (is (= ["done"] status)))
-              (client-send! client {:id (id-inc!) :op "load-file"
-                                    :ns "user" :file (slurp filename)
-                                    :file-name "xyz.lpy" :file-path filename})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.xyz" :value "\"abc\""}
-                {:id @id* :ns "abc.xyz" :status ["done"]})
-
-
-              (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.xyz" :value "\"sys\""}
-                {:id @id* :ns "abc.xyz" :status ["done"]})
-
-              (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.other" :value "abc.other"}
-                {:id @id* :ns "abc.other" :status ["done"]})
-              (client-send! client {:id (id-inc!) :op "load-file"
-                                    :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
-                                    :file-name "other.lpy" :file-path "/abc/other.lpy"})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.other" :value "9"}
-                {:id @id* :ns "abc.other" :status ["done"]})
-
-              (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.other" :value "55"}
-                {:id @id* :ns "abc.other" :status ["done"]})
-
-              (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.other" :value "\"abc\""}
-                {:id @id* :ns "abc.other" :status ["done"]})
-
-              (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
-                                    :file filename
-                                    :line 6 :column 2})
-              (let [{:keys [id err]} (client-recv! client)]
-                (is (= @id* id))
-                (is (= [""
-                        "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
-                        "      phase: :analyzing"
-                        "    message: unable to resolve symbol 'abc' in this context"
-                        "       form: abc"
-                        (str "   location: " filename ":6")
-                        "    context:"
-                        ""
-                        " 2   | (:import [sys :as s]))"
-                        " 3   | (defn afn []"
-                        " 4   |   (str/lower-case \"ABC\"))"
-                        " 5   | (comment"
-                        " 6 > |   (abc)"
-                        " 7   |   (xyz))"
-                        " 8   | "
-                        " 9   | (afn)"]
-                       (-> err
-                           ;; remove ansi control chars
-                           (str/replace #"\\x1B[@-_][0-?]*[ -/]*[@-~]" "")
-                           (str/split-lines)))))
-              (let [{:keys [id ex status ns]} (client-recv! client)]
-                (is (= @id* id))
-                (is (= "abc.xyz" ns))
-                (is (= ["eval-error"] status))
-                (is (str/starts-with? ex "Traceback (most recent call last):")))
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.xyz" :status ["done"]})
-
-
-              (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
-                                    :file-name "third.lpy" :file-path "/abc/third.lpy"})
-              (let [{:keys [id err]} (client-recv! client)]
-                (is (= @id* id))
-                (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
-              (let [{:keys [id ex status ns]} (client-recv! client)]
-                (is (= @id* id))
-                (is (= "abc.third" ns))
-                (is (= ["eval-error"] status))
-                (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
-                (is (str/starts-with? ex "Traceback (most recent call last):")))
-              (are [response] (= response (client-recv! client))
-                {:id @id* :ns "abc.third" :status ["done"]}))))
-
-        (finally
-          (os/close fd)
-          (os/unlink filename))))
-
-    (testing "no file"
-      (with-server {}
-        (with-connect client
-          (client-send! client {:id 1 :op "clone"})
-          (let [{:keys [status]} (client-recv! client)]
-            (is (= ["done"] status)))
-          (client-send! client {:id 2 :op "load-file" :ns "user"})
+          (client-send! client {:id (id-inc!) :op "load-file"
+                                :ns "user" :file (slurp filename)
+                                :file-name "xyz.lpy" :file-path filename})
           (are [response] (= response (client-recv! client))
-            {:id 2 :ns "user" :value "nil"}
-            {:id 2 :ns "user" :status ["done"]}))))))
+            {:id @id* :ns "abc.xyz" :value "\"abc\""}
+            {:id @id* :ns "abc.xyz" :status ["done"]})
+
+
+          (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.xyz" :value "\"sys\""}
+            {:id @id* :ns "abc.xyz" :status ["done"]})
+
+          (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.other" :value "abc.other"}
+            {:id @id* :ns "abc.other" :status ["done"]})
+          (client-send! client {:id (id-inc!) :op "load-file"
+                                :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
+                                :file-name "other.lpy" :file-path "/abc/other.lpy"})
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.other" :value "9"}
+            {:id @id* :ns "abc.other" :status ["done"]})
+
+          (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.other" :value "55"}
+            {:id @id* :ns "abc.other" :status ["done"]})
+
+          (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.other" :value "\"abc\""}
+            {:id @id* :ns "abc.other" :status ["done"]})
+
+          (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
+                                :file filename
+                                :line 6 :column 2})
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= @id* id))
+            (is (= [""
+                    "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
+                    "      phase: :analyzing"
+                    "    message: unable to resolve symbol 'abc' in this context"
+                    "       form: abc"
+                    (str "   location: " filename ":6")
+                    "    context:"
+                    ""
+                    " 2   | (:import [sys :as s]))"
+                    " 3   | (defn afn []"
+                    " 4   |   (str/lower-case \"ABC\"))"
+                    " 5   | (comment"
+                    " 6 > |   (abc)"
+                    " 7   |   (xyz))"
+                    " 8   | "
+                    " 9   | (afn)"]
+                   (-> err
+                       ;; remove ansi control chars
+                       (str/replace #"\\x1B[@-_][0-?]*[ -/]*[@-~]" "")
+                       (str/split-lines)))))
+          (let [{:keys [id ex status ns]} (client-recv! client)]
+            (is (= @id* id))
+            (is (= "abc.xyz" ns))
+            (is (= ["eval-error"] status))
+            (is (str/starts-with? ex "Traceback (most recent call last):")))
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.xyz" :status ["done"]})
+
+
+          (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
+                                :file-name "third.lpy" :file-path "/abc/third.lpy"})
+          (let [{:keys [id err]} (client-recv! client)]
+            (is (= @id* id))
+            (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
+          (let [{:keys [id ex status ns]} (client-recv! client)]
+            (is (= @id* id))
+            (is (= "abc.third" ns))
+            (is (= ["eval-error"] status))
+            (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
+            (is (str/starts-with? ex "Traceback (most recent call last):")))
+          (are [response] (= response (client-recv! client))
+            {:id @id* :ns "abc.third" :status ["done"]})))))
+
+  (testing "no file"
+    (with-server {}
+      (with-connect client
+        (client-send! client {:id 1 :op "clone"})
+        (let [{:keys [status]} (client-recv! client)]
+          (is (= ["done"] status)))
+        (client-send! client {:id 2 :op "load-file" :ns "user"})
+        (are [response] (= response (client-recv! client))
+          {:id 2 :ns "user" :value "nil"}
+          {:id 2 :ns "user" :status ["done"]})))))
 
 (deftest nrepl-server-params
   (testing "buffer size"

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -518,60 +518,114 @@
 
 (deftest nrepl-server-load-file
   (testing "basic"
-    (with-server {}
-      (with-connect client
-        (let [id* (atom 0)
-              id-inc! #(swap! id* inc)]
-          (client-send! client {:id (id-inc!) :op "clone"})
-          (let [{:keys [status]} (client-recv! client)]
-            (is (= ["done"] status)))
-          (client-send! client {:id (id-inc!) :op "load-file"
-                                :ns "user" :file "(ns abc.xyz (:require [clojure.string :as str]) (:import [sys :as s])) (defn afn []  (str/lower-case \"ABC\")) (afn)"
-                                :file-name "xyz.lpy" :file-path "/abc/xyz.lpy"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.xyz" :value "\"abc\""}
-            {:id @id* :ns "abc.xyz" :status ["done"]})
+
+    (with [tmpfile (tempfile/NamedTemporaryFile
+                          **
+                          ;; This allows the nREPL server to open the file independently
+                          ;; while it remains open in this test.
+                          :delete-on-close false)]
 
 
-          (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.xyz" :value "\"sys\""}
-            {:id @id* :ns "abc.xyz" :status ["done"]})
+          (with-server {}
+            (with-connect client
+              (let [id* (atom 0)
+                    id-inc! #(swap! id* inc)]
+                (client-send! client {:id (id-inc!) :op "clone"})
+                (let [{:keys [status]} (client-recv! client)]
+                  (is (= ["done"] status)))
+                (let [filename (.-name tmpfile)]
+                  (.write tmpfile #b "(ns abc.xyz (:require [clojure.string :as str])
+(:import [sys :as s]))
+(defn afn []
+  (str/lower-case \"ABC\"))
+(comment
+  (abc)
+  (xyz))
 
-          (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.other" :value "abc.other"}
-            {:id @id* :ns "abc.other" :status ["done"]})
-          (client-send! client {:id (id-inc!) :op "load-file"
-                                :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
-                                :file-name "other.lpy" :file-path "/abc/other.lpy"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.other" :value "9"}
-            {:id @id* :ns "abc.other" :status ["done"]})
+(afn)")
+                  (.flush tmpfile)
 
-          (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.other" :value "55"}
-            {:id @id* :ns "abc.other" :status ["done"]})
+                  (client-send! client {:id (id-inc!) :op "load-file"
+                                        :ns "user" :file "(ns abc.xyz (:require [clojure.string :as str]) (:import [sys :as s])) (defn afn []  (str/lower-case \"ABC\")) \n(comment\n (abc)\n (xyz)\n)\n (afn)"
+                                        :file-name "xyz.lpy" :file-path filename})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.xyz" :value "\"abc\""}
+                    {:id @id* :ns "abc.xyz" :status ["done"]})
 
-          (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.other" :value "\"abc\""}
-            {:id @id* :ns "abc.other" :status ["done"]})
 
-          (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
-                                :file-name "third.lpy" :file-path "/abc/third.lpy"})
-          (let [{:keys [id err]} (client-recv! client)]
-            (is (= @id* id))
-            (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
-          (let [{:keys [id ex status ns]} (client-recv! client)]
-            (is (= @id* id))
-            (is (= "abc.third" ns))
-            (is (= ["eval-error"] status))
-            (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
-            (is (str/starts-with? ex "Traceback (most recent call last):")))
-          (are [response] (= response (client-recv! client))
-            {:id @id* :ns "abc.third" :status ["done"]}))))
+                  (client-send! client {:id (id-inc!) :op "eval" :ns "abc.xyz" :code "s/__name__"})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.xyz" :value "\"sys\""}
+                    {:id @id* :ns "abc.xyz" :status ["done"]})
+
+                  (client-send! client {:id (id-inc!) :op "eval" :code "(in-ns 'abc.other)"})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.other" :value "abc.other"}
+                    {:id @id* :ns "abc.other" :status ["done"]})
+                  (client-send! client {:id (id-inc!) :op "load-file"
+                                        :ns "user" :file "(ns abc.other) (defn afn [] 55) (+ 5 4)"
+                                        :file-name "other.lpy" :file-path "/abc/other.lpy"})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.other" :value "9"}
+                    {:id @id* :ns "abc.other" :status ["done"]})
+
+                  (client-send! client {:id (id-inc!) :op "eval" :code "(afn)"})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.other" :value "55"}
+                    {:id @id* :ns "abc.other" :status ["done"]})
+
+                  (client-send! client {:id (id-inc!) :op "eval" :code "(abc.xyz/afn)"})
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.other" :value "\"abc\""}
+                    {:id @id* :ns "abc.other" :status ["done"]})
+
+                  (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
+                                        :file filename
+                                        :line 6 :column 2})
+                  (let [{:keys [id err]} (client-recv! client)]
+                    (is (= @id* id))
+                    (is (= [""
+                            "  exception: <class 'basilisp.lang.compiler.exception.CompilerException'>"
+                            "      phase: :analyzing"
+                            "    message: unable to resolve symbol 'abc' in this context"
+                            "       form: abc"
+                            (str "   location: " filename ":6")
+                            "    context:"
+                            ""
+                            " 2   | (:import [sys :as s]))"
+                            " 3   | (defn afn []"
+                            " 4   |   (str/lower-case \"ABC\"))"
+                            " 5   | (comment"
+                            " 6 > |   (abc)"
+                            " 7   |   (xyz))"
+                            " 8   | "
+                            " 9   | (afn)"]
+                           (-> err
+                               ;; remove ansi control chars
+                               (str/replace #"\\x1B[@-_][0-?]*[ -/]*[@-~]" "")
+                               (str/split-lines)))))
+                  (let [{:keys [id ex status ns]} (client-recv! client)]
+                    (is (= @id* id))
+                    (is (= "abc.xyz" ns))
+                    (is (= ["eval-error"] status))
+                    (is (str/starts-with? ex "Traceback (most recent call last):")))
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.xyz" :status ["done"]})
+
+
+                  (client-send! client {:id (id-inc!) :op "load-file" :ns "user" :file "(ns abc.third)\n\n(/ 3 0)"
+                                        :file-name "third.lpy" :file-path "/abc/third.lpy"})
+                  (let [{:keys [id err]} (client-recv! client)]
+                    (is (= @id* id))
+                    (is (str/includes? err "ZeroDivisionError: Fraction(3, 0)") (str/split-lines err)))
+                  (let [{:keys [id ex status ns]} (client-recv! client)]
+                    (is (= @id* id))
+                    (is (= "abc.third" ns))
+                    (is (= ["eval-error"] status))
+                    (is (not= -1 (.find ex "File \"/abc/third.lpy\", line 3")) ex)
+                    (is (str/starts-with? ex "Traceback (most recent call last):")))
+                  (are [response] (= response (client-recv! client))
+                    {:id @id* :ns "abc.third" :status ["done"]}))))))
 
     (testing "no file"
       (with-server {}

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -575,7 +575,7 @@
             {:id @id* :ns "abc.other" :value "\"abc\""}
             {:id @id* :ns "abc.other" :status ["done"]})
 
-          (client-send! client {:id (id-inc!) :ns "abc.xyz":op "eval" :code "(abc)"
+          (client-send! client {:id (id-inc!) :ns "abc.xyz" :op "eval" :code "(abc)"
                                 :file filename
                                 :line 6 :column 2})
           (let [{:keys [id err]} (client-recv! client)]

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -134,6 +134,40 @@ def test_stream_reader_loc():
     assert (3, 1) == sreader.loc
 
 
+def test_stream_reader_loc_other():
+    s = str("i=1\n" "b=2\n" "i")
+    sreader = reader.StreamReader(io.StringIO(s), line_num=5, column_num=3)
+    assert (5, 3) == sreader.loc
+
+    assert "i" == sreader.peek()
+    assert (5, 3) == sreader.loc
+
+    assert "=" == sreader.next_char()
+    assert (5, 4) == sreader.loc
+
+    assert "=" == sreader.peek()
+    assert (5, 4) == sreader.loc
+
+    sreader.pushback()
+    assert "i" == sreader.peek()
+    assert (5, 3) == sreader.loc
+
+    assert "=" == sreader.next_char()
+    assert (5, 4) == sreader.loc
+
+    assert "1" == sreader.next_char()
+    assert (5, 5) == sreader.loc
+
+    assert "\n" == sreader.next_char()
+    assert (5, 6) == sreader.loc
+
+    assert "b" == sreader.next_char()
+    assert (6, 0) == sreader.loc
+
+    assert "=" == sreader.next_char()
+    assert (6, 1) == sreader.loc
+
+
 class TestReaderLines:
     def test_reader_lines_from_str(self, tmp_path):
         _, _, l = list(reader.read_str("1\n2\n(/ 5 0)"))
@@ -143,6 +177,25 @@ class TestReaderLines:
             l.meta.get(reader.READER_END_LINE_KW),
             l.meta.get(reader.READER_COL_KW),
             l.meta.get(reader.READER_END_COL_KW),
+        )
+
+    def test_reader_lines_from_str_other_loc(self, tmp_path):
+        l1, _, l3 = list(
+            reader.read_str("(+ 1 2)\n2\n(/ 5 0)", line_num=6, column_num=7)
+        )
+
+        assert (6, 6, 7, 14) == (
+            l1.meta.get(reader.READER_LINE_KW),
+            l1.meta.get(reader.READER_END_LINE_KW),
+            l1.meta.get(reader.READER_COL_KW),
+            l1.meta.get(reader.READER_END_COL_KW),
+        )
+
+        assert (8, 8, 0, 7) == (
+            l3.meta.get(reader.READER_LINE_KW),
+            l3.meta.get(reader.READER_END_LINE_KW),
+            l3.meta.get(reader.READER_COL_KW),
+            l3.meta.get(reader.READER_END_COL_KW),
         )
 
     def test_reader_lines_from_file(self, tmp_path):

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -136,7 +136,7 @@ def test_stream_reader_loc():
 
 def test_stream_reader_loc_other():
     s = str("i=1\n" "b=2\n" "i")
-    sreader = reader.StreamReader(io.StringIO(s), line_num=5, column_num=3)
+    sreader = reader.StreamReader(io.StringIO(s), init_line=5, init_column=3)
     assert (5, 3) == sreader.loc
 
     assert "i" == sreader.peek()
@@ -181,7 +181,7 @@ class TestReaderLines:
 
     def test_reader_lines_from_str_other_loc(self, tmp_path):
         l1, _, l3 = list(
-            reader.read_str("(+ 1 2)\n2\n(/ 5 0)", line_num=6, column_num=7)
+            reader.read_str("(+ 1 2)\n2\n(/ 5 0)", init_line=6, init_column=7)
         )
 
         assert (6, 6, 7, 14) == (

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2439,6 +2439,45 @@
 
 
 ;;;;;;;;;;
+;; Read ;;
+;;;;;;;;;;
+
+(deftest read-seq-test
+
+  (testing "read-seq plain"
+    (with [stream (io/StringIO "(+ 1 2)\n(+ 4 \n5)")]
+          (let [[l1 l2] (read-seq stream)
+                {l1-l  :basilisp.lang.reader/line
+                 l1-el :basilisp.lang.reader/end-line
+                 l1-c  :basilisp.lang.reader/col
+                 l1-ec :basilisp.lang.reader/end-col} (meta l1)
+                {l2-l  :basilisp.lang.reader/line
+                 l2-el :basilisp.lang.reader/end-line
+                 l2-c  :basilisp.lang.reader/col
+                 l2-ec :basilisp.lang.reader/end-col} (meta l2)]
+            (is (= '(+ 1 2) l1))
+            (is (= '(+ 4 5) l2))
+            (is (= [1 1 0 7] [l1-l l1-el l1-c l1-ec]))
+            (is (= [2 3 0 2] [l2-l l2-el l2-c l2-ec])))))
+
+  (testing "read-seq with specified line and col numbers"
+      (with [stream (io/StringIO "(+ 1 2)\n(+ 4 \n5)")]
+            (let [[l1 l2] (read-seq {:line_num 10 :column_num 15} stream)
+                  {l1-l  :basilisp.lang.reader/line
+                   l1-el :basilisp.lang.reader/end-line
+                   l1-c  :basilisp.lang.reader/col
+                   l1-ec :basilisp.lang.reader/end-col} (meta l1)
+                  {l2-l  :basilisp.lang.reader/line
+                   l2-el :basilisp.lang.reader/end-line
+                   l2-c  :basilisp.lang.reader/col
+                   l2-ec :basilisp.lang.reader/end-col} (meta l2)]
+              (is (= '(+ 1 2) l1))
+              (is (= '(+ 4 5) l2))
+              (is (= [10 10 15 22] [l1-l l1-el l1-c l1-ec]))
+              (is (= [11 12 0 2] [l2-l l2-el l2-c l2-ec]))))))
+
+
+;;;;;;;;;;
 ;; Load ;;
 ;;;;;;;;;;
 

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -2462,7 +2462,7 @@
 
   (testing "read-seq with specified line and col numbers"
       (with [stream (io/StringIO "(+ 1 2)\n(+ 4 \n5)")]
-            (let [[l1 l2] (read-seq {:line_num 10 :column_num 15} stream)
+            (let [[l1 l2] (read-seq {:init-line 10 :init-column 15} stream)
                   {l1-l  :basilisp.lang.reader/line
                    l1-el :basilisp.lang.reader/end-line
                    l1-c  :basilisp.lang.reader/col


### PR DESCRIPTION
Hi,

could you please consider patch to pass the nREPL client's eval file line and column numbers down to the reader for more accurate compiler exception reporting. It fixes #1037.

I have attempted a focused approach to propagate the line and column parameters to the error reporting mechanism. If this approach is not optimal, I am open to reorganizing the code based on better suggestions.

I've included tests down the affected path to cover these changes.

Thanks