### PR TITLE
Do not attempt to resolve symbols in data reader tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Fix a bug where tags in data readers were resolved as Vars within syntax quotes, rather than using standard data readers rules (#1129)
 
 ## [v0.3.2]
 ### Added

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -1036,7 +1036,7 @@ def _read_byte_str(ctx: ReaderContext) -> bytes:
 
 
 @_with_loc
-def _read_sym(ctx: ReaderContext) -> MaybeSymbol:
+def _read_sym(ctx: ReaderContext, is_reader_macro_sym: bool = False) -> MaybeSymbol:
     """Return a symbol from the input stream.
 
     If a symbol appears in a syntax quoted form, the reader will attempt
@@ -1065,7 +1065,7 @@ def _read_sym(ctx: ReaderContext) -> MaybeSymbol:
             return False
         elif name == "&":
             return _AMPERSAND
-    if ctx.is_syntax_quoted and not name.endswith("#"):
+    if ctx.is_syntax_quoted and not name.endswith("#") and not is_reader_macro_sym:
         return ctx.resolve(sym.symbol(name, ns))
     return sym.symbol(name, ns=ns)
 
@@ -1670,7 +1670,7 @@ def _read_reader_macro(ctx: ReaderContext) -> LispReaderForm:  # noqa: MC0001
     elif char == "#":
         return _read_numeric_constant(ctx)
     elif ns_name_chars.match(char):
-        s = _read_sym(ctx)
+        s = _read_sym(ctx, is_reader_macro_sym=True)
         assert isinstance(s, sym.Symbol)
         if s.ns is None and s.name == "b":
             return _read_byte_str(ctx)


### PR DESCRIPTION
Fixes #1129 

For anyone who finds this PR (perhaps triaging a bug introduced by it in the future): I tried to ascertain exactly what Clojure JVM does in this situation and it is quite unclear in the reader code and not (at the time of writing) specified on any of the official documentation. Examples given there seem to indicate that fully qualified tags be given in `data_readers.cljc` and thus symbol resolution should not be performed on them, but they don't say explicitly. CLJS  `#js []` literals work as they do now in this PR so I'm going to assume this is the intended behavior.