### PR TITLE
Run tests on GraalPy

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,6 +83,56 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
+  run-graalpy-tests:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        version: ['3.11']
+        include:
+          - version: '3.11'
+            graalpy-version: '24.1.0'
+            tox-env: py311
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: graalpy-${{ matrix.graalpy-version }}
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: |
+            .tox
+            ~/.cache/pip
+            ~/.cache/pypoetry
+            ~/.local/bin/poetry
+            ~/.local/share/pypoetry
+          key: ${{ runner.os }}-graalpy-${{ matrix.version }}-poetry-${{ hashFiles('.github/workflows/run-tests.yml', 'pyproject.toml', 'tox.ini') }}
+      - name: Install Poetry
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: curl -sSL https://install.python-poetry.org | python3 -
+      - name: Install Tox
+        run: |
+          pip install -U pip
+          pip install tox
+      - name: Run tests
+        env:
+          TOX_PARALLEL_NO_SPINNER: 1
+          TOX_SHOW_OUTPUT: "True"
+          TOXENV: ${{ matrix.tox-env }}
+        run: |
+          tox run -- -n 2
+          mkdir coverage
+          mv .coverage.* "coverage/.coverage.pypy${{ matrix.version }}"
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage.graalpy${{ matrix.version }}
+          path: coverage/.coverage.py*
+          include-hidden-files: true
+          if-no-files-found: error
+
   run-pypy-tests:
     runs-on: ${{matrix.os}}
     strategy:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install Basilisp
         run: |
           pip install -U pip
-          pip install "pytest>=7.0.0,<9.0.0" "pygments"
+          pip install . "pytest>=7.0.0,<9.0.0" "pygments"
       - name: Run tests
         run: |
           pytest --import-mode=importlib

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,10 +90,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ['3.11']
+        version: ['3.12']
         include:
-          - version: '3.11'
-            graalpy-version: '24.1.0'
+          - version: '3.12'
+            graalpy-version: '25.0.2'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,6 +83,8 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
+  # Neither Tox nor Poetry have any real support for GraalPy right now, so we're
+  # just installing using GraalPy's pip and running PyTest manually in the runner.
   run-graalpy-tests:
     runs-on: ${{matrix.os}}
     strategy:
@@ -92,7 +94,6 @@ jobs:
         include:
           - version: '3.11'
             graalpy-version: '24.1.0'
-            tox-env: py311
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -103,35 +104,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            .tox
             ~/.cache/pip
-            ~/.cache/pypoetry
-            ~/.local/bin/poetry
-            ~/.local/share/pypoetry
-          key: ${{ runner.os }}-graalpy-${{ matrix.version }}-poetry-${{ hashFiles('.github/workflows/run-tests.yml', 'pyproject.toml', 'tox.ini') }}
-      - name: Install Poetry
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: curl -sSL https://install.python-poetry.org | python3 -
-      - name: Install Tox
+          key: ${{ runner.os }}-graalpy-${{ matrix.version }}-pip-${{ hashFiles('.github/workflows/run-tests.yml', 'pyproject.toml', 'tox.ini') }}
+      - name: Install Basilisp
         run: |
           pip install -U pip
-          pip install tox
+          pip install "pytest>=7.0.0,<9.0.0" "pygments"
       - name: Run tests
-        env:
-          TOX_PARALLEL_NO_SPINNER: 1
-          TOX_SHOW_OUTPUT: "True"
-          TOXENV: ${{ matrix.tox-env }}
         run: |
-          tox run -- -n 2
-          mkdir coverage
-          mv .coverage.* "coverage/.coverage.pypy${{ matrix.version }}"
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage.graalpy${{ matrix.version }}
-          path: coverage/.coverage.py*
-          include-hidden-files: true
-          if-no-files-found: error
+          pytest --import-mode=importlib
 
   run-pypy-tests:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,8 +83,6 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
 
-  # Neither Tox nor Poetry have any real support for GraalPy right now, so we're
-  # just installing using GraalPy's pip and running PyTest manually in the runner.
   run-graalpy-tests:
     runs-on: ${{matrix.os}}
     strategy:
@@ -109,10 +107,10 @@ jobs:
       - name: Install Basilisp
         run: |
           pip install -U pip
-          pip install . "pytest>=7.0.0,<9.0.0" "pygments"
+          pip install tox
       - name: Run tests
         run: |
-          pytest --import-mode=importlib
+          tox run -m test-graalpy
 
   run-pypy-tests:
     runs-on: ${{matrix.os}}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
-envlist = py310,py311,py312,py313,py314,pypy3,coverage,py{310,311,312,313,314}-mypy,py{310,311,312,313,314}-lint,format,bandit
+envlist = py310,py311,py312,py313,py314,graalpy312,pypy3,coverage,py{310,311,312,313,314}-mypy,py{310,311,312,313,314}-lint,format,bandit
 labels =
     test = py310,py311,py312,py313,py314,coverage
+    test-graalpy = graalpy312
+    test-pypy = pypy3
 
 [testenv]
 allowlist_externals = poetry


### PR DESCRIPTION
Also for creating a Graal standalone executable, there seems to be some issue with Basilisp's bytecode caching implementation. [This](https://www.graalvm.org/dev/reference-manual/python/Performance/https://www.graalvm.org/dev/reference-manual/python/Performance/) may be a helpful resource in figuring out the issue.