### PR TITLE
Fix PyPI publishing action ref

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -42,4 +42,4 @@ jobs:
           path: dist/
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.2


### PR DESCRIPTION
Looks like I used a mix of the generic `release/v1` and specific version ref.