### PR TITLE
Fix a bug where `#` characters were not legal in keywords and symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Fix a bug where `#` characters were not legal in keywords and symbols (#1149)
 
 ## [v0.3.3]
 ### Added

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -621,7 +621,7 @@ def _read_namespaced(
                 has_ns = True
                 ns = name
                 name = []
-        elif ns_name_chars.match(char) or (name and char == "'"):
+        elif ns_name_chars.match(char) or (name and char == "'") or char == "#":
             reader.next_char()
             name.append(char)
         elif allowed_suffix is not None and char == allowed_suffix:

--- a/tests/basilisp/reader_test.py
+++ b/tests/basilisp/reader_test.py
@@ -598,6 +598,8 @@ class TestKeyword:
             ("yay!", ":yay!"),
             ("*'", ":*'"),
             ("a:b", ":a:b"),
+            ("#", ":#"),
+            ("div#id", ":div#id"),
         ],
     )
     def test_legal_bare_keyword(self, v: str, raw: str):
@@ -611,6 +613,7 @@ class TestKeyword:
             ("kw", "really.qualified.ns", ":really.qualified.ns/kw"),
             ("a:b", "ab", ":ab/a:b"),
             ("a:b", "a:b", ":a:b/a:b"),
+            ("#", "html", ":html/#"),
         ],
     )
     def test_legal_ns_keyword(self, k: str, ns: str, raw: str):
@@ -668,6 +671,7 @@ class TestSymbol:
             "ns.name",
             "*'",
             "a:b",
+            "div#id",
         ],
     )
     def test_legal_bare_symbol(self, s: str):
@@ -697,6 +701,7 @@ class TestSymbol:
             "/sym",
             ".second.ns/name",
             "ns..third/name",
+            "#",
             # This will raise because the default pushback depth of the
             # reader.StreamReader instance used by the reader is 5, so
             # we are unable to pushback more - characters consumed by


### PR DESCRIPTION
Fixes #1149 