### PR TITLE
Refactor CLI run subcommand tests into nested classes for organization

### DIFF
--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -36,7 +36,7 @@ def isolated_filesystem():
         wd = os.getcwd()
         os.chdir(d)
         try:
-            yield
+            yield d
         finally:
             os.chdir(wd)
 
@@ -228,160 +228,165 @@ class TestREPL:
         assert "Exception: CLI test" in result.err
 
 
-class TestRun:
-    cli_args_params = [
-        ([], f"0{os.linesep}"),
-        (["--"], f"0{os.linesep}"),
-        (["1", "2", "3"], f"6{os.linesep}"),
-        (["--", "1", "2", "3"], f"6{os.linesep}"),
-    ]
-    cli_args_code = "(println (apply + (map int *command-line-args*)))"
+cli_run_args_params = [
+    ([], f"0{os.linesep}"),
+    (["--"], f"0{os.linesep}"),
+    (["1", "2", "3"], f"6{os.linesep}"),
+    (["--", "1", "2", "3"], f"6{os.linesep}"),
+]
+cli_run_args_code = "(println (apply + (map int *command-line-args*)))"
 
+
+class TestRun:
     def test_run_ns_and_code_mutually_exclusive(self, run_cli):
         with pytest.raises(SystemExit):
             run_cli(["run", "-c", "-n"])
 
-    def test_run_code(self, run_cli):
-        result = run_cli(["run", "-c", "(println (+ 1 2))"])
-        assert f"3{os.linesep}" == result.lisp_out
+    class TestRunCode:
+        def test_run_code(self, run_cli):
+            result = run_cli(["run", "-c", "(println (+ 1 2))"])
+            assert f"3{os.linesep}" == result.lisp_out
 
-    def test_run_code_main_ns(self, run_cli):
-        result = run_cli(["run", "-c", "(println *main-ns*)"])
-        assert f"nil{os.linesep}" == result.lisp_out
+        def test_run_code_main_ns(self, run_cli):
+            result = run_cli(["run", "-c", "(println *main-ns*)"])
+            assert f"nil{os.linesep}" == result.lisp_out
 
-    @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_code_with_args(self, run_cli, args: List[str], ret: str):
-        result = run_cli(["run", "-c", self.cli_args_code, *args])
-        assert ret == result.lisp_out
+        @pytest.mark.parametrize("args,ret", cli_run_args_params)
+        def test_run_code_with_args(self, run_cli, args: List[str], ret: str):
+            result = run_cli(["run", "-c", cli_run_args_code, *args])
+            assert ret == result.lisp_out
 
-    def test_run_file_rel(self, isolated_filesystem, run_cli):
-        with open("test.lpy", mode="w") as f:
-            f.write("(println (+ 1 2))")
-        result = run_cli(["run", "test.lpy"])
-        assert f"3{os.linesep}" == result.lisp_out
+    class TestRunFile:
+        def test_run_file_rel(self, isolated_filesystem, run_cli):
+            with open("test.lpy", mode="w") as f:
+                f.write("(println (+ 1 2))")
+            result = run_cli(["run", "test.lpy"])
+            assert f"3{os.linesep}" == result.lisp_out
 
-    def test_run_file_abs(self, isolated_filesystem, run_cli):
-        with open("test.lpy", mode="w") as f:
-            f.write("(println (+ 1 3))")
-        full_path = os.path.abspath("test.lpy")
-        result = run_cli(["run", full_path])
-        assert f"4{os.linesep}" == result.lisp_out
+        def test_run_file_abs(self, isolated_filesystem, run_cli):
+            with open("test.lpy", mode="w") as f:
+                f.write("(println (+ 1 3))")
+            full_path = os.path.abspath("test.lpy")
+            result = run_cli(["run", full_path])
+            assert f"4{os.linesep}" == result.lisp_out
 
-    def test_run_file_not_found(self, isolated_filesystem, run_cli):
-        with pytest.raises(FileNotFoundError):
-            run_cli(["run", "xyz.lpy"])
+        def test_run_file_not_found(self, isolated_filesystem, run_cli):
+            with pytest.raises(FileNotFoundError):
+                run_cli(["run", "xyz.lpy"])
 
-    def test_run_file_main_ns(self, isolated_filesystem, run_cli):
-        with open("test.lpy", mode="w") as f:
-            f.write("(println *main-ns*)")
-        result = run_cli(["run", "test.lpy"])
-        assert f"nil{os.linesep}" == result.lisp_out
+        def test_run_file_main_ns(self, isolated_filesystem, run_cli):
+            with open("test.lpy", mode="w") as f:
+                f.write("(println *main-ns*)")
+            result = run_cli(["run", "test.lpy"])
+            assert f"nil{os.linesep}" == result.lisp_out
 
