### PR TITLE
Switch Python import machinery to focus primarily on Python modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * `import` now returns nil instead of the last module's string representation (#1174)
  *  The `:decorators` key now works in `defn` when passed as a metadata name key, expanding its support to `defn`-derived macros like `defasync` (#1178).
- * Change Python import machinery to be centered around Python code, rather than Basilisp namespaces (#????)
+ * Change Python import machinery to be centered around Python code, rather than Basilisp namespaces (#1155, #1165)
 
 ### Fixed
  * Fix a bug in `defn` where the `attr-map?` and function metdata were merged into a seq instead of a map, causing `macroexpand` to fail in some cases (#1186)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * `import` now returns nil instead of the last module's string representation (#1174)
  *  The `:decorators` key now works in `defn` when passed as a metadata name key, expanding its support to `defn`-derived macros like `defasync` (#1178).
+ * Change Python import machinery to be centered around Python code, rather than Basilisp namespaces (#????)
 
 ### Fixed
  * Fix a bug in `defn` where the `attr-map?` and function metdata were merged into a seq instead of a map, causing `macroexpand` to fail in some cases (#1186)

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -41,28 +41,59 @@ For asserting repeatedly against different inputs, you can use the :lpy:fn:`are`
 Testing and ``PYTHONPATH``
 --------------------------
 
-Typical Clojure projects will have parallel ``src/`` and ``tests/`` folders in the project root.
+Typical Clojure projects will have parallel ``src/`` and ``test/`` folders in the project root.
 Project management tooling typically constructs the Java classpath to include both parallel trees for development and only ``src/`` for deployed software.
-Basilisp does not currently have such tooling (though it is planned!) and the recommended Python tooling is not configurable to allow for this distinction.
+Basilisp does not currently have such tooling, though it is planned.
 
-Due to this limitation, the easiest solution to facilitate test discovery with Pytest (Basilisp's default test runner) is to include a single, empty ``__init__.py`` file in the top-level ``tests`` directory:
+The easiest solution to facilitate test discovery with Pytest (Basilisp's default test runner) is to create a ``tests`` directory:
 
 .. code-block:: text
 
    tests
-   ├── __init__.py
    └── myproject
        └── core_test.lpy
 
 Test namespaces can then be created as if they are part of a giant ``tests`` package:
 
-.. code-block::
+.. code-block:: clojure
 
    (ns tests.myproject.core-test)
 
+Tests can be run with:
+
+.. code-block:: shell
+
+   $ basilisp test
+
+----
+
+Alternatively, you can follow the more traditional Clojure project structure by creating a ``test`` directory for your test namespaces:
+
+.. code-block:: text
+
+   test
+   └── myproject
+       └── core_test.lpy
+
+In this case, the test namespace can start at ``myproject``:
+
+.. code-block:: clojure
+
+   (ns myproject.core-test)
+
+
+However, the ``test`` directory must be explicitly added to the ``PYTHONPATH`` using the ``--include-path`` (or ``-p``) option when running the tests:
+
+.. code-block:: shell
+
+   $ basilisp test --include-path test
+
 .. note::
 
-   The project maintainers acknowledge that this is not an ideal solution and would like to provide a more Clojure-like solution in the future.
+   Test directory names can be arbitrary.
+   By default, the test runner searches all subdirectories for tests.
+   In the first example above (``tests``, a Python convention), the top-level directory is already in the ``PYTHONPATH``, allowing ``tests.myproject.core-test`` to be resolvable.
+   In the second example (``test``, a Clojure convention), the test directory is explicitly added to the ``PYTHONPATH``, enabling ``myproject.core-test`` to be resolvable.
 
 .. _test_fixtures:
 

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -182,8 +182,8 @@ def _get_fully_qualified_module_names(file: Path) -> list[str]:
     This works by traversing up the filesystem looking for the top-most package. From
     there, we derive a Python module name referring to the given module path."""
     paths = []
-    for path in sys.path:
-        root = Path(path)
+    for pth in sys.path:
+        root = Path(pth)
         if file.is_relative_to(root):
             paths.append(root)
 

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -185,29 +185,11 @@ def _get_fully_qualified_module_names(file: Path) -> list[str]:
     for pth in sys.path:
         root = Path(pth)
         if file.is_relative_to(root):
-            paths.append(root)
-
-    if not paths:
-        top = None
-        for p in file.parents:
-            if _is_package(p):
-                top = p
-            else:
-                break
-
-        if top is None or top == file.parent:
-            return [file.stem]
-
-        paths.append(top.parent)
-
-    computed_paths = []
-    for path in paths:
-        elems = list(file.with_suffix("").relative_to(path).parts)
-        if elems[-1] == "__init__":
-            elems.pop()
-        computed_paths.append(".".join(elems))
-
-    return computed_paths
+            elems = list(file.with_suffix("").relative_to(pth).parts)
+            if elems[-1] == "__init__":
+                elems.pop()
+            paths.append(".".join(elems))
+    return paths
 
 
 class BasilispFile(pytest.File):

--- a/src/basilisp/lang/compiler/generator.py
+++ b/src/basilisp/lang/compiler/generator.py
@@ -3916,13 +3916,13 @@ def gen_py_ast(ctx: GeneratorContext, lisp_ast: Node) -> GeneratedPyAST[ast.expr
 #############################
 
 
-def _module_imports(ns: runtime.Namespace) -> Iterable[ast.Import]:
+def _module_imports() -> Iterable[ast.Import]:
     """Generate the Python Import AST node for importing all required
     language support modules."""
     # Yield `import basilisp` so code attempting to call fully qualified
     # `basilisp.lang...` modules don't result in compiler errors
     yield ast.Import(names=[ast.alias(name="basilisp", asname=None)])
-    for s in sorted(ns.imports.keys(), key=lambda s: s.name):
+    for s in sorted(runtime.Namespace.DEFAULT_IMPORTS, key=lambda s: s.name):
         name = s.name
         alias = _MODULE_ALIASES.get(name, None)
         yield ast.Import(names=[ast.alias(name=name, asname=alias)])
@@ -3970,10 +3970,10 @@ def _ns_var(
     )
 
 
-def py_module_preamble(ns: runtime.Namespace) -> GeneratedPyAST:
+def py_module_preamble() -> GeneratedPyAST:
     """Bootstrap a new module with imports and other boilerplate."""
     preamble: list[PyASTNode] = []
-    preamble.extend(_module_imports(ns))
+    preamble.extend(_module_imports())
     preamble.extend(_from_module_imports())
     preamble.append(_ns_var())
     return GeneratedPyAST(node=ast.Constant(None), dependencies=preamble)

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -53,6 +53,7 @@ from basilisp.lang.reduced import Reduced
 from basilisp.lang.reference import RefBase, ReferenceBase
 from basilisp.lang.typing import BasilispFunction, CompilerOpts, LispNumber
 from basilisp.lang.util import OBJECT_DUNDER_METHODS, demunge, is_abstract, munge
+from basilisp.logconfig import TRACE
 from basilisp.util import Maybe
 
 logger = logging.getLogger(__name__)
@@ -832,6 +833,7 @@ class Namespace(ReferenceBase):
         # If this is a new namespace and we're given a module (typically from the
         # importer), attach the namespace to the module.
         if module is not None:
+            logger.debug(f"Setting module '{module}' namespace to '{new_ns}'")
             module.__basilisp_namespace__ = new_ns
 
         # The `ns` macro is important for setting up a new namespace, but it becomes

--- a/src/basilisp/lang/runtime.py
+++ b/src/basilisp/lang/runtime.py
@@ -53,7 +53,6 @@ from basilisp.lang.reduced import Reduced
 from basilisp.lang.reference import RefBase, ReferenceBase
 from basilisp.lang.typing import BasilispFunction, CompilerOpts, LispNumber
 from basilisp.lang.util import OBJECT_DUNDER_METHODS, demunge, is_abstract, munge
-from basilisp.logconfig import TRACE
 from basilisp.util import Maybe
 
 logger = logging.getLogger(__name__)

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -261,3 +261,111 @@ def test_fixtures_with_errors(
     pytester.syspathinsert()
     result: pytest.RunResult = pytester.runpytest()
     result.assert_outcomes(passed=passes, failed=failures, errors=errors)
+
+
+def test_ns_in_syspath(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch):
+    runtime.Namespace.remove(sym.symbol("a.test-path"))
+
+    code = """
+    (ns a.test-path
+      (:require
+       [basilisp.test :refer [deftest is]]))
+    (deftest passing-test
+      (is true))
+    (deftest failing-test
+      (is false))
+    """
+    pytester.makefile(".lpy", **{"./test/a/test_path": code})
+    pytester.syspathinsert()
+    # ensure `a` namespace is in sys.path
+    monkeypatch.syspath_prepend(pytester.path / "test")
+    result: pytest.RunResult = pytester.runpytest("test")
+    result.assert_outcomes(passed=1, failed=1)
+
+
+def test_ns_in_syspath_w_src(
+    pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+):
+    runtime.Namespace.remove(sym.symbol("a.src"))
+    runtime.Namespace.remove(sym.symbol("a.test-path"))
+
+    code_src = """
+    (ns a.src)
+    (def abc 5)
+    """
+
+    code = """
+    (ns a.test-path
+      (:require
+       a.src
+       [basilisp.test :refer [deftest is]]))
+    (deftest a-test (is (= a.src/abc 5)))
+    (deftest passing-test
+      (is true))
+    (deftest failing-test
+      (is false))
+    """
+    # a slightly more complicated setup where packages under namespace
+    # `a` are both in src and test.
+    pytester.makefile(".lpy", **{"./test/a/test_path": code, "./src/a/src": code_src})
+    pytester.syspathinsert()
+    # ensure src and test is in sys.path
+    monkeypatch.syspath_prepend(pytester.path / "test")
+    monkeypatch.syspath_prepend(pytester.path / "src")
+    result: pytest.RunResult = pytester.runpytest("test")
+    result.assert_outcomes(passed=2, failed=1)
+
+
+def test_ns_not_in_syspath(pytester: pytest.Pytester):
+    runtime.Namespace.remove(sym.symbol("a.test-path"))
+
+    code = """
+    (ns a.test-path
+      (:require
+       [basilisp.test :refer [deftest is]]))
+    """
+    pytester.makefile(".lpy", **{"./test/a/test_path": code})
+    pytester.syspathinsert()
+    result: pytest.RunResult = pytester.runpytest("test")
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(["*ModuleNotFoundError: No module named 'test.a'"])
+
+
+def test_ns_with_underscore(pytester: pytest.Pytester):
+    runtime.Namespace.remove(sym.symbol("test_underscore"))
+
+    code = """
+    (ns test_underscore
+      (:require
+       [basilisp.test :refer [deftest is]]))
+    (deftest passing-test
+      (is true))
+    (deftest failing-test
+      (is false))
+    """
+    pytester.makefile(".lpy", test_underscore=code)
+    pytester.syspathinsert()
+    result: pytest.RunResult = pytester.runpytest()
+    result.assert_outcomes(passed=1, failed=1)
+
+
+def test_no_ns(pytester: pytest.Pytester):
+    runtime.Namespace.remove(sym.symbol("abc"))
+
+    code = """
+    (in-ns 'abc)
+    (require '[basilisp.test :refer [deftest is]]))
+    (deftest passing-test
+      (is true))
+    (deftest failing-test
+      (is false))
+    """
+    pytester.makefile(".lpy", test_under=code)
+    pytester.syspathinsert()
+    result: pytest.RunResult = pytester.runpytest()
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(
+        [
+            "*basilisp.lang.compiler.exception.CompilerException: unable to resolve symbol 'require'*"
+        ]
+    )


### PR DESCRIPTION
Possible alternative solution to #1165 and #1155

This PR changes the Python `importlib` machinery for Basilisp to simply focus on importing modules, without getting itself too mixed up in the business of figuring out what a namespace is actually _called_ from the module name. When `importlib.import_module` is called, Basilisp just figures out the location of the module on disk and starts loading it up as if it were a Basilisp module. It sets the newly introduced `basilisp.core/*import-module*` dynamic Var to the value of the importing module and lets the Basilisp runtime fetch that value down and attach it to a new namespace if and when it is appropriate to do so.

There may be some unintended side effects here for strange cases, so noting those here for now:
 * If multiple namespaces are created within a single invocation of `import.import_lib` (excluding recursive calls for other imports or requires), a module could be attached to multiple namespaces. I'm not sure if that's actually an issue, but it's certainly bizarre and could lead to some unintended consequences. That being said, I don't really think it is a priority for the project to support this style of bizarre metaprogramming, so that may be fine.
 * Namespace names and module names aren't necessarily "linked" anymore, although they never were linked directly before due to the required munging of module names for Python code.
 * Others?