### PR TITLE
Add support for Python 3.13; drop support for Python 3.8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         include:
           - version: '3.8'
             tox-env: py38,py38-mypy,py38-lint,safety
@@ -28,6 +28,8 @@ jobs:
             tox-env: py311,py311-mypy,py311-lint,safety
           - version: '3.12'
             tox-env: py312,py312-mypy,py312-lint,format,safety
+          - version: '3.13'
+            tox-env: py311,py311-mypy,py311-lint,safety
           - os: windows-latest
             version: '3.12'
             tox-env: py312,safety

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -188,7 +188,7 @@ jobs:
           tox run-parallel -p 2
 
   report-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
      - run-tests
      - run-pypy-tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,10 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         include:
-          - version: '3.8'
-            tox-env: py38,py38-mypy,py38-lint,safety
           - version: '3.9'
             tox-env: py39,py39-mypy,py39-lint,safety
           - version: '3.10'
@@ -150,8 +148,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ['3.8']
-        tox-env: ['py38']
+        version: ['3.9']
+        tox-env: ['py39']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,10 +32,10 @@ jobs:
             tox-env: py313,py313-mypy,py313-lint,safety
           - os: windows-latest
             version: '3.13'
-            tox-env: py312,safety
+            tox-env: py313,safety
           - os: macos-latest
             version: '3.13'
-            tox-env: py312,safety
+            tox-env: py313,safety
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - version: '3.12'
             tox-env: py312,py312-mypy,py312-lint,format,safety
           - version: '3.13'
-            tox-env: py311,py311-mypy,py311-lint,safety
+            tox-env: py313,py313-mypy,py313-lint,safety
           - os: windows-latest
             version: '3.12'
             tox-env: py312,safety

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,10 +31,10 @@ jobs:
           - version: '3.13'
             tox-env: py313,py313-mypy,py313-lint,safety
           - os: windows-latest
-            version: '3.12'
+            version: '3.13'
             tox-env: py312,safety
           - os: macos-latest