-    @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_file_with_args(
-        self, isolated_filesystem, run_cli, args: List[str], ret: str
-    ):
-        with open("test.lpy", mode="w") as f:
-            f.write(self.cli_args_code)
-        result = run_cli(["run", "test.lpy", *args])
-        assert ret == result.lisp_out
+        @pytest.mark.parametrize("args,ret", cli_run_args_params)
+        def test_run_file_with_args(
+            self, isolated_filesystem, run_cli, args: List[str], ret: str
+        ):
+            with open("test.lpy", mode="w") as f:
+                f.write(cli_run_args_code)
+            result = run_cli(["run", "test.lpy", *args])
+            assert ret == result.lisp_out
 
-    @pytest.fixture
-    def namespace_name(self) -> str:
-        return f"package.core{secrets.token_hex(4)}"
+    class TestRunNamespace:
+        @pytest.fixture
+        def namespace_name(self) -> str:
+            return f"package.core{secrets.token_hex(4)}"
 
-    @pytest.fixture
-    def namespace_file(
-        self, monkeypatch, tmp_path: pathlib.Path, namespace_name: str
-    ) -> pathlib.Path:
-        parent_ns, child_ns = namespace_name.split(".", maxsplit=1)
-        parent = tmp_path / parent_ns
-        parent.mkdir()
-        nsfile = parent / f"{child_ns}.lpy"
-        nsfile.touch()
-        monkeypatch.syspath_prepend(str(tmp_path))
-        yield nsfile
+        @pytest.fixture
+        def namespace_file(
+            self, monkeypatch, tmp_path: pathlib.Path, namespace_name: str
+        ) -> pathlib.Path:
+            parent_ns, child_ns = namespace_name.split(".", maxsplit=1)
+            parent = tmp_path / parent_ns
+            parent.mkdir()
+            nsfile = parent / f"{child_ns}.lpy"
+            nsfile.touch()
+            monkeypatch.syspath_prepend(str(tmp_path))
+            yield nsfile
 
-    def test_cannot_run_namespace_with_in_ns_arg(
-        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
-    ):
-        namespace_file.write_text("(println (+ 1 2))")
-        with pytest.raises(SystemExit):
-            run_cli(["run", "--in-ns", "otherpackage.core", "-n", namespace_name])
+        def test_cannot_run_namespace_with_in_ns_arg(
+            self, run_cli, namespace_name: str, namespace_file: pathlib.Path
+        ):
+            namespace_file.write_text("(println (+ 1 2))")
+            with pytest.raises(SystemExit):
+                run_cli(["run", "--in-ns", "otherpackage.core", "-n", namespace_name])
 
-    def test_run_namespace(
-        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
-    ):
-        namespace_file.write_text(f"(ns {namespace_name}) (println (+ 1 2))")
-        result = run_cli(["run", "-n", namespace_name])
-        assert f"3{os.linesep}" == result.lisp_out
+        def test_run_namespace(
+            self, run_cli, namespace_name: str, namespace_file: pathlib.Path
+        ):
+            namespace_file.write_text(f"(ns {namespace_name}) (println (+ 1 2))")
+            result = run_cli(["run", "-n", namespace_name])
+            assert f"3{os.linesep}" == result.lisp_out
 
-    def test_run_namespace_main_ns(
-        self, run_cli, namespace_name: str, namespace_file: pathlib.Path
-    ):
-        namespace_file.write_text(
-            f"(ns {namespace_name}) (println (name *ns*)) (println *main-ns*)"
-        )
-        result = run_cli(["run", "-n", namespace_name])
-        assert (
-            f"{namespace_name}{os.linesep}{namespace_name}{os.linesep}"
-            == result.lisp_out
-        )
+        def test_run_namespace_main_ns(
+            self, run_cli, namespace_name: str, namespace_file: pathlib.Path
+        ):
+            namespace_file.write_text(
+                f"(ns {namespace_name}) (println (name *ns*)) (println *main-ns*)"
+            )
+            result = run_cli(["run", "-n", namespace_name])
+            assert (
+                f"{namespace_name}{os.linesep}{namespace_name}{os.linesep}"
+                == result.lisp_out
+            )
 
