### PR TITLE
Fix issue with `basilisp test` standard streams output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Fix an issue with `basilisp test` standard streams output that can lead to failures on MS-Windows (#1080)
 
 ## [v0.2.4]
 ### Added

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -42,21 +42,19 @@ def pytest_configure(config):
     # during tests and restore them afterward.
     out_var = runtime.Var.find(OUT_VAR_SYM)
     err_var = runtime.Var.find(ERR_VAR_SYM)
-    if out_var:
-        out_var.push_bindings(sys.stdout)
-        config.out_var = out_var
-    if err_var:
-        err_var.push_bindings(sys.stderr)
-        config.err_var = err_var
+    bindings = {
+        k: v for k, v in {out_var: sys.stdout, err_var: sys.stderr}.items() if k
+    }
+    if bindings.items():
+        runtime.push_thread_bindings(bindings)
+        config.basilisp_bindings = bindings
 
     basilisp.bootstrap("basilisp.test")
 
 
 def pytest_unconfigure(config):
-    if hasattr(config, "out_var"):
-        config.out_var.pop_bindings()
-    if hasattr(config, "err_var"):
-        config.err_var.pop_bindings()
+    if hasattr(config, "basilisp_bindings"):
+        runtime.pop_thread_bindings()
 
 
 def pytest_collect_file(  # pylint: disable=unused-argument

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -46,7 +46,7 @@ def pytest_configure(config):
         k: v for k, v in {out_var: sys.stdout, err_var: sys.stderr}.items() if k
     }
     if bindings.items():
-        runtime.push_thread_bindings(bindings)
+        runtime.push_thread_bindings(lmap.map(bindings))
         config.basilisp_bindings = bindings
 
     basilisp.bootstrap("basilisp.test")

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -1,6 +1,7 @@
 import importlib.util
 import inspect
 import os
+import sys
 import traceback
 from pathlib import Path
 from types import GeneratorType
@@ -12,6 +13,7 @@ from basilisp import main as basilisp
 from basilisp.lang import keyword as kw
 from basilisp.lang import map as lmap
 from basilisp.lang import runtime as runtime
+from basilisp.lang import symbol as sym
 from basilisp.lang import vector as vec
 from basilisp.lang.obj import lrepr
 from basilisp.util import Maybe
@@ -20,13 +22,46 @@ _EACH_FIXTURES_META_KW = kw.keyword("each-fixtures", "basilisp.test")
 _ONCE_FIXTURES_NUM_META_KW = kw.keyword("once-fixtures", "basilisp.test")
 _TEST_META_KW = kw.keyword("test", "basilisp.test")
 
+CORE_NS = "basilisp.core"
+CORE_NS_SYM = sym.symbol(CORE_NS)
+OUT_VAR_NAME = "*out*"
+OUT_VAR_SYM = sym.symbol(OUT_VAR_NAME, ns=CORE_NS)
+ERR_VAR_NAME = "*err*"
+ERR_VAR_SYM = sym.symbol(ERR_VAR_NAME, ns=CORE_NS)
 
-# pylint: disable=unused-argument
+
 def pytest_configure(config):
+
+    # https://github.com/pytest-dev/pytest/issues/12876
+    #
+    # Basilisp's standard output streams may be initialized before
+    # pytest captures sys streams (sys.stdout and sys.stderr) for
+    # testing (e.g., with `basilisp test`). Writing to the original
+    # handles during tests on Windows can cause invalid handle
+    # errors. To prevent this, we rebind them to pytest's streams
+    # during tests and restore them afterward.
+    out_var = runtime.Var.find(OUT_VAR_SYM)
+    err_var = runtime.Var.find(ERR_VAR_SYM)
+    if out_var:
+        out_var.push_bindings(sys.stdout)
+        config.out_var = out_var
+    if err_var:
+        err_var.push_bindings(sys.stderr)
+        config.err_var = err_var
+
     basilisp.bootstrap("basilisp.test")
 
 
-def pytest_collect_file(file_path: Path, path, parent):
+def pytest_unconfigure(config):
+    if hasattr(config, "out_var"):
+        config.out_var.pop_bindings()
+    if hasattr(config, "err_var"):
+        config.err_var.pop_bindings()
+
+
+def pytest_collect_file(  # pylint: disable=unused-argument
+    file_path: Path, path, parent
+):
     """Primary PyTest hook to identify Basilisp test files."""
     if file_path.suffix == ".lpy":
         if file_path.name.startswith("test_") or file_path.stem.endswith("_test"):


### PR DESCRIPTION
Hi,

can you please review patch to address the `basilisp test` failure on MS-Windows. It fixes #1080.

The problem arises because pytest's mechanism for capturing standard streams during tests breaks when those streams are saved before pytest.main is called and then used in the test. This happens when running `basilisp test` from the CLI:

In `basilisp.init`, `sys.stdout` and `sys.stderr` are saved to the `*out*` and `*err*` dynamic variables before `pytest.main` is called. If a test prints anything, it tries to write to these original streams, causing failures due to an issue I just reported in https://github.com/pytest-dev/pytest/issues/12876.

This patch rebinds `*out*` and `*err*` to the streams set by `pytest` and restores them when `pytest` finishes (via the `configure` functions). I've tested it with a case that prints to `*out*` and `*err*` at the top level, inside a test, and inside a fixture, and it works as expected.
```clojure
(ns tests.issuetests.issue-test
  (:require [basilisp.test :refer [deftest are is testing use-fixtures]])
  (:import sys))

(println :top-out)
(binding [*out* *err*]
  (println :top-err))

(defn fixture-gen-test []
  (println :fix-gen-out)
  (yield)
  (binding [*out* *err*]
    (println :fix-gen-err)))

(use-fixtures :each fixture-gen-test)

(deftest print_test
  (println :test-out)
  (is (= 5 5))
  (binding [*out* *err*]
    (println :test-err)))

```

```powershell
> basilisp test
=============================================================================================================== test session starts ================================================================================================================
platform win32 -- Python 3.11.4, pytest-8.4.0.dev100+g410c51011, pluggy-1.5.0
rootdir: C:\clj\issues\issue-bas-test-macro-print
configfile: pyproject.toml
plugins: basilisp-0.2.4
collecting ... :top-out
:top-err
collected 1 item

tests\issuetests\issue_test.lpy :fix-gen-out
:test-out
:test-err
.:fix-gen-err
```

I’d also like to discuss `Basilisp` integration tests, which I think the above testing falls under, though there’s currently no support for such tests in `Basilisp`.

Ideally I think, I would like to create a `Basilisp` project in a temporary directory, add the above test, install the fix alongside `pytest`, activate the environment, and then run `basilisp test`.

Do you have any suggestions how to extend the `Basilisp` test suite to implement this? or shall I open a new ticket for this discussion? I was thinking of having a new `--integration` pytest option for these tests, something I have been experimenting with in the basilisp-blender package.

Thanks