### PR TITLE
Fix keywordization of keys from `py->lisp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
  * Fix a bug where `#` characters were not legal in keywords and symbols (#1149)
  * Fix a bug where seqs were not considered valid input for matching clauses of the `case` macro (#1148)
+ * Fix a bug where `py->lisp` did not keywordize string keys potentially containing namespaces (#1156)
 
 ## [v0.3.3]
 ### Added

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -1837,8 +1837,8 @@ def _keywordize_keys(k, keywordize_keys: bool = True):
 
 
 @_keywordize_keys.register(str)
-def _keywordize_keys_str(k, keywordize_keys: bool = True):
-    return kw.keyword(k)
+def _keywordize_keys_str(k: str, keywordize_keys: bool = True):
+    return keyword_from_name(k)
 
 
 @to_lisp.register(dict)

--- a/tests/basilisp/runtime_test.py
+++ b/tests/basilisp/runtime_test.py
@@ -687,6 +687,8 @@ class TestToLisp:
                         kw.keyword("f"): vec.v("tuple", "not", "list"),
                     }
                 ),
+                kw.keyword("h", ns="g"): "i/j",
+                kw.keyword("m", ns="k.l"): None,
             }
         ) == runtime.to_lisp(
             {
@@ -697,6 +699,8 @@ class TestToLisp:
                     "e": {"a", "set"},
                     kw.keyword("f"): ("tuple", "not", "list"),
                 },
+                "g/h": "i/j",
+                "k.l/m": None,
             }
         )
 


### PR DESCRIPTION
Fixes #1156 