### PR TITLE
Set *print-length* default value to nil instead of 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix an issue where destructuring a vector would throw an exception rather than returning `nil` for invalid key types (#1090)
  * Fix an issue where destructuring default values would take precedence over falsey values in the source data structure (#1078)
  * Fixed a bug where imported Python names containing `-` (in lieu of `_`) could not be referenced using the `-` syntax (#1085)
+ * Fixed a compatibility issue where `*print-length*` defaulted to 50 instead of `nil` (#1093)
 
 ### Removed
  * Removed support for Python 3.8 (#1083)

--- a/src/basilisp/lang/obj.py
+++ b/src/basilisp/lang/obj.py
@@ -20,7 +20,7 @@ SURPASSED_PRINT_LENGTH = "..."
 SURPASSED_PRINT_LEVEL = "#"
 
 PRINT_DUP = False
-PRINT_LENGTH: PrintCountSetting = 50
+PRINT_LENGTH: PrintCountSetting = None
 PRINT_LEVEL: PrintCountSetting = None
 PRINT_META = False
 PRINT_NAMESPACE_MAPS = False

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -2460,7 +2460,19 @@ def bootstrap_core(compiler_opts: CompilerOpts) -> None:
         CORE_NS_SYM, sym.symbol(PRINT_DUP_VAR_NAME), lobj.PRINT_DUP, dynamic=True
     )
     Var.intern(
-        CORE_NS_SYM, sym.symbol(PRINT_LENGTH_VAR_NAME), lobj.PRINT_LENGTH, dynamic=True
+        CORE_NS_SYM,
+        sym.symbol(PRINT_LENGTH_VAR_NAME),
+        lobj.PRINT_LENGTH,
+        dynamic=True,
+        meta=lmap.map(
+            {
+                _DOC_META_KEY: (
+                    "Limits the number of items printed per collection. If falsy, all items are shown."
+                    " If set to an integer, only that many items are printed,"
+                    " with ``...`` indicating more. By default, it is ``nil``, meaning no limit."
+                )
+            }
+        ),
     )
     Var.intern(
         CORE_NS_SYM, sym.symbol(PRINT_LEVEL_VAR_NAME), lobj.PRINT_LEVEL, dynamic=True

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -6,6 +6,7 @@
   (:require
    [basilisp.io :as bio]
    [basilisp.set :as set]
+   [basilisp.string :as str]
    [basilisp.test :refer [deftest are is testing]]))
 
 (deftest vec-test
@@ -2552,6 +2553,13 @@
 (deftest pr-test
   (testing "is dynamic"
     (is (= '(1) (binding [pr (fn [& more] more)] (pr 1)))))
+
+  (testing "*print-level* support"
+    (let [v-str (pr-str (range 100))]
+      (is (str/ends-with? v-str " 99)") v-str))
+
+    (binding [*print-length* 4]
+      (is (= "(0 1 2 3 ...)" (pr-str (range 5))))))
 
   (testing "with *print-namespace-maps*"
     (is (= "#py {:a/x 5}" (binding [*print-namespace-maps* false] (pr-str #py {:a/x 5}))))

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,9 @@ commands =
     ruff check src/
 
 [testenv:safety]
-deps = safety
+deps =
+     safety
+     # work around 3.13 issue to avoid building an earlier version of pydantic-core on macos
+     pydantic-core>=2.25.0
 commands =
     safety check -i 40291 -i 67599 -i 70612


### PR DESCRIPTION
Hi,

could you please review patch to set the `*print-length*` default to `nil` instead of 50. It addresses #1093.

I’ve also added a docstring  (feedback welcome!) and a test.

Thanks