### PR TITLE
Check for updated source file when formating source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `keys` and `vals` would fail for records (#1030)
  * Fix a bug where operations on records created by `defrecord` failed for fields whose Python-safe names were mangled by the Python compiler (#1029)
  * Fix incorrect line numbers for compiler exceptions in nREPL when evaluating forms in loaded files (#1037)
+ * Fix issue where the compiler exception message from the nREPL server could refer to the initially loaded file instead of the updated one (#1042)
 
 ## [v0.2.1]
 ### Changed

--- a/src/basilisp/lang/source.py
+++ b/src/basilisp/lang/source.py
@@ -78,6 +78,7 @@ def format_source_context(  # pylint: disable=too-many-arguments,too-many-locals
         else:
             cause_range = range(line, line + 1)
 
+        linecache.checkcache(filename=filename)
         if source_lines := linecache.getlines(filename):
             selected_lines: Iterable[str]
             if end_line is None and line > len(source_lines):

--- a/tests/basilisp/source_test.py
+++ b/tests/basilisp/source_test.py
@@ -62,3 +62,47 @@ def test_format_source_context(monkeypatch, source_file, source_file_path):
         " 5   | (let [a 5]" + os.linesep,
         " 6   |   (b))" + os.linesep,
     ] == format_bnc
+
+
+def test_format_source_context_file_change(monkeypatch, source_file, source_file_path):
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            (ns source-test)
+
+            (a)
+            (let [a 5]
+              (b))
+            """
+        )
+    )
+    format_nc1 = format_source_context(
+        source_file_path, 2, end_line=4, disable_color=True
+    )
+    assert [
+        " 1   | " + os.linesep,
+        " 2 > | (ns source-test)" + os.linesep,
+        " 3 > | " + os.linesep,
+        " 4 > | (a)" + os.linesep,
+        " 5   | (let [a 5]" + os.linesep,
+        " 6   |   (b))" + os.linesep,
+    ] == format_nc1
+
+    source_file.write_text(
+        textwrap.dedent(
+            """
+            (ns source-test)
+            (a)
+            (abcd)
+            """
+        )
+    )
+    format_nc2 = format_source_context(
+        source_file_path, 2, end_line=4, disable_color=True
+    )
+    assert [
+        " 1   | " + os.linesep,
+        " 2 > | (ns source-test)" + os.linesep,
+        " 3 > | (a)" + os.linesep,
+        " 4 > | (abcd)" + os.linesep,
+    ] == format_nc2


### PR DESCRIPTION
Hi,

could you please review patch which checks for a newer version of a source file when formatting the source context. It fixes #1042.

I've made the check a permanent feature rather than an option passed to `format_source_contest`, as I couldn't think of a scenario where using the cached version would be preferable if the file had been modified (but I could be wrong).

Added a test to cover this case.

Thanks