### PR TITLE
Add support for highlighting closing parens, brackets, and braces at the REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added functions to `basilisp.test` for using and combining test fixtures (#980)
  * Added the `importing-resolve` function for dynamically importing and resolving a Python name (#1065, #1070)
- * Added support for highlighting matching parens, brackets, and braces at the REPL (#???)
+ * Added support for highlighting matching parens, brackets, and braces at the REPL (#1074)
 
 ### Fixed
  * Fix a bug where the reader was double counting the CRLF newline seq in metadata (#1063)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
  * Added functions to `basilisp.test` for using and combining test fixtures (#980)
  * Added the `importing-resolve` function for dynamically importing and resolving a Python name (#1065, #1070)
+ * Added support for highlighting matching parens, brackets, and braces at the REPL (#???)
 
 ### Fixed
  * Fix a bug where the reader was double counting the CRLF newline seq in metadata (#1063)

--- a/src/basilisp/prompt.py
+++ b/src/basilisp/prompt.py
@@ -14,6 +14,7 @@ from prompt_toolkit.document import Document
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPressEvent
+from prompt_toolkit.layout.processors import HighlightMatchingBracketProcessor
 
 from basilisp.lang import reader as reader
 from basilisp.lang import runtime as runtime
@@ -77,6 +78,7 @@ class PromptToolkitPrompter(Prompter):
             key_bindings=self._get_key_bindings(),
             lexer=self._prompt_toolkit_lexer,
             multiline=True,
+            input_processors=[HighlightMatchingBracketProcessor(chars="[](){}")],
             **self._style_settings,
         )
 


### PR DESCRIPTION
This is a very helpful feature I noticed on the Clojure REPL and prompt-toolkit supported it natively, so it was a no brainer to add.