### PR TITLE
Ensure `defn` metadata are always preserved as a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  * `import` now returns nil instead of the last module's string representation (#1174)
 
+### Fixed
+ * Fix a bug in `defn` where the `attr-map?` and function metdata were merged into a seq instead of a map, causing `macroexpand` to fail in some cases (#1186)
+
 ## [v0.3.5]
 ### Changed
  * `alter-var-root` now returns the new value to align with Clojure behavior. Updated the docstring to highlight side effects of direct linking optimization (#1166)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -383,7 +383,7 @@
                    (first body)
                    nil)
           fname  (if fmeta
-                   (vary-meta name conj fmeta)
+                   (vary-meta name #(conj {} %1 %2) fmeta)
                    name)
           fname  (if doc
                    (vary-meta fname assoc :doc doc)

--- a/tests/basilisp/test_core_macros.lpy
+++ b/tests/basilisp/test_core_macros.lpy
@@ -79,7 +79,24 @@
         (is (= 'f8 (:name vmeta)))
         (is (= '([] [a]) (:arglists vmeta)))
         (is (= "0.1" (:added vmeta)))
-        (is (= "another multi-arity docstring" (:doc vmeta)))))))
+        (is (= "another multi-arity docstring" (:doc vmeta))))))
+
+  (testing "meta"
+    (let [fvar  (defn ^{:abc 9} f9 [] :kw)
+          vmeta (meta fvar)]
+      (is (= 'f9 (:name vmeta)))
+      (is (= '([]) (:arglists vmeta)))
+      (is (= 9 (:abc vmeta)))))
+
+  (testing "attr-map? and meta"
+    (let [fvar  (defn ^{:abc 9 :lmn 15} f10 {:abc 10 :xyz 11} [] :kw)
+          vmeta (meta fvar)]
+      (is (= 'f10 (:name vmeta)))
+      (is (= '([]) (:arglists vmeta)))
+      (is (= {:abc 10 :lmn 15 :xyz 11} (select-keys vmeta [:abc :lmn :xyz])))))
+
+  (testing "macroexpand with attr-map?"
+    (is (macroexpand '(defn fx {:abc 10} [] :kw)))))
 
 (deftest defasync-test
   (testing "single arity defasync"


### PR DESCRIPTION
Hi,

can you please review patch to merge the `attr-map?` and the metadata in `defn` using a `loop` rather than `conj`. It addresses #1186.

The previous `conj` operation was return in a list rather than a map. This also appears to be the likely cause why the `:decorators` meta key didn't work when passed in as `defn` metadata in `defasync`.

I've updated the test suite for the same.

Thanks