### PR TITLE
`keyword` and `symbol` functions should treat strings as potentially namespaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  * Fix a bug where tags in data readers were resolved as Vars within syntax quotes, rather than using standard data readers rules (#1129)
+ * Fix a bug where `keyword` and `symbol` functions did not treat string arguments as potentially namespaced (#1131)
 
 ## [v0.3.2]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -507,9 +507,11 @@
 (defn symbol
   "Create a new symbol with ``name`` and optional namespace ``ns``.
 
-  ``name`` may be keyword, symbol, string, or Var. If ``name`` is a keyword or symbol with a
-  namespace, the namespace will be included in the resulting value. If ``name`` is a Var,
-  the Var's namespace will always be the namespace of the resulting value.
+  ``name`` may be keyword, symbol, string, or Var. If ``name`` is a keyword or symbol
+  with a namespace, the namespace will be included in the resulting value. If ``name``
+  is a Var, the Var's namespace will always be the namespace of the resulting value. If
+  ``name`` is a string with at least one '/', the string will be split on the first '/'
+  character with the first segment being used as ``ns`` and the second as ``name``.
 
   If ``ns`` is not ``nil``, then both ``name`` and ``ns`` must be strings."
   ([name]
@@ -522,7 +524,9 @@
   have the colon prefix added automatically, so it should not be provided.
 
   ``name`` may be keyword, symbol, or string. If ``name`` is a keyword or symbol with a
-  namespace, the namespace will be included in the resulting value.
+  namespace, the namespace will be included in the resulting value. If ``name`` is a
+  string with at least one '/', the string will be split on the first '/' character
+  with the first segment being used as ``ns`` and the second as ``name``.
 
   If ``ns`` is not ``nil``, then both ``name`` and ``ns`` must be strings."
   ([name]

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1081,7 +1081,7 @@ def _keyword_from_name_symbol(o: sym.Symbol) -> kw.Keyword:
 
 @keyword_from_name.register(str)
 def _keyword_from_name_str(o: str) -> kw.Keyword:
-    if "/" in o:
+    if "/" in o and o != "/":
         ns, name = o.split("/", maxsplit=1)
         return kw.keyword(name, ns=ns)
     return kw.keyword(o)
@@ -1113,7 +1113,7 @@ def _symbol_from_name_symbol(o: sym.Symbol) -> sym.Symbol:
 
 @symbol_from_name.register(str)
 def _symbol_from_name_str(o: str) -> sym.Symbol:
-    if "/" in o:
+    if "/" in o and o != "/":
         ns, name = o.split("/", maxsplit=1)
         return sym.symbol(name, ns=ns)
     return sym.symbol(o)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1081,6 +1081,9 @@ def _keyword_from_name_symbol(o: sym.Symbol) -> kw.Keyword:
 
 @keyword_from_name.register(str)
 def _keyword_from_name_str(o: str) -> kw.Keyword:
+    if "/" in o:
+        ns, name = o.split("/", maxsplit=1)
+        return kw.keyword(name, ns=ns)
     return kw.keyword(o)
 
 
@@ -1110,6 +1113,9 @@ def _symbol_from_name_symbol(o: sym.Symbol) -> sym.Symbol:
 
 @symbol_from_name.register(str)
 def _symbol_from_name_str(o: str) -> sym.Symbol:
+    if "/" in o:
+        ns, name = o.split("/", maxsplit=1)
+        return sym.symbol(name, ns=ns)
     return sym.symbol(o)
 
 

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -41,10 +41,12 @@
 (deftest keyword-test
   (testing "name only"
     (are [res name] (= res (keyword name))
-      (keyword "") ""
-      :name        "name"
-      :ns/name     :ns/name
-      :ns/name     'ns/name)
+      (keyword "")                     ""
+      :name                            "name"
+      :ns/name                         "ns/name"
+      (keyword "ns" "name/with-slash") "ns/name/with-slash"
+      :ns/name                         :ns/name
+      :ns/name                         'ns/name)
 
     (are [v] (thrown? python/TypeError (keyword v))
       nil
@@ -58,25 +60,27 @@
       :dotted.ns/name "dotted.ns" "name")
 
     (are [ns name] (thrown? python/TypeError (keyword ns name))
-      nil nil
-      :kw :kw
+      nil  nil
+      :kw  :kw
       'sym 'sym)))
 
 (deftest symbol-test
   (testing "name only"
     (are [res name] (= res (symbol name))
-      (symbol "")        ""
-      'name              "name"
-      'ns/name           :ns/name
-      'ns/name           'ns/name
-      'basilisp.core/map #'basilisp.core/map)
+      (symbol "")                     ""
+      'name                           "name"
+      'ns/name                        "ns/name"
+      (symbol "ns" "name/with-slash") "ns/name/with-slash"
+      'ns/name                        :ns/name
+      'ns/name                        'ns/name
+      'basilisp.core/map              #'basilisp.core/map)
 
     (are [v] (thrown? python/TypeError (symbol v))
       nil))
 
   (testing "name and namespace"
     (are [res ns name] (= res (symbol ns name))
-      (symbol "" "") ""          ""
+      (symbol "" "")  ""          ""
       'name           nil         "name"
       'ns/name        "ns"        "name"
       'dotted.ns/name "dotted.ns" "name")

--- a/tests/basilisp/test_core_fns.lpy
+++ b/tests/basilisp/test_core_fns.lpy
@@ -42,6 +42,8 @@
   (testing "name only"
     (are [res name] (= res (keyword name))
       (keyword "")                     ""
+      (keyword "/")                    "/"
+      (keyword "" "/")                 "//"
       :name                            "name"
       :ns/name                         "ns/name"
       (keyword "ns" "name/with-slash") "ns/name/with-slash"
@@ -68,6 +70,8 @@
   (testing "name only"
     (are [res name] (= res (symbol name))
       (symbol "")                     ""
+      (symbol "/")                    "/"
+      (symbol "" "/")                 "//"
       'name                           "name"
       'ns/name                        "ns/name"
       (symbol "ns" "name/with-slash") "ns/name/with-slash"


### PR DESCRIPTION
Fixes #1131 