### PR TITLE
return nil from `import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+ * `import` now returns nil instead of the last module's string representation (#1174)
 
 ## [v0.3.5]
 ### Changed
  * `alter-var-root` now returns the new value to align with Clojure behavior. Updated the docstring to highlight side effects of direct linking optimization (#1166)
- * `import` now returns nil instead of the last module's string representation (#1174)
 
 ### Fixed
  * Fix a regression introduced in #1161 which prevented passing namespace metadata on the name in the `ns` macro (#1173)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.3.5]
 ### Changed
  * `alter-var-root` now returns the new value to align with Clojure behavior. Updated the docstring to highlight side effects of direct linking optimization (#1166)
+ * `import` now returns nil instead of the last module's string representation (#1174)
 
 ### Fixed
  * Fix a regression introduced in #1161 which prevented passing namespace metadata on the name in the `ns` macro (#1173)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4936,9 +4936,9 @@
   ;; to the new ns, the global python namespace can still refer to the
   ;; old python global ns where the import would have been evaluated
   ;; otherwise.
-  (let [form `(import* ~@modules)]
-    `(do (eval '~form  *ns*)
-         nil)))
+  (let [form `(do (import* ~@modules)
+                  nil)]
+    `(eval '~form  *ns*)))
 
 (defn ^:private rewrite-clojure-libspec
   "Rewrite libspecs which point to namespaces starting with 'clojure.' to use a

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4937,7 +4937,8 @@
   ;; old python global ns where the import would have been evaluated
   ;; otherwise.
   (let [form `(import* ~@modules)]
-    `(eval '~form  *ns*)))
+    `(do (eval '~form  *ns*)
+         nil)))
 
 (defn ^:private rewrite-clojure-libspec
   "Rewrite libspecs which point to namespaces starting with 'clojure.' to use a


### PR DESCRIPTION
Hi,

can you please review patch to have `import` to return `nil`. It addresses #1174.

I haven't included a test for this case, nor mentioned it in the docstring, implying the return value is unspecified. I'm not sure this is something we want to fix at the API level (although I did request it as an aesthetic addition).