### PR TITLE
Fix a bug with seqs in matching clauses of the `case` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
  * Fix a bug where `#` characters were not legal in keywords and symbols (#1149)
+ * Fix a bug where seqs were not considered valid input for matching clauses of the `case` macro (#1148)
 
 ## [v0.3.3]
 ### Added

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -3537,7 +3537,7 @@
                         (mapcat (fn [pair]
                                   (let [binding (first pair)
                                         expr    `(fn [] ~(second pair))]
-                                    (if (list? binding)
+                                    (if (seq? binding)
                                       (map #(vector (list 'quote %) expr) binding)
                                       [[(list 'quote binding) expr]])))
                                 (partition 2

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -318,8 +318,8 @@
 
 (defmacro case-with-seq
   []
-  (case :val
-    ~(seq [:val]) :found))
+  `(case :val
+     ~(seq [:val]) :found))
 
 (deftest case-test
   (is (= "yes" (case :a :b "nope" :c "mega nope" :a "yes" "nerp")))

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -316,6 +316,11 @@
   (let [l #py [1 2 3]]
     (is (= 6 (areduce l idx ret 0 (+ ret (aget l idx)))))))
 
+(defmacro case-with-seq
+  []
+  (case :val
+    ~(seq [:val]) :found))
+
 (deftest case-test
   (is (= "yes" (case :a :b "nope" :c "mega nope" :a "yes" "nerp")))
   (is (= "nope" (case :b :b "nope" :c "mega nope" :a "yes" "nerp")))
@@ -328,6 +333,7 @@
   (is (= "also no" (case 'd :a "no" (b c d) "also no" "duh")))
   (is (= "duh" (case 'e :a "no" (b c d) "also no" "duh")))
   (is (= 0 (case 1 0)))
+  (is (= :found (case-with-seq)))
   (let [out* (atom [])]
     (is (= 2 (case :2
                :1 (do (swap! out* conj 1) 1)


### PR DESCRIPTION
Fixes #1148 