-    @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_namespace_with_args(
-        self,
-        run_cli,
-        namespace_name: str,
-        namespace_file: pathlib.Path,
-        args: List[str],
-        ret: str,
-    ):
-        namespace_file.write_text(f"(ns {namespace_name}) {self.cli_args_code}")
-        result = run_cli(["run", "-n", namespace_name, *args])
-        assert ret == result.lisp_out
+        @pytest.mark.parametrize("args,ret", cli_run_args_params)
+        def test_run_namespace_with_args(
+            self,
+            run_cli,
+            namespace_name: str,
+            namespace_file: pathlib.Path,
+            args: List[str],
+            ret: str,
+        ):
+            namespace_file.write_text(f"(ns {namespace_name}) {cli_run_args_code}")
+            result = run_cli(["run", "-n", namespace_name, *args])
+            assert ret == result.lisp_out
 
-    def test_run_namespace_with_subnamespace(
-        self, run_cli, monkeypatch, tmp_path: pathlib.Path
-    ):
-        ns_name = f"parent{secrets.token_hex(4)}"
-        child = "child"
+        def test_run_namespace_with_subnamespace(
+            self, run_cli, monkeypatch, tmp_path: pathlib.Path
+        ):
+            ns_name = f"parent{secrets.token_hex(4)}"
+            child = "child"
 
-        parent_ns_dir = tmp_path / ns_name
-        parent_ns_dir.mkdir()
+            parent_ns_dir = tmp_path / ns_name
+            parent_ns_dir.mkdir()
 
-        parent_ns_file = tmp_path / f"{ns_name}.lpy"
-        parent_ns_file.touch()
-        parent_ns_file.write_text(
-            f'(ns {ns_name} (:require [{ns_name}.{child}])) (python/print "loading:" *ns*)'
-        )
+            parent_ns_file = tmp_path / f"{ns_name}.lpy"
+            parent_ns_file.touch()
+            parent_ns_file.write_text(
+                f'(ns {ns_name} (:require [{ns_name}.{child}])) (python/print "loading:" *ns*)'
+            )
 
-        child_ns_file = parent_ns_dir / f"{child}.lpy"
-        child_ns_file.touch()
-        child_ns_file.write_text(
-            f'(ns {ns_name}.{child}) (python/print "loading:" *ns*)'
-        )
+            child_ns_file = parent_ns_dir / f"{child}.lpy"
+            child_ns_file.touch()
+            child_ns_file.write_text(
+                f'(ns {ns_name}.{child}) (python/print "loading:" *ns*)'
+            )
 
-        monkeypatch.syspath_prepend(str(tmp_path))
+            monkeypatch.syspath_prepend(str(tmp_path))
 
-        result = run_cli(["run", "-n", ns_name])
-        assert f"loading: {ns_name}.{child}\nloading: {ns_name}\n" == result.out
+            result = run_cli(["run", "-n", ns_name])
+            assert f"loading: {ns_name}.{child}\nloading: {ns_name}\n" == result.out
 
-    def test_run_stdin(self, run_cli):
-        result = run_cli(["run", "-"], input="(println (+ 1 2))")
-        assert f"3{os.linesep}" == result.lisp_out
+    class TestRunStdin:
+        def test_run_stdin(self, run_cli):
+            result = run_cli(["run", "-"], input="(println (+ 1 2))")
+            assert f"3{os.linesep}" == result.lisp_out
 
-    def test_run_stdin_main_ns(self, run_cli):
-        result = run_cli(["run", "-"], input="(println *main-ns*)")
-        assert f"nil{os.linesep}" == result.lisp_out
+        def test_run_stdin_main_ns(self, run_cli):
+            result = run_cli(["run", "-"], input="(println *main-ns*)")
+            assert f"nil{os.linesep}" == result.lisp_out
 
-    @pytest.mark.parametrize("args,ret", cli_args_params)
-    def test_run_stdin_with_args(self, run_cli, args: List[str], ret: str):
-        result = run_cli(
-            ["run", "-", *args],
-            input=self.cli_args_code,
-        )
-        assert ret == result.lisp_out
+        @pytest.mark.parametrize("args,ret", cli_run_args_params)
+        def test_run_stdin_with_args(self, run_cli, args: List[str], ret: str):
+            result = run_cli(
+                ["run", "-", *args],
+                input=cli_run_args_code,
+            )
+            assert ret == result.lisp_out
 
 
 def test_version(run_cli):


### PR DESCRIPTION
No functional changes. Just moving the tests that already exist into nested subclasses based on the particular "form" of `basilisp run` that each is testing (e.g. code string, file, stdin, or namespace).