### PR TITLE
conform to spec on nrepl's info op on :file and :column values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fix a bug where the reader was double counting the CRLF newline seq in metadata (#1063)
+ * Conform to the `cider-nrepl` `info` ops spec by ensuring result's `:file` is URI, also added missing :column number (#1066)
 
 ## [v0.2.3]
 ### Added

--- a/src/basilisp/contrib/nrepl_server.lpy
+++ b/src/basilisp/contrib/nrepl_server.lpy
@@ -6,9 +6,11 @@
             [basilisp.string :as str])
   (:import basilisp.logconfig
            logging
+           os
            socketserver
            sys
            traceback
+           urllib
            uuid))
 
 (def ^:private logger
@@ -222,7 +224,7 @@
   "Look up ``:sym`` (CIDER) or ``:symbol`` (calva) from ``request`` in ``ns``
   (or if not provided ``:eval-ns`` from ``client*``) and pass results to ``send-fn``.
 
-  Serves both :eldoc and :info ``request`` :op's."
+  Serves both cider-nrepl's :eldoc and :info ``request`` :op's."
   [{:keys [ns client*] :as request} send-fn]
   (let [mapping-type      (-> request :op)
         {:keys [eval-ns]} @client*]
@@ -237,7 +239,7 @@
             [tp var-maybe] (symbol-identify lookup-ns sym-str)
             var-meta       (when (= tp :var) (meta var-maybe))
 
-            {:keys [arglists doc file ns line] symname :name} var-meta
+            {:keys [arglists doc file ns line col] symname :name} var-meta
 
             ref      (when (= tp :var) (var-get var-maybe))
             response (when symname
@@ -254,8 +256,12 @@
                          :info  {"doc"          doc
                                  "ns"           (str ns)
                                  "name"         (str symname)
-                                 "file"         file
+                                 "file"         (if (os.path/isabs file)
+                                                  (->> (urllib.parse/quote file)
+                                                       (urllib.parse/urljoin "file:"))
+                                                  file)
                                  "line"         line
+                                 "column"       col
                                  "arglists-str" (forms-join arglists)
                                  "status"       ["done"]}))
             status   (if (and (nil? symname) (= mapping-type :eldoc) )
@@ -322,8 +328,8 @@
   handlers for those operations."
   {:eval      handle-eval
    :describe  handle-describe
-   :info      handle-lookup
-   :eldoc     handle-lookup
+   :info      handle-lookup     ;; cider-nrepl middleware
+   :eldoc     handle-lookup     ;; cider-nrepl middleware
    :clone     handle-clone
    :close     handle-close
    :load-file handle-load-file

--- a/tests/basilisp/contrib/nrepl_server_test.lpy
+++ b/tests/basilisp/contrib/nrepl_server_test.lpy
@@ -12,7 +12,8 @@
    socket
    tempfile
    threading
-   time))
+   time
+   urllib))
 
 (use-fixtures :each fixtures/tempdir)
 
@@ -454,13 +455,17 @@
           (let [{:keys [status]} (client-recv! client)]
             (is (= ["done"] status)))
           (client-send! client {:id (id-inc!) :op "info" :ns "user" :sym "sort-by"})
-          (let [{:keys [file line] :as response} (client-recv! client)
-                {:keys [doc]
-                 meta-file :file} (meta (resolve 'sort-by))]
+          (let [{:keys [file line column] :as response} (client-recv! client)
+                {:keys [doc col]
+                 meta-file :file
+                 meta-line :line} (meta (resolve 'sort-by))
+                meta-file-uri     (->> (urllib.parse/quote meta-file)
+                                       (urllib.parse/urljoin "file:"))]
             (is (= {:ns "basilisp.core" :status ["done"] :id @id* :arglists-str "[keyfn coll]\n[keyfn cmp coll]"
+                    :line line :column col
                     :doc doc :name "sort-by"}
-                   (select-keys response [:ns :status :id :arglists-str :doc :name])))
-            (is (= meta-file file)))
+                   (select-keys response [:ns :status :id :arglists-str :doc :name :line :column])))
+            (is (= meta-file-uri file)))
 
           ;; test fqdn, aliases and refers
           (client-send! client {:id (id-inc!) :op "eval"


### PR DESCRIPTION
Hi,

could you please review patch to align the nrepl server's `info` op with the `cider-nrepl` spec. It fixes #1066.

According to the spec,  the `:file` return value should be a URI when it refers to an absolute path. It also specifies `:column` as a return key, which was previously missing.

`cider-nrepl` `info` spec: https://docs.cider.mx/cider-nrepl/nrepl-api/ops.html#info

The  nrepl-server's `info` test has been updated accordingly.

Thanks