### PR TITLE
Derive module (test) names from `ns` declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  * `alter-var-root` now returns the new value to align with Clojure behavior. Updated the docstring to highlight side effects of direct linking optimization (#1166)
+ * The test runner now supports loading test namespaces from any directory relative to `sys.path` without requiring any `__init__.py` files (#1155)
+
+### Fixed
+ * Fix an issue where test runner couldn't load test namespaces with underscores in their names (#1165)
 
 ## [v0.3.4]
 ### Added

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -88,6 +88,10 @@ However, the ``test`` directory must be explicity added to the `PYTHONPATH` usin
 
    $ basilisp test --include-path test
 
+.. note::
+
+   Test directory names can be arbitrary. By default, the test runner searches all subdirectories for tests. In the first example above (``tests``, a Python convention), the top-level directory is already in the `PYTHONPATH`, allowing ``tests.myproject.core-test`` to be resolvable. In the second example (``test``, a Clojure convention), the test directory is explicitly added to the `PYTHONPATH`, enabling ``myproject.core-test`` to be resolvable.
+
 .. _test_fixtures:
 
 Fixtures

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -41,28 +41,52 @@ For asserting repeatedly against different inputs, you can use the :lpy:fn:`are`
 Testing and ``PYTHONPATH``
 --------------------------
 
-Typical Clojure projects will have parallel ``src/`` and ``tests/`` folders in the project root.
+Typical Clojure projects will have parallel ``src/`` and ``test/`` folders in the project root.
 Project management tooling typically constructs the Java classpath to include both parallel trees for development and only ``src/`` for deployed software.
-Basilisp does not currently have such tooling (though it is planned!) and the recommended Python tooling is not configurable to allow for this distinction.
+Basilisp does not currently have such tooling, though it is planned.
 
-Due to this limitation, the easiest solution to facilitate test discovery with Pytest (Basilisp's default test runner) is to include a single, empty ``__init__.py`` file in the top-level ``tests`` directory:
+The easiest solution to facilitate test discovery with Pytest (Basilisp's default test runner) is to create a ``tests`` directory:
 
 .. code-block:: text
 
    tests
-   ├── __init__.py
    └── myproject
        └── core_test.lpy
 
 Test namespaces can then be created as if they are part of a giant ``tests`` package:
 
-.. code-block::
+.. code-block:: clojure
 
    (ns tests.myproject.core-test)
 
-.. note::
+Tests can be run with:
 
-   The project maintainers acknowledge that this is not an ideal solution and would like to provide a more Clojure-like solution in the future.
+.. code-block:: shell
+
+   $ basilisp test
+
+----
+
+Alternatively, you can follow the more tradiation Clojure project structure by creating a `test` (or similar) directory for your test namespaces:
+
+.. code-block:: text
+
+   test
+   └── myproject
+       └── core_test.lpy
+
+In this case, the test namespace can start at ``myproject``:
+
+.. code-block:: clojure
+
+   (ns myproject.core-test)
+
+
+However, the ``test`` directory must be explicity added to the `PYTHONPATH` using the ``--include-path`` (or ``-p``) option when running the tests:
+
+.. code-block:: shell
+
+   $ basilisp test --include-path test
 
 .. _test_fixtures:
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -67,7 +67,7 @@ Tests can be run with:
 
 ----
 
-Alternatively, you can follow the more tradiation Clojure project structure by creating a `test` (or similar) directory for your test namespaces:
+Alternatively, you can follow the more traditional Clojure project structure by creating a `test` directory for your test namespaces:
 
 .. code-block:: text
 
@@ -82,7 +82,7 @@ In this case, the test namespace can start at ``myproject``:
    (ns myproject.core-test)
 
 
-However, the ``test`` directory must be explicity added to the `PYTHONPATH` using the ``--include-path`` (or ``-p``) option when running the tests:
+However, the ``test`` directory must be explicitly added to the `PYTHONPATH` using the ``--include-path`` (or ``-p``) option when running the tests:
 
 .. code-block:: shell
 

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -59,9 +59,7 @@ def pytest_unconfigure(config):
         runtime.pop_thread_bindings()
 
 
-def pytest_collect_file(
-    file_path: Path, parent
-):
+def pytest_collect_file(file_path: Path, parent):
     """Primary PyTest hook to identify Basilisp test files."""
     if file_path.suffix == ".lpy":
         if file_path.name.startswith("test_") or file_path.stem.endswith("_test"):

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -59,8 +59,8 @@ def pytest_unconfigure(config):
         runtime.pop_thread_bindings()
 
 
-def pytest_collect_file(  # pylint: disable=unused-argument
-    file_path: Path, path, parent
+def pytest_collect_file(
+    file_path: Path, parent
 ):
     """Primary PyTest hook to identify Basilisp test files."""
     if file_path.suffix == ".lpy":

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -129,13 +129,13 @@ def _is_namespace_package(path: str) -> bool:
     return no_inits and has_basilisp_files
 
 
-def read_namespace_name(file: Path) -> str:
+def read_namespace_name(file: Path) -> Optional[str]:
     """Read the top-level `ns` form from Basilisp `file` and return
     its name. Return None if the the top sexp is not a valid `ns`
     form.
 
     """
-    ns_form = next(reader.read_file(file))
+    ns_form = next(iter(reader.read_file(str(file))))
     if (
         (isinstance(ns_form, lst.PersistentList) and len(ns_form) > 1)
         and str(ns_form[0]) == "ns"


### PR DESCRIPTION
Hi,

can you please review patch to derive module names for test namespaces directly from their top level `ns` declaration. It fixes #1155 and #1165.

The new approach improves upon the previous implementation by setting module names explicitly from the `ns` declaration at the top of the Basilisp files, instead of infering them from the file system structure using heuristics like checking for  `__init__.py` files.

I've updated the testrunner tests accordingly to cover various setups and tested it with various projects with tests, including basilisp-blender and basilisp-kernel, and the hiccup port, which follows the typical clojure test structure. I've also updated the documentation to describe the default `tests/` as well as the typical clojure `test/` structure.

Since I don't have a full understanding of the Basilisp module loading system, I may have missed something, so any feedback or suggestions are welcome.

Lastly, I’ve introduced strict handling for loading test namespaces without an `ns` declaration: an exception will be thrown in such cases. This behavior can be relaxed if necessary, but I can't think of a scenario where a Basilisp test file would be missing an ns declaration at the top.

Thanks

**Update1**: I've also removed the following `path` deprecated parameter while at it:

```shell
tests/basilisp/testrunner_test.py: 13 warnings
  /home/runner/work/basilisp/basilisp/.tox/py39/lib/python3.9/site-packages/basilisp/contrib/pytest/testrunner.py:62: PytestRemovedIn9Warning: The (path: py.path.local) argument is deprecated, please use (file_path: pathlib.Path)
  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
    def pytest_collect_file(  # pylint: disable=unused-argument

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```