-            version: '3.12'
+            version: '3.13'
             tox-env: py312,safety
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ * Added support for Python 3.13 (#1056)
+
 ### Fixed
  * Fix an issue with `basilisp test` standard streams output that can lead to failures on MS-Windows (#1080)
+
+### Removed
+ * Removed support for Python 3.8 (#1083)
 
 ## [v0.2.4]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added a compiler metadata flag for suppressing warnings when Var indirection is unavoidable (#1052)
  * Added the `--emit-generated-python` CLI argument to control whether generated Python code strings are stored by the runtime for each compiled namespace (#1045)
  * Added the ability to reload namespaces using the `:reload` flag on `require` (#1060)
- * Added support for Python 3.13 (#1056)
 
 ### Changed
  * The compiler will issue a warning when adding any alias that might conflict with any other alias (#1045)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added a compiler metadata flag for suppressing warnings when Var indirection is unavoidable (#1052)
  * Added the `--emit-generated-python` CLI argument to control whether generated Python code strings are stored by the runtime for each compiled namespace (#1045)
  * Added the ability to reload namespaces using the `:reload` flag on `require` (#1060)
+ * Added support for Python 3.13 (#1056)
 
 ### Changed
  * The compiler will issue a warning when adding any alias that might conflict with any other alias (#1045)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐍 basilisp 🐍
 
-A Clojure-compatible(-ish) Lisp dialect targeting Python 3.8+.
+A Clojure-compatible(-ish) Lisp dialect targeting Python 3.9+.
 
 [![PyPI](https://img.shields.io/pypi/v/basilisp.svg?style=flat-square)](https://pypi.org/project/basilisp/) [![python](https://img.shields.io/pypi/pyversions/basilisp.svg?style=flat-square)](https://pypi.org/project/basilisp/) [![pyimpl](https://img.shields.io/pypi/implementation/basilisp.svg?style=flat-square)](https://pypi.org/project/basilisp/) [![readthedocs](https://img.shields.io/readthedocs/basilisp.svg?style=flat-square)](https://basilisp.readthedocs.io/) [![Run tests](https://github.com/basilisp-lang/basilisp/actions/workflows/run-tests.yml/badge.svg?branch=main)](https://github.com/basilisp-lang/basilisp/actions/workflows/run-tests.yml) [![Coveralls github](https://img.shields.io/coveralls/github/basilisp-lang/basilisp.svg?style=flat-square)](https://coveralls.io/github/basilisp-lang/basilisp) [![license](https://img.shields.io/github/license/basilisp-lang/basilisp.svg?style=flat-square)](https://github.com/basilisp-lang/basilisp/blob/master/LICENSE)
 

--- a/docs/differencesfromclojure.rst
+++ b/docs/differencesfromclojure.rst
@@ -16,7 +16,7 @@ Hosted on Python
 ----------------
 
 Unlike Clojure, Basilisp is hosted on the Python VM.
-Basilisp supports versions of Python 3.8+.
+Basilisp supports versions of Python 3.9+.
 Basilisp projects and libraries may both import Python code and be imported by Python code (once the Basilisp runtime has been :ref:`initialized <bootstrapping>` and the import hooks have been installed).
 
 .. _type_differences:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to Basilisp's documentation!
 ====================================
 
-Basilisp is a :ref:`Clojure-compatible(-ish) <differences_from_clojure>` Lisp dialect targeting Python 3.8+.
+Basilisp is a :ref:`Clojure-compatible(-ish) <differences_from_clojure>` Lisp dialect targeting Python 3.9+.
 
 Basilisp compiles down to raw Python 3 code and executes on the Python 3 virtual machine, allowing natural interoperability between existing Python libraries and new Lisp code.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ documentation = "https://basilisp.readthedocs.io/"
 classifiers = [
     # Trove classifiers
     # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 3 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
     "Programming Language :: Python",
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Compilers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -31,24 +30,19 @@ classifiers = [
 include = ["README.md", "LICENSE"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 attrs = ">=22.2.0"
-graphlib-backport = { version = "^1.1.0", python = "<3.9" }
 immutables = ">=0.20,<1.0.0"
 prompt-toolkit = ">=3.0.0,<4.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"
 typing-extensions = ">=4.7.0,<5.0.0"
 
-astor = { version = "^0.8.1", python = "<3.9", optional = true }
 pytest = { version = ">=7.0.0,<9.0.0", optional = true }
 pygments = { version = ">=2.9.0,<3.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 black = ">=24.0.0"
-docutils = [
-    { version = "<0.21", python = "3.8" },
-    { version = "*", python = ">=3.9" }
-]
+docutils = "*"
 isort = "*"
 pygments = "*"
 pytest = ">=7.0.0,<9.0.0"
@@ -80,7 +74,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 88
-target-version = ["py38"]
+target-version = ["py39"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -6,8 +6,9 @@ import pathlib
 import sys
 import textwrap
 import types
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Sequence, Type, Union
+from typing import Any, Callable, Optional, Union
 
 from basilisp import main as basilisp
 from basilisp.lang import compiler as compiler
@@ -109,8 +110,8 @@ def _to_bool(v: Optional[str]) -> Optional[bool]:
 
 
 def _set_envvar_action(
-    var: str, parent: Type[argparse.Action] = argparse.Action
-) -> Type[argparse.Action]:
+    var: str, parent: type[argparse.Action] = argparse.Action
+) -> type[argparse.Action]:
     """Return an argparse.Action instance (deriving from `parent`) that sets the value
     as the default value of the environment variable `var`."""
 
@@ -381,7 +382,7 @@ def _add_runtime_arg_group(parser: argparse.ArgumentParser) -> None:
 
 Handler = Union[
     Callable[[argparse.ArgumentParser, argparse.Namespace], None],
-    Callable[[argparse.ArgumentParser, argparse.Namespace, List[str]], None],
+    Callable[[argparse.ArgumentParser, argparse.Namespace, list[str]], None],
 ]
 
 
@@ -729,7 +730,7 @@ def _add_run_subcommand(parser: argparse.ArgumentParser) -> None:
 def test(
     parser: argparse.ArgumentParser,
     args: argparse.Namespace,
-    extra: List[str],
+    extra: list[str],
 ) -> None:  # pragma: no cover
     init_path(args)
     basilisp.init(_compiler_opts(args))

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -43,10 +43,9 @@ def pytest_configure(config):
     # during tests and restore them afterward.
     out_var = runtime.Var.find(OUT_VAR_SYM)
     err_var = runtime.Var.find(ERR_VAR_SYM)
-    bindings = {
+    if bindings := {
         k: v for k, v in {out_var: sys.stdout, err_var: sys.stderr}.items() if k
-    }
-    if bindings.items():
+    }:
         runtime.push_thread_bindings(lmap.map(bindings))
         config.basilisp_bindings = bindings
 

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -3,9 +3,10 @@ import inspect
 import os
 import sys
 import traceback
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from types import GeneratorType
-from typing import Callable, Iterable, Iterator, Optional, Tuple
+from typing import Callable, Optional
 
 import pytest
 
@@ -210,7 +211,7 @@ class BasilispFile(pytest.File):
     @staticmethod
     def _collected_fixtures(
         ns: runtime.Namespace,
-    ) -> Tuple[Iterable[FixtureFunction], Iterable[FixtureFunction]]:
+    ) -> tuple[Iterable[FixtureFunction], Iterable[FixtureFunction]]:
         """Collect all of the declared fixtures of the namespace."""
         if ns.meta is not None:
             return (

--- a/src/basilisp/contrib/sphinx/autodoc.py
+++ b/src/basilisp/contrib/sphinx/autodoc.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import sys
 import types
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Optional, cast
 
 from sphinx.ext.autodoc import (
     ClassDocumenter,
@@ -51,7 +51,7 @@ _SOURCE_PROTOCOL_KW = kw.keyword("source-protocol", ns=runtime.CORE_NS)
 _METHODS_KW = kw.keyword("methods")
 
 
-def _get_doc(reference: IReference) -> Optional[List[List[str]]]:
+def _get_doc(reference: IReference) -> Optional[list[list[str]]]:
     """Return the docstring of an IReference type (e.g. Namespace or Var)."""
     docstring = reference.meta and reference.meta.val_at(_DOC_KW)
     if docstring is None:
@@ -91,7 +91,7 @@ class NamespaceDocumenter(Documenter):
         v = runtime.first(reader.read_str(self.name))
         if isinstance(v, sym.Symbol) and v.ns is None:
             self.modname = v.name
-            self.objpath: List[str] = []
+            self.objpath: list[str] = []
             self.args = ""
             self.retann = ""
             self.fullname = v.name
@@ -100,7 +100,7 @@ class NamespaceDocumenter(Documenter):
 
     def resolve_name(
         self, modname: str, parents: Any, path: str, base: Any
-    ) -> Tuple[str, List[str]]:
+    ) -> tuple[str, list[str]]:
         """Unused method since parse_name is overridden."""
         return NotImplemented
 
@@ -122,11 +122,11 @@ class NamespaceDocumenter(Documenter):
         self.module = ns.module
         return True
 
-    def get_doc(self) -> Optional[List[List[str]]]:
+    def get_doc(self) -> Optional[list[list[str]]]:
         assert self.object is not None
         return _get_doc(self.object)
 
-    def get_object_members(self, want_all: bool) -> Tuple[bool, List[ObjectMember]]:
+    def get_object_members(self, want_all: bool) -> tuple[bool, list[ObjectMember]]:
         assert self.object is not None
         interns = self.object.interns
 
@@ -145,8 +145,8 @@ class NamespaceDocumenter(Documenter):
         return False, selected
 
     def filter_members(
-        self, members: List[ObjectMember], want_all: bool
-    ) -> List[Tuple[str, Any, bool]]:
+        self, members: list[ObjectMember], want_all: bool
+    ) -> list[tuple[str, Any, bool]]:
         filtered = []
         for member in members:
             name, val = member.__name__, member.object
@@ -173,14 +173,14 @@ class NamespaceDocumenter(Documenter):
         return filtered
 
     def sort_members(
-        self, documenters: List[Tuple["Documenter", bool]], order: str
-    ) -> List[Tuple["Documenter", bool]]:
+        self, documenters: list[tuple["Documenter", bool]], order: str
+    ) -> list[tuple["Documenter", bool]]:
         assert self.object is not None
         if order == "bysource":
             # By the time this method is called, the object isn't hydrated in the
             # Documenter wrapper, so we cannot rely on the existence of that to get
             # line numbers. Instead, we have to build an index manually.
-            line_numbers: Dict[str, int] = {
+            line_numbers: dict[str, int] = {
                 s.name: (
                     cast(int, v.meta.val_at(_LINE_KW, sys.maxsize))
                     if v.meta is not None
@@ -189,7 +189,7 @@ class NamespaceDocumenter(Documenter):
                 for s, v in self.object.interns.items()
             }
 
-            def _line_num(e: Tuple["Documenter", bool]) -> int:
+            def _line_num(e: tuple["Documenter", bool]) -> int:
                 documenter = e[0]
                 _, name = documenter.name.split("::", maxsplit=1)
                 return line_numbers.get(name, sys.maxsize)
@@ -238,7 +238,7 @@ class VarDocumenter(Documenter):
 
     def resolve_name(
         self, modname: str, parents: Any, path: str, base: Any
-    ) -> Tuple[str, List[str]]:
+    ) -> tuple[str, list[str]]:
         """Unused method since parse_name is overridden."""
         return NotImplemented
 
@@ -270,7 +270,7 @@ class VarDocumenter(Documenter):
             return f"{file}:docstring of {self.object}"
         return f"docstring of {self.object}"
 
-    def get_object_members(self, want_all: bool) -> Tuple[bool, List[ObjectMember]]:
+    def get_object_members(self, want_all: bool) -> tuple[bool, list[ObjectMember]]:
         assert self.object is not None
         return False, []
 
@@ -292,7 +292,7 @@ class VarDocumenter(Documenter):
             if self.object.meta.val_at(_DEPRECATED_KW):
                 self.add_line("   :deprecated:", sourcename)
 
-    def get_doc(self) -> Optional[List[List[str]]]:
+    def get_doc(self) -> Optional[list[list[str]]]:
         assert self.object is not None
         return _get_doc(self.object)
 
@@ -372,7 +372,7 @@ class ProtocolDocumenter(VarDocumenter):
             and member.meta.val_at(_PROTOCOL_KW) is True
         )
 
-    def get_object_members(self, want_all: bool) -> Tuple[bool, List[ObjectMember]]:
+    def get_object_members(self, want_all: bool) -> tuple[bool, list[ObjectMember]]:
         assert self.object is not None
         assert want_all
         ns = self.object.ns
@@ -390,8 +390,8 @@ class ProtocolDocumenter(VarDocumenter):
         )
 
     def filter_members(
-        self, members: List[ObjectMember], want_all: bool
-    ) -> List[Tuple[str, Any, bool]]:
+        self, members: list[ObjectMember], want_all: bool
+    ) -> list[tuple[str, Any, bool]]:
         filtered = []
         for member in members:
             name, val = member.__name__, member.object
@@ -428,7 +428,7 @@ class TypeDocumenter(VarDocumenter):
             and issubclass(member.value, IType)
         )
 
-    def get_object_members(self, want_all: bool) -> Tuple[bool, List[ObjectMember]]:
+    def get_object_members(self, want_all: bool) -> tuple[bool, list[ObjectMember]]:
         return ClassDocumenter.get_object_members(self, want_all)
 
 

--- a/src/basilisp/contrib/sphinx/linkcode.py
+++ b/src/basilisp/contrib/sphinx/linkcode.py
@@ -1,5 +1,3 @@
-from typing import Set
-
 from docutils import nodes
 from docutils.nodes import Node
 from sphinx import addnodes
@@ -22,7 +20,7 @@ def doctree_read(app: Sphinx, doctree: Node) -> None:
         if domain != "lpy":
             continue
 
-        uris: Set[str] = set()
+        uris: set[str] = set()
         for signode in objnode:
             if not isinstance(signode, addnodes.desc_signature):
                 continue

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -5,19 +5,11 @@ import os
 import os.path
 import sys
 import types
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from functools import lru_cache
 from importlib.abc import MetaPathFinder, SourceLoader
 from importlib.machinery import ModuleSpec
-from typing import (
-    Any,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Sequence,
-    cast,
-)
+from typing import Any, Optional, cast
 
 from typing_extensions import TypedDict
 
@@ -49,7 +41,7 @@ def _w_long(x: int) -> bytes:
 
 
 def _basilisp_bytecode(
-    mtime: int, source_size: int, code: List[types.CodeType]
+    mtime: int, source_size: int, code: list[types.CodeType]
 ) -> bytes:
     """Return the bytes for a Basilisp bytecode cache file."""
     data = bytearray(MAGIC_NUMBER)
@@ -61,7 +53,7 @@ def _basilisp_bytecode(
 
 def _get_basilisp_bytecode(
     fullname: str, mtime: int, source_size: int, cache_data: bytes
-) -> List[types.CodeType]:
+) -> list[types.CodeType]:
     """Unmarshal the bytes from a Basilisp bytecode cache file, validating the
     file header prior to returning. If the file header does not match, throw
     an exception."""
@@ -104,7 +96,7 @@ def _cache_from_source(path: str) -> str:
     return os.path.join(cache_path, filename + ".lpyc")
 
 
-@lru_cache()
+@lru_cache
 def _is_package(path: str) -> bool:
     """Return True if path should be considered a Basilisp (and consequently
     a Python) package.
@@ -118,7 +110,7 @@ def _is_package(path: str) -> bool:
     return False
 
 
-@lru_cache()
+@lru_cache
 def _is_namespace_package(path: str) -> bool:
     """Return True if the current directory is a namespace Basilisp package.
 
@@ -270,7 +262,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):  # pylint: disable=abstrac
             # in a synthetic namespace.
             #
             # The target namespace is free to interpret
-            code: List[types.CodeType] = []
+            code: list[types.CodeType] = []
             path = "/" + "/".join(fullname.split("."))
             try:
                 compiler.load(
@@ -347,7 +339,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):  # pylint: disable=abstrac
             # During compilation, bytecode objects are added to the list which is
             # passed to the compiler. The collected bytecodes will be used to generate
             # an .lpyc file for caching the compiled file.
-            all_bytecode: List[types.CodeType] = []
+            all_bytecode: list[types.CodeType] = []
 
             logger.debug(f"Reading and compiling Basilisp module '{fullname}'")
             # Cast to basic ReaderForm since the reader can never return a reader conditional
@@ -412,7 +404,7 @@ class BasilispImporter(MetaPathFinder, SourceLoader):  # pylint: disable=abstrac
         else:
             try:
                 self._exec_cached_module(fullname, spec.loader_state, path_stats, ns)
-            except (EOFError, ImportError, IOError, OSError) as e:
+            except (EOFError, ImportError, OSError) as e:
                 logger.debug(f"Failed to load cached Basilisp module: {e}")
                 self._exec_module(fullname, spec.loader_state, path_stats, ns)
 

--- a/src/basilisp/io.lpy
+++ b/src/basilisp/io.lpy
@@ -34,7 +34,7 @@
       (let [path (.-path f)]
         ;; On MS-Windows, extracting an absolute path from the URL
         ;; incorrectly adds a leading `/', .e.g. /C:\xyz.
-        (pathlib/Path #?(:windows (if (os.path/isabs path) (subs path 1) path)
+        (pathlib/Path #?(:windows (if (str/starts-with? path "/") (subs path 1) path)
                          :default path)))
       (throw
        (ex-info "Cannot coerce non-File URL to pathlib.Path"

--- a/src/basilisp/io.lpy
+++ b/src/basilisp/io.lpy
@@ -411,13 +411,6 @@
        (clean-binary-mode)
        (make-output-stream f)))
 
-(defmacro ^:private buf-size
-  "In Python 3.8+, a default buffer size value is supplied if 0 is given. In earlier
-  versions, the default value is supplied via keyword argument and providing 0 ends
-  up causing 0 length buffers to be used."
-  []
-  #?(:py38+ 0 :py37- 16384))
-
 (defmulti copy-file
   "Multi-method implementation for copying files.
 
@@ -429,16 +422,16 @@
   (fn [input output _] [(type input) (type output)]))
 
 (defmethod copy-file [io/TextIOBase io/TextIOBase]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (shutil/copyfileobj input output ** :length buffer-size))
 
 (defmethod copy-file [pathlib/Path io/TextIOBase]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (with-open [r (reader input)]
     (shutil/copyfileobj r output ** :length buffer-size)))
 
 (defmethod copy-file [io/TextIOBase pathlib/Path]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (with-open [w (writer output)]
     (shutil/copyfileobj input w ** :length buffer-size)))
 
@@ -452,12 +445,12 @@
 
 (defmethod copy-file [io/BufferedIOBase io/TextIOBase]
   ;; Decode a binary buffer into a text buffer
-  [input output {:keys [buffer-size encoding] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size encoding] :or {buffer-size 0}}]
   (with-open [r (reader input :encoding encoding)]
     (shutil/copyfileobj r output ** :length buffer-size)))
 
 (defmethod copy-file [io/BufferedIOBase io/BufferedIOBase]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (shutil/copyfileobj input output ** :length buffer-size))
 
 (defmethod copy-file [python/bytes io/BufferedIOBase]
@@ -465,12 +458,12 @@
   (copy-file (input-stream input) output opts))
 
 (defmethod copy-file [pathlib/Path io/BufferedIOBase]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (with-open [r (input-stream input)]
     (shutil/copyfileobj r output ** :length buffer-size)))
 
 (defmethod copy-file [io/BufferedIOBase pathlib/Path]
-  [input output {:keys [buffer-size] :or {buffer-size (buf-size)}}]
+  [input output {:keys [buffer-size] :or {buffer-size 0}}]
   (with-open [w (output-stream output)]
     (shutil/copyfileobj input w ** :length buffer-size)))
 

--- a/src/basilisp/lang/compiler/__init__.py
+++ b/src/basilisp/lang/compiler/__init__.py
@@ -1,10 +1,11 @@
 import ast
 import itertools
 import os
-import sys
 import types
+from ast import unparse
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Optional
 
 from basilisp.lang import list as llist
 from basilisp.lang import map as lmap
@@ -43,33 +44,10 @@ from basilisp.util import Maybe
 _DEFAULT_FN = "__lisp_expr__"
 
 
-if sys.version_info >= (3, 9):
-    from ast import unparse
-
-    def to_py_str(t: ast.AST) -> str:
-        """Return a string of the Python code which would generate the input
-        AST node."""
-        return unparse(t) + "\n\n"
-
-else:
-    try:
-        from astor import code_gen as codegen
-
-        def to_py_str(t: ast.AST) -> str:
-            """Return a string of the Python code which would generate the input
-            AST node."""
-            return codegen.to_source(t)
-
-    except ImportError:
-        import warnings
-
-        def to_py_str(t: ast.AST) -> str:  # pylint: disable=unused-argument
-            warnings.warn(
-                "Unable to generate Python code from generated AST due to missing "
-                "dependency 'astor'",
-                RuntimeWarning,
-            )
-            return ""
+def to_py_str(t: ast.AST) -> str:
+    """Return a string of the Python code which would generate the input
+    AST node."""
+    return unparse(t) + "\n\n"
 
 
 BytecodeCollector = Callable[[types.CodeType], None]
@@ -293,7 +271,7 @@ def compile_module(
 
 
 def compile_bytecode(
-    code: List[types.CodeType],
+    code: list[types.CodeType],
     gctx: GeneratorContext,
     optimizer: PythonASTOptimizer,
     ns: runtime.Namespace,

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -16,7 +16,7 @@ from decimal import Decimal
 from fractions import Fraction
 from functools import partial, wraps
 from re import Pattern
-from typing import Any, Callable, Deque, Optional, TypeVar, Union, cast
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 import attr
 from typing_extensions import Literal
@@ -328,12 +328,12 @@ class AnalyzerContext:
     ) -> None:
         self._allow_unresolved_symbols = allow_unresolved_symbols
         self._filename = Maybe(filename).or_else_get(DEFAULT_COMPILER_FILE_PATH)
-        self._func_ctx: Deque[FunctionContext] = collections.deque([])
-        self._is_quoted: Deque[bool] = collections.deque([])
+        self._func_ctx: collections.deque[FunctionContext] = collections.deque([])
+        self._is_quoted: collections.deque[bool] = collections.deque([])
         self._opts = (
             Maybe(opts).map(lmap.map).or_else_get(lmap.PersistentMap.empty())  # type: ignore[arg-type, unused-ignore]
         )
-        self._recur_points: Deque[RecurPoint] = collections.deque([])
+        self._recur_points: collections.deque[RecurPoint] = collections.deque([])
         self._should_macroexpand = should_macroexpand
         self._st = collections.deque([SymbolTable("<Top>", is_context_boundary=True)])
         self._syntax_pos = collections.deque([NodeSyntacticPosition.EXPR])

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -10,30 +10,13 @@ import re
 import sys
 import uuid
 from collections import defaultdict
+from collections.abc import Collection, Iterable, Mapping, MutableMapping, MutableSet
 from datetime import datetime
 from decimal import Decimal
 from fractions import Fraction
 from functools import partial, wraps
-from typing import (
-    Any,
-    Callable,
-    Collection,
-    Deque,
-    FrozenSet,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    MutableSet,
-    Optional,
-    Pattern,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from re import Pattern
+from typing import Any, Callable, Deque, Optional, TypeVar, Union, cast
 
 import attr
 from typing_extensions import Literal
@@ -688,7 +671,7 @@ T_node = TypeVar("T_node", bound=Node)
 LispAnalyzer = Callable[[T_form, AnalyzerContext], T_node]
 
 
-def _loc(form: T_form) -> Optional[Tuple[int, int, int, int]]:
+def _loc(form: T_form) -> Optional[tuple[int, int, int, int]]:
     """Fetch the location of the form in the original filename from the
     input form, if it has metadata."""
     # Technically, IMeta is sufficient for fetching `form.meta` but the
@@ -741,7 +724,7 @@ def _clean_meta(meta: Optional[lmap.PersistentMap]) -> Optional[lmap.PersistentM
 
 def _body_ast(
     form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext
-) -> Tuple[Iterable[Node], Node]:
+) -> tuple[Iterable[Node], Node]:
     """Analyze the form and produce a body of statement nodes and a single
     return expression node.
 
@@ -773,7 +756,7 @@ def _body_ast(
 
 def _call_args_ast(
     form: ISeq, ctx: AnalyzerContext
-) -> Tuple[Iterable[Node], KeywordArgs]:
+) -> tuple[Iterable[Node], KeywordArgs]:
     """Return a tuple of positional arguments and keyword arguments, splitting at the
     keyword argument marker symbol '**'."""
     with ctx.expr_pos():
@@ -1125,7 +1108,7 @@ def _def_ast(  # pylint: disable=too-many-locals,too-many-statements
 
 def __deftype_method_param_bindings(
     params: vec.PersistentVector, ctx: AnalyzerContext, special_form: sym.Symbol
-) -> Tuple[bool, int, List[Binding]]:
+) -> tuple[bool, int, list[Binding]]:
     """Generate parameter bindings for `deftype*` or `reify*` methods.
 
     Return a tuple containing a boolean, indicating if the parameter bindings
@@ -1199,8 +1182,9 @@ def __deftype_classmethod(
     kwarg_support: Optional[KeywordArgSupport] = None,
 ) -> DefTypeClassMethod:
     """Emit a node for a :classmethod member of a `deftype*` form."""
-    with ctx.hide_parent_symbol_table(), ctx.new_symbol_table(
-        method_name, is_context_boundary=True
+    with (
+        ctx.hide_parent_symbol_table(),
+        ctx.new_symbol_table(method_name, is_context_boundary=True),
     ):
         try:
             cls_arg = args[0]
@@ -1390,8 +1374,9 @@ def __deftype_staticmethod(
     kwarg_support: Optional[KeywordArgSupport] = None,
 ) -> DefTypeStaticMethod:
     """Emit a node for a :staticmethod member of a `deftype*` form."""
-    with ctx.hide_parent_symbol_table(), ctx.new_symbol_table(
-        method_name, is_context_boundary=True
+    with (
+        ctx.hide_parent_symbol_table(),
+        ctx.new_symbol_table(method_name, is_context_boundary=True),
     ):
         has_vargs, fixed_arity, param_nodes = __deftype_method_param_bindings(
             args, ctx, SpecialForm.DEFTYPE
@@ -1505,7 +1490,7 @@ def __deftype_or_reify_prop_or_method_arity(
 def __deftype_or_reify_method_node_from_arities(
     form: Union[llist.PersistentList, ISeq],
     ctx: AnalyzerContext,
-    arities: List[DefTypeMethodArity],
+    arities: list[DefTypeMethodArity],
     special_form: sym.Symbol,
 ) -> DefTypeMember:
     """Roll all of the collected `deftype*` or `reify*` arities up into a single
@@ -1542,7 +1527,7 @@ def __deftype_or_reify_method_node_from_arities(
         )
 
     assert (
-        len(set(arity.name for arity in arities)) <= 1
+        len({arity.name for arity in arities}) <= 1
     ), "arities must have the same name defined"
 
     if len(arities) > 1 and any(arity.kwarg_support is not None for arity in arities):
@@ -1564,7 +1549,7 @@ def __deftype_or_reify_method_node_from_arities(
 
 def __deftype_or_reify_impls(  # pylint: disable=too-many-branches,too-many-locals  # noqa: MC0001
     form: ISeq, ctx: AnalyzerContext, special_form: sym.Symbol
-) -> Tuple[List[DefTypeBase], List[DefTypeMember]]:
+) -> tuple[list[DefTypeBase], list[DefTypeMember]]:
     """Roll up `deftype*` and `reify*` declared bases and method implementations."""
     assert special_form in {SpecialForm.DEFTYPE, SpecialForm.REIFY}
 
@@ -1612,7 +1597,7 @@ def __deftype_or_reify_impls(  # pylint: disable=too-many-branches,too-many-loca
     # keys to act as an ordered set of members we've seen. We don't want to register
     # duplicates.
     member_order = {}
-    methods: MutableMapping[str, List[DefTypeMethodArity]] = collections.defaultdict(
+    methods: MutableMapping[str, list[DefTypeMethodArity]] = collections.defaultdict(
         list
     )
     py_members: MutableMapping[str, DefTypePythonMember] = {}
@@ -1653,7 +1638,7 @@ def __deftype_or_reify_impls(  # pylint: disable=too-many-branches,too-many-loca
                 )
             methods[member.name].append(member)
 
-    members: List[DefTypeMember] = []
+    members: list[DefTypeMember] = []
     for member_name in member_order:
         arities = methods.get(member_name)
         if arities is not None:
@@ -1686,18 +1671,18 @@ def __is_reify_member(mem) -> bool:
 
 if platform.python_implementation() == "CPython":
 
-    def __is_type_weakref(tp: Type) -> bool:
+    def __is_type_weakref(tp: type) -> bool:
         return getattr(tp, "__weakrefoffset__", 0) > 0
 
 else:
 
-    def __is_type_weakref(tp: Type) -> bool:  # pylint: disable=unused-argument
+    def __is_type_weakref(tp: type) -> bool:  # pylint: disable=unused-argument
         return True
 
 
 def __get_artificially_abstract_members(
     ctx: AnalyzerContext, special_form: sym.Symbol, interface: DefTypeBase
-) -> Set[str]:
+) -> set[str]:
     if (
         declared_abstract_members := _artificially_abstract_members(
             cast(IMeta, interface.form)
@@ -1780,8 +1765,8 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
 
     supertype_possibly_weakref = []
     unverifiably_abstract = set()
-    artificially_abstract: Set[DefTypeBase] = set()
-    artificially_abstract_base_members: Set[str] = set()
+    artificially_abstract: set[DefTypeBase] = set()
+    artificially_abstract_base_members: set[str] = set()
     is_member = {
         SpecialForm.DEFTYPE: __is_deftype_member,
         SpecialForm.REIFY: __is_reify_member,
@@ -1790,7 +1775,7 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
     field_names = frozenset(fields)
     member_names = frozenset(deftype_or_reify_python_member_names(members))
     all_member_names = field_names.union(member_names)
-    all_interface_methods: Set[str] = set()
+    all_interface_methods: set[str] = set()
     for interface in interfaces:
         if isinstance(interface, (MaybeClass, MaybeHostForm)):
             interface_type = interface.target
@@ -1852,8 +1837,8 @@ def __deftype_and_reify_impls_are_all_abstract(  # pylint: disable=too-many-loca
             )
             supertype_possibly_weakref.append(__is_type_weakref(interface_type))
         elif is_abstract(interface_type):
-            interface_names: FrozenSet[str] = interface_type.__abstractmethods__
-            interface_property_names: FrozenSet[str] = frozenset(
+            interface_names: frozenset[str] = interface_type.__abstractmethods__
+            interface_property_names: frozenset[str] = frozenset(
                 method
                 for method in interface_names
                 if isinstance(getattr(interface_type, method), property)
@@ -2093,9 +2078,14 @@ def __fn_method_ast(  # pylint: disable=too-many-locals
 
         fn_loop_id = genname("fn_arity" if fnname is None else fnname.name)
         with ctx.new_recur_point(fn_loop_id, param_nodes):
-            with ctx.new_func_ctx(
-                FunctionContext.ASYNC_FUNCTION if is_async else FunctionContext.FUNCTION
-            ), ctx.expr_pos():
+            with (
+                ctx.new_func_ctx(
+                    FunctionContext.ASYNC_FUNCTION
+                    if is_async
+                    else FunctionContext.FUNCTION
+                ),
+                ctx.expr_pos(),
+            ):
                 stmts, ret = _body_ast(form.rest, ctx)
             method = FnArity(
                 form=form,
@@ -2142,12 +2132,12 @@ InlineMeta = Union[Callable, bool, None]
 
 
 @functools.singledispatch
-def __unquote_args(f: LispForm, _: FrozenSet[sym.Symbol]):
+def __unquote_args(f: LispForm, _: frozenset[sym.Symbol]):
     return f
 
 
 @__unquote_args.register(sym.Symbol)
-def __unquote_args_sym(f: sym.Symbol, args: FrozenSet[sym.Symbol]):
+def __unquote_args_sym(f: sym.Symbol, args: frozenset[sym.Symbol]):
     if f in args:
         return llist.l(reader._UNQUOTE, f)
     return f
@@ -2512,7 +2502,7 @@ T_alias_node = TypeVar("T_alias_node", ImportAlias, RequireAlias)
 
 def _do_warn_on_import_or_require_name_clash(
     ctx: AnalyzerContext,
-    alias_nodes: List[T_alias_node],
+    alias_nodes: list[T_alias_node],
     action: Literal["import", "require"],
 ) -> None:
     assert alias_nodes, "Must have at least one alias"
@@ -2663,7 +2653,7 @@ def _do_warn_on_arity_mismatch(
     fn: VarRef, form: Union[llist.PersistentList, ISeq], ctx: AnalyzerContext
 ) -> None:
     if ctx.warn_on_arity_mismatch and getattr(fn.var.value, "_basilisp_fn", False):
-        arities: Optional[Tuple[Union[int, kw.Keyword]]] = getattr(
+        arities: Optional[tuple[Union[int, kw.Keyword]]] = getattr(
             fn.var.value, "arities", None
         )
         if arities is not None:
@@ -2678,7 +2668,7 @@ def _do_warn_on_arity_mismatch(
             if has_variadic and (max_fixed_arity is None or num_args > max_fixed_arity):
                 return
             if num_args not in fixed_arities:
-                report_arities = cast(Set[Union[int, str]], set(fixed_arities))
+                report_arities = cast(set[Union[int, str]], set(fixed_arities))
                 if has_variadic:
                     report_arities.discard(cast(int, max_fixed_arity))
                     report_arities.add(f"{max_fixed_arity}+")

--- a/src/basilisp/lang/compiler/exception.py
+++ b/src/basilisp/lang/compiler/exception.py
@@ -2,7 +2,7 @@ import ast
 import os
 from enum import Enum
 from types import TracebackType
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Optional, Union
 
 import attr
 
@@ -67,7 +67,7 @@ class CompilerException(IExceptionInfo):
 
     @property
     def data(self) -> IPersistentMap:
-        d: Dict[kw.Keyword, Any] = {_PHASE: self.phase.value}
+        d: dict[kw.Keyword, Any] = {_PHASE: self.phase.value}
         d[_FILE] = self.filename
         loc = None
         if self.form is not None:
@@ -112,10 +112,10 @@ class CompilerException(IExceptionInfo):
 @format_exception.register(CompilerException)
 def format_compiler_exception(  # pylint: disable=too-many-branches,unused-argument
     e: CompilerException,
-    tp: Optional[Type[Exception]] = None,
+    tp: Optional[type[Exception]] = None,
     tb: Optional[TracebackType] = None,
     disable_color: Optional[bool] = None,
-) -> List[str]:
+) -> list[str]:
     """Format a compiler exception as a list of newline-terminated strings.
 
     If `disable_color` is True, no color formatting will be applied to the source

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -17,16 +17,7 @@ from fractions import Fraction
 from functools import partial, wraps
 from itertools import chain
 from re import Pattern
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Deque,
-    Generic,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Callable, Generic, Optional, TypeVar, Union, cast
 
 import attr
 from typing_extensions import Concatenate, ParamSpec
@@ -229,10 +220,10 @@ class GeneratorContext:
     ) -> None:
         self._filename = Maybe(filename).or_else_get(DEFAULT_COMPILER_FILE_PATH)
         self._opts = Maybe(opts).map(lmap.map).or_else_get(lmap.m())  # type: ignore
-        self._recur_points: Deque[RecurPoint] = collections.deque([])
+        self._recur_points: collections.deque[RecurPoint] = collections.deque([])
         self._st = collections.deque([SymbolTable("<Top>", is_context_boundary=True)])
-        self._this: Deque[sym.Symbol] = collections.deque([])
-        self._var_indirection_override: Deque[bool] = collections.deque([])
+        self._this: collections.deque[sym.Symbol] = collections.deque([])
+        self._var_indirection_override: collections.deque[bool] = collections.deque([])
 
         if logger.isEnabledFor(logging.DEBUG):  # pragma: no cover
             for k, v in self._opts.items():

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -103,7 +103,6 @@ from basilisp.lang.compiler.utils import (
     ast_AsyncFunctionDef,
     ast_ClassDef,
     ast_FunctionDef,
-    ast_index,
 )
 from basilisp.lang.interfaces import IMeta, IRecord, ISeq, ISeqable, IType
 from basilisp.lang.runtime import CORE_NS
@@ -1985,7 +1984,7 @@ def __multi_arity_dispatch_fn(  # pylint: disable=too-many-arguments,too-many-lo
         ret_ann_ast = (
             ast.Subscript(
                 value=ast.Name(id=_UNION_ALIAS, ctx=ast.Load()),
-                slice=ast_index(ast.Tuple(elts=ret_ann_asts, ctx=ast.Load())),
+                slice=ast.Tuple(elts=ret_ann_asts, ctx=ast.Load()),
                 ctx=ast.Load(),
             )
             if ret_ann_asts

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -1,17 +1,7 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, MutableMapping, Sequence
 from enum import Enum
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Iterable,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 import attr
 
@@ -196,7 +186,7 @@ class Node(ABC, Generic[T]):
                 f(child, *args, **kwargs)
 
     def fix_missing_locations(
-        self, form_loc: Optional[Tuple[int, int, int, int]] = None
+        self, form_loc: Optional[tuple[int, int, int, int]] = None
     ) -> "Node[T]":
         """Return a transformed copy of this node with location in this node's
         environment updated to match the `form_loc` if given, or using its

--- a/src/basilisp/lang/compiler/optimizer.py
+++ b/src/basilisp/lang/compiler/optimizer.py
@@ -1,18 +1,19 @@
 import ast
 import functools
 from collections import deque
+from collections.abc import Iterable
 from contextlib import contextmanager
-from typing import Deque, Iterable, List, Optional, Set
+from typing import Deque, Optional
 
 from basilisp.lang.compiler.constants import OPERATOR_ALIAS
 from basilisp.lang.compiler.utils import ast_FunctionDef, ast_index
 
 
-def _filter_dead_code(nodes: Iterable[ast.stmt]) -> List[ast.stmt]:
+def _filter_dead_code(nodes: Iterable[ast.stmt]) -> list[ast.stmt]:
     """Return a list of body nodes, trimming out unreachable code (any
     statements appearing after `break`, `continue`, `raise`, and `return`
     nodes)."""
-    new_nodes: List[ast.stmt] = []
+    new_nodes: list[ast.stmt] = []
     for node in nodes:
         if isinstance(node, (ast.Break, ast.Continue, ast.Raise, ast.Return)):
             new_nodes.append(node)
@@ -125,7 +126,7 @@ class PythonASTOptimizer(ast.NodeTransformer):
     __slots__ = ("_global_ctx",)
 
     def __init__(self):
-        self._global_ctx: Deque[Set[str]] = deque([set()])
+        self._global_ctx: Deque[set[str]] = deque([set()])
 
     @contextmanager
     def _new_global_context(self):
@@ -137,7 +138,7 @@ class PythonASTOptimizer(ast.NodeTransformer):
             self._global_ctx.pop()
 
     @property
-    def _global_context(self) -> Set[str]:
+    def _global_context(self) -> set[str]:
         """Return the current Python `global` context."""
         return self._global_ctx[-1]
 

--- a/src/basilisp/lang/compiler/optimizer.py
+++ b/src/basilisp/lang/compiler/optimizer.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from typing import Deque, Optional
 
 from basilisp.lang.compiler.constants import OPERATOR_ALIAS
-from basilisp.lang.compiler.utils import ast_FunctionDef, ast_index
+from basilisp.lang.compiler.utils import ast_FunctionDef
 
 
 def _filter_dead_code(nodes: Iterable[ast.stmt]) -> list[ast.stmt]:
@@ -109,15 +109,13 @@ def _optimize_operator_call_attr(  # pylint: disable=too-many-return-statements
             target, index = node.args
             assert len(node.args) == 2
             return ast.Delete(
-                targets=[
-                    ast.Subscript(value=target, slice=ast_index(index), ctx=ast.Del())
-                ]
+                targets=[ast.Subscript(value=target, slice=index, ctx=ast.Del())]
             )
 
         if fn.attr == "getitem":
             target, index = node.args
             assert len(node.args) == 2
-            return ast.Subscript(value=target, slice=ast_index(index), ctx=ast.Load())
+            return ast.Subscript(value=target, slice=index, ctx=ast.Load())
 
     return node
 

--- a/src/basilisp/lang/compiler/utils.py
+++ b/src/basilisp/lang/compiler/utils.py
@@ -2,15 +2,9 @@ import ast
 import sys
 from functools import partial
 
-if sys.version_info >= (3, 9):
 
-    def ast_index(v: ast.expr) -> ast.expr:
-        return v
-
-else:
-
-    def ast_index(v: ast.expr) -> ast.Index:
-        return ast.Index(value=v)
+def ast_index(v: ast.expr) -> ast.expr:
+    return v
 
 
 if sys.version_info >= (3, 12):

--- a/src/basilisp/lang/compiler/utils.py
+++ b/src/basilisp/lang/compiler/utils.py
@@ -2,11 +2,6 @@ import ast
 import sys
 from functools import partial
 
-
-def ast_index(v: ast.expr) -> ast.expr:
-    return v
-
-
 if sys.version_info >= (3, 12):
     ast_AsyncFunctionDef = partial(ast.AsyncFunctionDef, type_params=[])
     ast_ClassDef = partial(ast.ClassDef, type_params=[])
@@ -17,4 +12,4 @@ else:
     ast_FunctionDef = ast.FunctionDef
 
 
-__all__ = ("ast_ClassDef", "ast_FunctionDef", "ast_index")
+__all__ = ("ast_ClassDef", "ast_FunctionDef")

--- a/src/basilisp/lang/exception.py
+++ b/src/basilisp/lang/exception.py
@@ -2,7 +2,7 @@ import functools
 import sys
 import traceback
 from types import TracebackType
-from typing import List, Optional, Type
+from typing import Optional
 
 import attr
 
@@ -27,10 +27,10 @@ class ExceptionInfo(IExceptionInfo):
 @functools.singledispatch
 def format_exception(  # pylint: disable=unused-argument
     e: Optional[BaseException],
-    tp: Optional[Type[BaseException]] = None,
+    tp: Optional[type[BaseException]] = None,
     tb: Optional[TracebackType] = None,
     disable_color: Optional[bool] = None,
-) -> List[str]:
+) -> list[str]:
     """Format an exception into something readable, returning a list of newline
     terminated strings.
 
@@ -50,7 +50,7 @@ def format_exception(  # pylint: disable=unused-argument
 
 def print_exception(
     e: Optional[BaseException],
-    tp: Optional[Type[BaseException]] = None,
+    tp: Optional[type[BaseException]] = None,
     tb: Optional[TracebackType] = None,
 ) -> None:
     """Print the given exception `e` using Basilisp's own exception formatting.

--- a/src/basilisp/lang/interfaces.py
+++ b/src/basilisp/lang/interfaces.py
@@ -1,18 +1,14 @@
 import itertools
 from abc import ABC, abstractmethod
-from collections.abc import Hashable, Sized
+from collections.abc import Hashable, Iterable, Iterator, Mapping, Sequence, Sized
 from typing import (
     AbstractSet,
     Any,
     Callable,
     Final,
     Generic,
-    Iterable,
-    Iterator,
-    Mapping,
     Optional,
     Protocol,
-    Sequence,
     TypeVar,
     Union,
     overload,

--- a/src/basilisp/lang/keyword.py
+++ b/src/basilisp/lang/keyword.py
@@ -1,6 +1,7 @@
 import threading
+from collections.abc import Iterable
 from functools import total_ordering
-from typing import Iterable, Optional, Union
+from typing import Optional, Union
 
 from typing_extensions import Unpack
 

--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -1,16 +1,7 @@
 from builtins import map as pymap
+from collections.abc import Iterable, Mapping
 from itertools import islice
-from typing import (
-    Any,
-    Callable,
-    Iterable,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Optional, TypeVar, Union, cast
 
 from immutables import Map as _Map
 from immutables import MapMutation
@@ -129,7 +120,7 @@ class TransientMap(ITransientMap[K, V]):
 
 
 def map_lrepr(  # pylint: disable=too-many-locals
-    entries: Callable[[], Iterable[Tuple[Any, Any]]],
+    entries: Callable[[], Iterable[tuple[Any, Any]]],
     start: str,
     end: str,
     meta: Optional[IPersistentMap] = None,
@@ -237,7 +228,7 @@ class PersistentMap(
     @classmethod
     def from_coll(
         cls,
-        members: Union[Mapping[K, V], Iterable[Tuple[K, V]]],
+        members: Union[Mapping[K, V], Iterable[tuple[K, V]]],
         meta: Optional[IPersistentMap] = None,
     ) -> "PersistentMap[K, V]":
         return PersistentMap(_Map(members), meta=meta)

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -3,12 +3,14 @@ import math
 import re
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from decimal import Decimal
 from fractions import Fraction
 from functools import singledispatch
 from itertools import islice
 from pathlib import Path
-from typing import Any, Iterable, Pattern, Union, cast
+from re import Pattern
+from typing import Any, Union, cast
 
 from typing_extensions import TypedDict, Unpack
 

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -14,7 +14,7 @@ from fractions import Fraction
 from itertools import chain
 from re import Pattern
 from types import TracebackType
-from typing import Any, Callable, Deque, NoReturn, Optional, TypeVar, Union, cast
+from typing import Any, Callable, NoReturn, Optional, TypeVar, Union, cast
 
 import attr
 from typing_extensions import Unpack
@@ -385,9 +385,9 @@ class ReaderContext:
         self._process_reader_cond = process_reader_cond
         self._reader = reader
         self._resolve = Maybe(resolver).or_else_get(lambda x: x)
-        self._in_anon_fn: Deque[bool] = collections.deque([])
-        self._syntax_quoted: Deque[bool] = collections.deque([])
-        self._gensym_env: Deque[GenSymEnvironment] = collections.deque([])
+        self._in_anon_fn: collections.deque[bool] = collections.deque([])
+        self._syntax_quoted: collections.deque[bool] = collections.deque([])
+        self._gensym_env: collections.deque[GenSymEnvironment] = collections.deque([])
         self._eof = eof
 
     @property

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -8,30 +8,13 @@ import io
 import os
 import re
 import uuid
+from collections.abc import Collection, Iterable, MutableMapping, Sequence
 from datetime import datetime
 from fractions import Fraction
 from itertools import chain
+from re import Pattern
 from types import TracebackType
-from typing import (
-    Any,
-    Callable,
-    Collection,
-    Deque,
-    Dict,
-    Iterable,
-    List,
-    MutableMapping,
-    NoReturn,
-    Optional,
-    Pattern,
-    Sequence,
-    Set,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Deque, NoReturn, Optional, TypeVar, Union, cast
 
 import attr
 from typing_extensions import Unpack
@@ -148,7 +131,7 @@ class SyntaxError(Exception):
         )
 
     def __str__(self):
-        keys: Dict[str, Union[str, int]] = {}
+        keys: dict[str, Union[str, int]] = {}
         if self.filename is not None:
             keys["file"] = self.filename
         if self.line is not None and self.col is not None:
@@ -164,10 +147,10 @@ class SyntaxError(Exception):
 @format_exception.register(SyntaxError)
 def format_syntax_error(  # pylint: disable=unused-argument
     e: SyntaxError,
-    tp: Optional[Type[Exception]] = None,
+    tp: Optional[type[Exception]] = None,
     tb: Optional[TracebackType] = None,
     disable_color: Optional[bool] = None,
-) -> List[str]:
+) -> list[str]:
     """If `disable_color` is True, no color formatting will be applied to the source
     code."""
 
@@ -269,7 +252,7 @@ class StreamReader:
         return self._line[self._idx]
 
     @property
-    def loc(self) -> Tuple[int, int]:
+    def loc(self) -> tuple[int, int]:
         """Return the location of the character returned by `peek` as a tuple of
         (line, col)."""
         return self.line, self.col
@@ -494,7 +477,7 @@ class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
 
     def __init__(
         self,
-        form: llist.PersistentList[Tuple[kw.Keyword, ReaderForm]],
+        form: llist.PersistentList[tuple[kw.Keyword, ReaderForm]],
         is_splicing: bool = False,
     ):
         self._form = form
@@ -502,13 +485,13 @@ class ReaderConditional(ILookup[kw.Keyword, ReaderForm], ILispObject):
         self._is_splicing = is_splicing
 
     @staticmethod
-    def _compile_feature_vec(form: IPersistentList[Tuple[kw.Keyword, ReaderForm]]):
-        found_features: Set[kw.Keyword] = set()
-        feature_list: List[Tuple[kw.Keyword, ReaderForm]] = []
+    def _compile_feature_vec(form: IPersistentList[tuple[kw.Keyword, ReaderForm]]):
+        found_features: set[kw.Keyword] = set()
+        feature_list: list[tuple[kw.Keyword, ReaderForm]] = []
 
         try:
             for k, v in partition(
-                cast(Sequence[Tuple[kw.Keyword, ReaderForm]], form), 2
+                cast(Sequence[tuple[kw.Keyword, ReaderForm]], form), 2
             ):
                 if not isinstance(k, kw.Keyword):
                     raise SyntaxError(
@@ -591,10 +574,10 @@ def _with_loc(f: W) -> W:
 
 def _read_namespaced(
     ctx: ReaderContext, allowed_suffix: Optional[str] = None
-) -> Tuple[Optional[str], str]:
+) -> tuple[Optional[str], str]:
     """Read a namespaced token (keyword or symbol) from the input stream."""
-    ns: List[str] = []
-    name: List[str] = []
+    ns: list[str] = []
+    name: list[str] = []
     reader = ctx.reader
     has_ns = False
     while True:
@@ -644,7 +627,7 @@ def _read_coll(
 ):
     """Read a collection from the input stream and create the
     collection using f."""
-    coll: List = []
+    coll: list = []
     reader = ctx.reader
     while True:
         char = reader.peek()
@@ -839,7 +822,7 @@ def _read_num(  # noqa: C901  # pylint: disable=too-many-locals,too-many-stateme
     ctx: ReaderContext,
 ) -> MaybeNumber:
     """Return a numeric (complex, Decimal, float, int, Fraction) from the input stream."""
-    chars: List[str] = []
+    chars: list[str] = []
     reader = ctx.reader
 
     while True:
@@ -934,7 +917,7 @@ def _read_str(ctx: ReaderContext, allow_arbitrary_escapes: bool = False) -> str:
 
     If allow_arbitrary_escapes is True, do not throw a SyntaxError if an
     unknown escape sequence is encountered."""
-    s: List[str] = []
+    s: list[str] = []
     reader = ctx.reader
     while True:
         char = reader.next_char()
@@ -997,7 +980,7 @@ def _read_byte_str(ctx: ReaderContext) -> bytes:
     if char != '"':
         raise ctx.syntax_error(f"Expected '\"'; got '{char}' instead")
 
-    b: List[bytes] = []
+    b: list[bytes] = []
     while True:
         char = reader.next_char()
         if char == "":
@@ -1188,7 +1171,7 @@ def _read_function(ctx: ReaderContext) -> llist.PersistentList:
 
     body = _postwalk(identify_and_replace, form) if len(form) > 0 else None
 
-    arg_list: List[sym.Symbol] = []
+    arg_list: list[sym.Symbol] = []
     numbered_args = sorted(map(int, filter(lambda k: k != "rest", arg_set)))
     if len(numbered_args) > 0:
         max_arg = max(numbered_args)
@@ -1378,7 +1361,7 @@ def _read_character(ctx: ReaderContext) -> str:
     start = ctx.reader.advance()
     assert start == "\\"
 
-    s: List[str] = []
+    s: list[str] = []
     reader = ctx.reader
     char = reader.peek()
     is_first_char = True

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -85,7 +85,7 @@ NS_VAR_NAME = "*ns*"
 NS_VAR_SYM = sym.symbol(NS_VAR_NAME, ns=CORE_NS)
 NS_VAR_NS = CORE_NS
 REPL_DEFAULT_NS = "basilisp.user"
-SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 8), (3, 9), (3, 10), (3, 11), (3, 12)})
+SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 8), (3, 9), (3, 10), (3, 11), (3, 12), (3, 13)})
 BASILISP_VERSION_STRING = importlib.metadata.version("basilisp")
 BASILISP_VERSION = vec.vector(
     (int(s) if s.isdigit() else s) for s in BASILISP_VERSION_STRING.split(".")

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1367,7 +1367,7 @@ def nth(coll, i: int, notfound=__nth_sentinel):
 
 @nth.register(type(None))
 def _nth_none(_: None, i: int, notfound=__nth_sentinel) -> None:
-    return notfound if notfound is not __nth_sentinel else None
+    return notfound if notfound is not __nth_sentinel else None  # type: ignore[return-value]
 
 
 @nth.register(Sequence)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1345,7 +1345,7 @@ def nth(coll, i: int, notfound=__nth_sentinel):
 
 @nth.register(type(None))
 def _nth_none(_: None, i: int, notfound=__nth_sentinel) -> None:
-    return notfound if notfound is not __nth_sentinel else None
+    return notfound if notfound is not __nth_sentinel else None  # type: ignore[return-value]
 
 
 @nth.register(Sequence)
@@ -2108,7 +2108,7 @@ def _basilisp_type(
                 continue
 
             if is_abstract(interface):
-                interface_names: frozenset[str] = interface.__abstractmethods__  # type: ignore[attr-definedm]
+                interface_names: frozenset[str] = interface.__abstractmethods__  # type: ignore[attr-defined]
                 interface_property_names: frozenset[str] = frozenset(
                     method
                     for method in interface_names

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1367,7 +1367,7 @@ def nth(coll, i: int, notfound=__nth_sentinel):
 
 @nth.register(type(None))
 def _nth_none(_: None, i: int, notfound=__nth_sentinel) -> None:
-    return notfound if notfound is not __nth_sentinel else None  # type: ignore[return-value]
+    return notfound if notfound is not __nth_sentinel else None
 
 
 @nth.register(Sequence)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -85,7 +85,7 @@ NS_VAR_NAME = "*ns*"
 NS_VAR_SYM = sym.symbol(NS_VAR_NAME, ns=CORE_NS)
 NS_VAR_NS = CORE_NS
 REPL_DEFAULT_NS = "basilisp.user"
-SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 8), (3, 9), (3, 10), (3, 11), (3, 12), (3, 13)})
+SUPPORTED_PYTHON_VERSIONS = frozenset({(3, 9), (3, 10), (3, 11), (3, 12), (3, 13)})
 BASILISP_VERSION_STRING = importlib.metadata.version("basilisp")
 BASILISP_VERSION = vec.vector(
     (int(s) if s.isdigit() else s) for s in BASILISP_VERSION_STRING.split(".")

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -2108,7 +2108,7 @@ def _basilisp_type(
                 continue
 
             if is_abstract(interface):
-                interface_names: frozenset[str] = interface.__abstractmethods__
+                interface_names: frozenset[str] = interface.__abstractmethods__  # type: ignore[attr-definedm]
                 interface_property_names: frozenset[str] = frozenset(
                     method
                     for method in interface_names

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -1,6 +1,7 @@
 import functools
 import threading
-from typing import Callable, Iterable, Optional, TypeVar, overload
+from collections.abc import Iterable
+from typing import Callable, Optional, TypeVar, overload
 
 from basilisp.lang.interfaces import (
     IPersistentMap,

--- a/src/basilisp/lang/set.py
+++ b/src/basilisp/lang/set.py
@@ -1,5 +1,6 @@
+from collections.abc import Iterable
 from collections.abc import Set as _PySet
-from typing import AbstractSet, Iterable, Optional, TypeVar
+from typing import AbstractSet, Optional, TypeVar
 
 from immutables import Map as _Map
 from immutables import MapMutation

--- a/src/basilisp/lang/source.py
+++ b/src/basilisp/lang/source.py
@@ -1,7 +1,8 @@
 import itertools
 import linecache
 import os
-from typing import Iterable, List, Optional
+from collections.abc import Iterable
+from typing import Optional
 
 try:
     import pygments.formatters
@@ -59,7 +60,7 @@ def format_source_context(  # pylint: disable=too-many-arguments,too-many-locals
     num_context_lines: int = 5,
     show_cause_marker: bool = True,
     disable_color: Optional[bool] = None,
-) -> List[str]:
+) -> list[str]:
     """Format source code context with line numbers and identifiers for the affected
     line(s).
 

--- a/src/basilisp/lang/typing.py
+++ b/src/basilisp/lang/typing.py
@@ -2,7 +2,8 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 from fractions import Fraction
-from typing import Optional, Pattern, Protocol, Union
+from re import Pattern
+from typing import Optional, Protocol, Union
 
 from basilisp.lang import keyword as kw
 from basilisp.lang import list as llist

--- a/src/basilisp/lang/util.py
+++ b/src/basilisp/lang/util.py
@@ -4,9 +4,10 @@ import inspect
 import keyword
 import re
 import uuid
+from collections.abc import Iterable
 from decimal import Decimal
 from fractions import Fraction
-from typing import Iterable, Match, Pattern, Type
+from re import Match, Pattern
 
 from basilisp.lang import atom as atom
 
@@ -71,7 +72,7 @@ def demunge(s: str) -> str:
     return re.sub(_DEMUNGE_PATTERN, demunge_replacer, s).replace("_", "-")
 
 
-def is_abstract(tp: Type) -> bool:
+def is_abstract(tp: type) -> bool:
     """Return True if tp is an abstract class.
 
     The builtin `inspect.isabstract` returns False for marker abstract classes

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -57,7 +57,7 @@ class TransientVector(ITransientVector[T]):
         return self
 
     def assoc_transient(self, *kvs: T) -> "TransientVector[T]":
-        for i, v in cast("Sequence[Tuple[int, T]]", partition(kvs, 2)):
+        for i, v in cast("Sequence[tuple[int, T]]", partition(kvs, 2)):
             self._inner.set(i, v)
         return self
 

--- a/src/basilisp/lang/vector.py
+++ b/src/basilisp/lang/vector.py
@@ -1,14 +1,6 @@
+from collections.abc import Iterable, Sequence
 from functools import total_ordering
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Optional, TypeVar, Union, cast, overload
 
 from pyrsistent import PVector, pvector  # noqa # pylint: disable=unused-import
 from pyrsistent.typing import PVectorEvolver
@@ -34,9 +26,6 @@ from basilisp.lang.obj import seq_lrepr as _seq_lrepr
 from basilisp.lang.reduced import Reduced
 from basilisp.lang.seq import sequence
 from basilisp.util import partition
-
-if TYPE_CHECKING:
-    from typing import Tuple
 
 T = TypeVar("T")
 

--- a/src/basilisp/main.py
+++ b/src/basilisp/main.py
@@ -1,7 +1,7 @@
 import importlib
 import site
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 from basilisp import importer as importer
 from basilisp import logconfig
@@ -56,7 +56,7 @@ def bootstrap(
         getattr(mod, fn_name)()
 
 
-def bootstrap_python(site_packages: Optional[List[str]] = None) -> None:
+def bootstrap_python(site_packages: Optional[list[str]] = None) -> None:
     """Bootstrap a Python installation by installing a ``.pth`` file in the first
     available ``site-packages`` directory (as by
     :external:py:func:`site.getsitepackages`).
@@ -75,7 +75,7 @@ def bootstrap_python(site_packages: Optional[List[str]] = None) -> None:
         break
 
 
-def unbootstrap_python(site_packages: Optional[List[str]] = None) -> List[str]:
+def unbootstrap_python(site_packages: Optional[list[str]] = None) -> list[str]:
     """Remove any `basilispbootstrap.pth` files found in any Python site-packages
     directory (as by :external:py:func:`site.getsitepackages`). Return a list of
     removed filenames."""

--- a/src/basilisp/prompt.py
+++ b/src/basilisp/prompt.py
@@ -2,9 +2,10 @@
 
 import os
 import re
+from collections.abc import Iterable, Mapping
 from functools import partial
 from types import MappingProxyType
-from typing import Any, Iterable, Mapping, Optional, Type
+from typing import Any, Optional
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.application import run_in_terminal
@@ -127,7 +128,7 @@ class PromptToolkitPrompter(Prompter):
         return self._session.prompt(msg)
 
 
-_DEFAULT_PROMPTER: Type[Prompter] = PromptToolkitPrompter
+_DEFAULT_PROMPTER: type[Prompter] = PromptToolkitPrompter
 
 
 try:

--- a/src/basilisp/string.lpy
+++ b/src/basilisp/string.lpy
@@ -123,7 +123,7 @@
      (instance? typing/Pattern pattern)
      (if (= "" (.-pattern pattern))
        (split s "" limit)
-       (vec (re/split pattern s (or (when limit (dec limit)) 0))))
+       (vec (re/split pattern s ** :maxsplit (or (when limit (dec limit)) 0))))
 
      (string? pattern)
      (vec
@@ -224,7 +224,8 @@
               #(replacement (.group % 0))
               replacement)
             s
-            1)
+            **
+            :count 1)
 
     (and (string? match) (string? replacement))
     (.replace s match replacement 1)

--- a/src/basilisp/util.py
+++ b/src/basilisp/util.py
@@ -1,6 +1,7 @@
 import contextlib
 import time
-from typing import Callable, Generic, Iterable, Optional, Sequence, Tuple, TypeVar
+from collections.abc import Iterable, Sequence
+from typing import Callable, Generic, Optional, TypeVar
 
 
 @contextlib.contextmanager
@@ -65,7 +66,7 @@ class Maybe(Generic[T]):
         return self._inner is not None
 
 
-def partition(coll: Sequence[T], n: int) -> Iterable[Tuple[T, ...]]:
+def partition(coll: Sequence[T], n: int) -> Iterable[tuple[T, ...]]:
     """Partition `coll` into groups of size `n`."""
     assert n > 0
     start = 0

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -11,7 +11,8 @@ import sys
 import tempfile
 import time
 from threading import Thread
-from typing import List, Optional, Sequence
+from typing import List, Optional
+from collections.abc import Sequence
 from unittest.mock import patch
 
 import attr
@@ -33,7 +34,7 @@ def env_vars():
 
 
 @pytest.fixture(autouse=True)
-def sys_path() -> List[str]:
+def sys_path() -> list[str]:
     sys_path = list(sys.path)
     try:
         yield sys_path
@@ -43,7 +44,7 @@ def sys_path() -> List[str]:
 
 
 @pytest.fixture()
-def temp_paths(tmp_path_factory) -> List[pathlib.Path]:
+def temp_paths(tmp_path_factory) -> list[pathlib.Path]:
     paths = []
     for i in range(3):
         path = tmp_path_factory.mktemp(f"dir{i}")
@@ -52,7 +53,7 @@ def temp_paths(tmp_path_factory) -> List[pathlib.Path]:
 
 
 @pytest.fixture
-def temp_path_args(temp_paths: List[pathlib.Path]) -> List[str]:
+def temp_path_args(temp_paths: list[pathlib.Path]) -> list[str]:
     args = []
     for p in temp_paths:
         args.extend(("-p", str(p)))
@@ -288,7 +289,7 @@ class TestREPL:
             assert sys_path[0] == sys.path[0]
 
         def test_repl_include_extra_path(
-            self, run_cli, temp_paths: List[pathlib.Path], temp_path_args: List[str]
+            self, run_cli, temp_paths: list[pathlib.Path], temp_path_args: list[str]
         ):
             result = run_cli(
                 ["repl", *temp_path_args],
@@ -330,7 +331,7 @@ class TestRun:
             assert f"nil{os.linesep}" == result.lisp_out
 
         @pytest.mark.parametrize("args,ret", cli_run_args_params)
-        def test_run_code_with_args(self, run_cli, args: List[str], ret: str):
+        def test_run_code_with_args(self, run_cli, args: list[str], ret: str):
             result = run_cli(["run", "-c", cli_run_args_code, *args])
             assert ret == result.lisp_out
 
@@ -365,7 +366,7 @@ class TestRun:
             assert sys_path[0] == sys.path[0]
 
         def test_run_code_include_extra_path(
-            self, run_cli, temp_paths: List[pathlib.Path], temp_path_args: List[str]
+            self, run_cli, temp_paths: list[pathlib.Path], temp_path_args: list[str]
         ):
             result = run_cli(
                 [
@@ -412,7 +413,7 @@ class TestRun:
 
         @pytest.mark.parametrize("args,ret", cli_run_args_params)
         def test_run_file_with_args(
-            self, isolated_filesystem, run_cli, args: List[str], ret: str
+            self, isolated_filesystem, run_cli, args: list[str], ret: str
         ):
             with open("test.lpy", mode="w") as f:
                 f.write(cli_run_args_code)
@@ -470,8 +471,8 @@ class TestRun:
             self,
             isolated_filesystem,
             run_cli,
-            temp_paths: List[pathlib.Path],
-            temp_path_args: List[str],
+            temp_paths: list[pathlib.Path],
+            temp_path_args: list[str],
         ):
             with open("test.lpy", mode="w") as f:
                 f.write(
@@ -540,7 +541,7 @@ class TestRun:
             run_cli,
             namespace_name: str,
             namespace_file: pathlib.Path,
-            args: List[str],
+            args: list[str],
             ret: str,
         ):
             namespace_file.write_text(f"(ns {namespace_name}) {cli_run_args_code}")
@@ -618,8 +619,8 @@ class TestRun:
             run_cli,
             namespace_name: str,
             namespace_file: pathlib.Path,
-            temp_paths: List[pathlib.Path],
-            temp_path_args: List[str],
+            temp_paths: list[pathlib.Path],
+            temp_path_args: list[str],
         ):
             namespace_file.write_text(
                 os.linesep.join(
@@ -646,7 +647,7 @@ class TestRun:
             assert f"nil{os.linesep}" == result.lisp_out
 
         @pytest.mark.parametrize("args,ret", cli_run_args_params)
-        def test_run_stdin_with_args(self, run_cli, args: List[str], ret: str):
+        def test_run_stdin_with_args(self, run_cli, args: list[str], ret: str):
             result = run_cli(
                 ["run", "-", *args],
                 input=cli_run_args_code,
@@ -685,8 +686,8 @@ class TestRun:
         def test_run_stdin_include_extra_path(
             self,
             run_cli,
-            temp_paths: List[pathlib.Path],
-            temp_path_args: List[str],
+            temp_paths: list[pathlib.Path],
+            temp_path_args: list[str],
         ):
             result = run_cli(
                 ["run", *temp_path_args, "-"],
@@ -724,7 +725,7 @@ def test_version(run_cli):
         (["1", "hi", "yes"], b'["1" "hi" "yes"]\n'),
     ],
 )
-def test_run_script(tmp_path: pathlib.Path, args: List[str], ret: bytes):
+def test_run_script(tmp_path: pathlib.Path, args: list[str], ret: bytes):
     script_path = tmp_path / "script.lpy"
     script_path.write_text(
         "\n".join(

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -10,9 +10,9 @@ import subprocess
 import sys
 import tempfile
 import time
-from threading import Thread
-from typing import List, Optional
 from collections.abc import Sequence
+from threading import Thread
+from typing import Optional
 from unittest.mock import patch
 
 import attr

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -1006,7 +1006,7 @@ class TestDefType:
         assert "y" not in hints
 
     @pytest.mark.skipif(
-        sys.version_info > (3, 9), reason="This version is intended for 3.8 and 3.9"
+        sys.version_info > (3, 9), reason="This version is intended for 3.9"
     )
     def test_deftype_field_tag_annotations_pre310(
         self, lcompile: CompileFn, ns: runtime.Namespace

--- a/tests/basilisp/conftest.py
+++ b/tests/basilisp/conftest.py
@@ -12,7 +12,7 @@ from basilisp.lang import symbol as sym
 from tests.basilisp.helpers import CompileFn, get_or_create_ns
 
 
-@pytest.fixture(params=[3, 4] if sys.version_info < (3, 8) else [3, 4, 5])
+@pytest.fixture(params=[3, 4, 5])
 def pickle_protocol(request) -> int:
     return request.param
 

--- a/tests/basilisp/conftest.py
+++ b/tests/basilisp/conftest.py
@@ -47,7 +47,7 @@ def lcompile(ns: runtime.Namespace, compiler_file_path: str) -> CompileFn:
     def _lcompile(
         s: str,
         resolver: Optional[reader.Resolver] = None,
-        opts: Optional[Dict[str, bool]] = None,
+        opts: Optional[dict[str, bool]] = None,
     ):
         """Compile and execute the code in the input string.
 
@@ -64,7 +64,7 @@ def lcompile(ns: runtime.Namespace, compiler_file_path: str) -> CompileFn:
 
 
 @pytest.fixture
-def cap_lisp_io() -> Tuple[io.StringIO, io.StringIO]:
+def cap_lisp_io() -> tuple[io.StringIO, io.StringIO]:
     """Capture the values of `*out*` and `*err*` during test execution, returning
     `io.StringIO` for each."""
     with io.StringIO() as outbuf, io.StringIO() as errbuf:

--- a/tests/basilisp/helpers.py
+++ b/tests/basilisp/helpers.py
@@ -7,7 +7,7 @@ CompileFn = Callable[[str], Any]
 
 
 def get_or_create_ns(
-    name: sym.Symbol, refer: Tuple[sym.Symbol] = (CORE_NS_SYM,)
+    name: sym.Symbol, refer: tuple[sym.Symbol] = (CORE_NS_SYM,)
 ) -> Namespace:
     """Get or create the namespace named by `name`, referring in all of the symbols
     of the namespaced named by `refer`."""

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 from multiprocessing import Process, get_start_method
 from tempfile import TemporaryDirectory
-from typing import List, Optional, Tuple
+from typing import Optional
 from unittest.mock import patch
 
 import pytest

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -76,7 +76,7 @@ def test_demunged_import(pytester: pytest.Pytester):
             )
 
 
-def _ns_and_module(filename: str) -> Tuple[str, str]:
+def _ns_and_module(filename: str) -> tuple[str, str]:
     basename = os.path.splitext(os.path.basename(filename))[0]
     return demunge(basename), basename
 
@@ -578,7 +578,7 @@ class TestImporter:
             monkeypatch: pytest.MonkeyPatch,
             make_new_module,
             capsys,
-            args: List[str],
+            args: list[str],
             output: str,
         ):
             make_new_module(
@@ -635,7 +635,7 @@ def bootstrap_file() -> pathlib.Path:
     ],
 )
 def test_run_namespace_as_python_module(
-    bootstrap_file: pathlib.Path, tmp_path: pathlib.Path, args: List[str], ret: bytes
+    bootstrap_file: pathlib.Path, tmp_path: pathlib.Path, args: list[str], ret: bytes
 ):
     parent = tmp_path / "package"
     parent.mkdir()

--- a/tests/basilisp/importer_test.py
+++ b/tests/basilisp/importer_test.py
@@ -52,8 +52,9 @@ def test_demunged_import(pytester: pytest.Pytester):
             module.write(code)
 
         with runtime.remove_ns_bindings():
-            with patch("sys.path", new=[tmpdir]), patch(
-                "sys.meta_path", new=[importer.BasilispImporter()]
+            with (
+                patch("sys.path", new=[tmpdir]),
+                patch("sys.meta_path", new=[importer.BasilispImporter()]),
             ):
                 importlib.import_module(
                     "long__AMP__namespace_name__PLUS__with___LT__punctuation__GT__"

--- a/tests/basilisp/map_test.py
+++ b/tests/basilisp/map_test.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import Mapping
+from collections.abc import Mapping
 
 import pytest
 

--- a/tests/basilisp/prompt_test.py
+++ b/tests/basilisp/prompt_test.py
@@ -1,4 +1,5 @@
-from typing import Callable, Iterable, Tuple
+from typing import Callable, Tuple
+from collections.abc import Iterable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -132,12 +133,12 @@ class TestCompleter:
         ],
     )
     def test_completer(
-        self, completer: Completer, ns: Namespace, val: str, expected: Tuple[str]
+        self, completer: Completer, ns: Namespace, val: str, expected: tuple[str]
     ):
         doc = Document(val, len(val))
         completions = list(completer.get_completions(doc, CompleteEvent()))
         assert len(completions) == len(expected)
-        assert set(c.text for c in completions) == set(expected)
+        assert {c.text for c in completions} == set(expected)
 
 
 class TestPrompter:
@@ -227,7 +228,7 @@ class TestKeyBindings:
             ("[", "          ", "          ", ":a :b :c", "", "]"),
         ],
     )
-    def test_multiline_input(self, handler: Binding, lines: Tuple[str]):
+    def test_multiline_input(self, handler: Binding, lines: tuple[str]):
         *begin, last = lines
 
         line_buffer = []

--- a/tests/basilisp/prompt_test.py
+++ b/tests/basilisp/prompt_test.py
@@ -1,5 +1,5 @@
-from typing import Callable, Tuple
 from collections.abc import Iterable
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/basilisp/prompt_test.py
+++ b/tests/basilisp/prompt_test.py
@@ -184,9 +184,10 @@ class TestKeyBindings:
 
     @pytest.fixture(autouse=True)
     def assert_syntax_error(self):
-        with patch("basilisp.prompt.run_in_terminal") as run_in_terminal, patch(
-            "basilisp.prompt.partial"
-        ) as partial:
+        with (
+            patch("basilisp.prompt.run_in_terminal") as run_in_terminal,
+            patch("basilisp.prompt.partial") as partial,
+        ):
             marker = object()
             partial.return_value = marker
 

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -89,7 +89,7 @@ def test_stream_reader():
 
 
 def test_stream_reader_loc():
-    s = str("i=1\n" "b=2\n" "i")
+    s = "i=1\n" "b=2\n" "i"
     sreader = reader.StreamReader(io.StringIO(s))
     assert (1, 0) == sreader.loc
 
@@ -135,7 +135,7 @@ def test_stream_reader_loc():
 
 
 def test_stream_reader_loc_other():
-    s = str("i=1\n" "b=2\n" "i")
+    s = "i=1\n" "b=2\n" "i"
     sreader = reader.StreamReader(io.StringIO(s), init_line=5, init_column=3)
     assert (5, 3) == sreader.loc
 
@@ -233,7 +233,7 @@ class TestReaderLines:
         with open(filename, mode="w", encoding="utf-8") as f:
             f.write("1\n2\n(/ 5 0)")
 
-        with open(filename, mode="r", encoding="utf-8") as f:
+        with open(filename, encoding="utf-8") as f:
             _, _, l = list(reader.read(f))
 
         assert (3, 3, 0, 7) == (

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -42,6 +42,7 @@ def test_is_supported_python_version():
                     "lpy310-",
                     "lpy311-",
                     "lpy312-",
+                    "lpy313-",
                     platform.system().lower(),
                 ],
             )
@@ -59,6 +60,7 @@ def test_is_supported_python_version():
                     "lpy310-",
                     "lpy311-",
                     "lpy312-",
+                    "lpy313-",
                     platform.system().lower(),
                 ],
             )
@@ -70,6 +72,7 @@ def test_is_supported_python_version():
                     "lpy310",
                     "default",
                     "lpy",
+                    "lpy313-",
                     "lpy312-",
                     "lpy311-",
                     "lpy310+",
@@ -88,6 +91,7 @@ def test_is_supported_python_version():
                     "default",
                     "lpy",
                     "lpy311+",
+                    "lpy313-",
                     "lpy312-",
                     "lpy311-",
                     "lpy310+",
@@ -106,8 +110,26 @@ def test_is_supported_python_version():
                     "lpy",
                     "lpy311+",
                     "lpy312+",
+                    "lpy313-",
                     "lpy312-",
+                    "lpy39+",
+                    "lpy38+",
+                    platform.system().lower(),
+                ],
+            )
+        ),
+        (3, 13): frozenset(
+            map(
+                kw.keyword,
+                [
+                    "lpy313",
+                    "default",
+                    "lpy",
                     "lpy311+",
+                    "lpy312+",
+                    "lpy313+",
+                    "lpy313-",
+                    "lpy310+",
                     "lpy39+",
                     "lpy38+",
                     platform.system().lower(),

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -29,24 +29,6 @@ def test_is_supported_python_version():
 @pytest.mark.parametrize(
     "feature",
     {
-        (3, 8): frozenset(
-            map(
-                kw.keyword,
-                [
-                    "lpy38",
-                    "default",
-                    "lpy",
-                    "lpy38-",
-                    "lpy38+",
-                    "lpy39-",
-                    "lpy310-",
-                    "lpy311-",
-                    "lpy312-",
-                    "lpy313-",
-                    platform.system().lower(),
-                ],
-            )
-        ),
         (3, 9): frozenset(
             map(
                 kw.keyword,
@@ -56,7 +38,6 @@ def test_is_supported_python_version():
                     "lpy",
                     "lpy39-",
                     "lpy39+",
-                    "lpy38+",
                     "lpy310-",
                     "lpy311-",
                     "lpy312-",
@@ -78,7 +59,6 @@ def test_is_supported_python_version():
                     "lpy310+",
                     "lpy310-",
                     "lpy39+",
-                    "lpy38+",
                     platform.system().lower(),
                 ],
             )
@@ -96,7 +76,6 @@ def test_is_supported_python_version():
                     "lpy311-",
                     "lpy310+",
                     "lpy39+",
-                    "lpy38+",
                     platform.system().lower(),
                 ],
             )
@@ -113,7 +92,6 @@ def test_is_supported_python_version():
                     "lpy313-",
                     "lpy312-",
                     "lpy39+",
-                    "lpy38+",
                     platform.system().lower(),
                 ],
             )
@@ -131,7 +109,6 @@ def test_is_supported_python_version():
                     "lpy313-",
                     "lpy310+",
                     "lpy39+",
-                    "lpy38+",
                     platform.system().lower(),
                 ],
             )

--- a/tests/basilisp/set_test.py
+++ b/tests/basilisp/set_test.py
@@ -113,5 +113,5 @@ def test_set_pickleability(pickle_protocol: int, o: lset.PersistentSet):
         (lset.s(keyword("kw1"), keyword("kw2")), {"#{:kw1 :kw2}", "#{:kw2 :kw1}"}),
     ],
 )
-def test_set_repr(l: lset.PersistentSet, str_repr: typing.Set[str]):
+def test_set_repr(l: lset.PersistentSet, str_repr: set[str]):
     assert repr(l) in str_repr

--- a/tests/basilisp/test_stacktrace.lpy
+++ b/tests/basilisp/test_stacktrace.lpy
@@ -60,17 +60,18 @@
       ;; one stack frame
       (let [trace1 (-> (with-out-str (s/print-cause-trace e 1))
                        (str/split-lines))]
-        (is (= 4 (count trace1)) trace1)
+        (doseq [line trace1]
+          (println line))
         (is (= "Traceback (most recent call last):" (first trace1)))
-        (is (= ["    (try" " ZeroDivisionError: Fraction(5, 0)" ] (take-last 2 trace1))))
+        (is (every? (set trace1) ["    (try" " ZeroDivisionError: Fraction(5, 0)"])))
 
       ;; full stack
       (let [trace (-> (with-out-str (s/print-cause-trace e))
                       (str/split-lines))]
-        (is (< 4 (count trace)) trace)
         (is (= "Traceback (most recent call last):" (first trace)))
         (is (= ["    raise ZeroDivisionError('Fraction(%s, 0)' % numerator)"
-                " ZeroDivisionError: Fraction(5, 0)" ] (take-last 2 trace)))))))
+                " ZeroDivisionError: Fraction(5, 0)"]
+               (take-last 2 trace)))))))
 
 (deftest print-throwable
   (try

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,pypy3,coverage,py{38,39,310,311,312}-mypy,py{38,39,310,311,312}-lint,format,safety
+envlist = py38,py39,py310,py311,py312,py313,pypy3,coverage,py{38,39,310,311,312,313}-mypy,py{38,39,310,311,312,313}-lint,format,safety
 labels =
-    test = py38,py39,py310,py311,py312
+    test = py38,py39,py310,py311,py312,py313
 
 [testenv]
 allowlist_externals = poetry
@@ -23,7 +23,7 @@ commands =
              {posargs}
 
 [testenv:coverage]
-depends = py38, py39, py310, py311, py312
+depends = py38, py39, py310, py311, py312, py313
 deps = coverage[toml]
 commands =
     coverage combine
@@ -38,7 +38,7 @@ commands =
     isort --check .
     black --check .
 
-[testenv:py{38,39,310,311,312}-mypy]
+[testenv:py{38,39,310,311,312,313}-mypy]
 labels = mypy
 deps =
     mypy
@@ -47,7 +47,7 @@ deps =
 commands =
     mypy --config-file={toxinidir}/pyproject.toml -p basilisp
 
-[testenv:py{38,39,310,311,312}-lint]
+[testenv:py{38,39,310,311,312,313}-lint]
 labels = lint
 deps =
     pylint >=3.0.0,<4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,py313,pypy3,coverage,py{38,39,310,311,312,313}-mypy,py{38,39,310,311,312,313}-lint,format,safety
+envlist = py39,py310,py311,py312,py313,pypy3,coverage,py{39,310,311,312,313}-mypy,py{39,310,311,312,313}-lint,format,safety
 labels =
-    test = py38,py39,py310,py311,py312,py313
+    test = py39,py310,py311,py312,py313
 
 [testenv]
 allowlist_externals = poetry
@@ -23,7 +23,7 @@ commands =
              {posargs}
 
 [testenv:coverage]
-depends = py38, py39, py310, py311, py312, py313
+depends = py39, py310, py311, py312, py313
 deps = coverage[toml]
 commands =
     coverage combine
@@ -38,7 +38,7 @@ commands =
     isort --check .
     black --check .
 
-[testenv:py{38,39,310,311,312,313}-mypy]
+[testenv:py{39,310,311,312,313}-mypy]
 labels = mypy
 deps =
     mypy
@@ -47,7 +47,7 @@ deps =
 commands =
     mypy --config-file={toxinidir}/pyproject.toml -p basilisp
 
-[testenv:py{38,39,310,311,312,313}-lint]
+[testenv:py{39,310,311,312,313}-lint]
 labels = lint
 deps =
     pylint >=3.0.0,<4.0.0


### PR DESCRIPTION
Fixes #1056 

I ran [`pyupgrade --py39-plus`](https://github.com/asottile/pyupgrade) on the entire source tree to convert from `typing.{List,Set,...}` to the generic forms of the builtins (among other available upgrades).

Upgrading to 3.13 also surfaced #1088 which I filed to address separately since this PR is already quite large.