### PR TITLE
Fix a bug with inherited stdout in `basilisp.process/exec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  * Fix a bug in `defn` where the `attr-map?` and function metdata were merged into a seq instead of a map, causing `macroexpand` to fail in some cases (#1186)
+ * Fix a bug where `basilisp.process/exec` threw an exception when inheriting the stdout stream from the current process (#1190)
 
 ## [v0.3.5]
 ### Changed

--- a/src/basilisp/process.lpy
+++ b/src/basilisp/process.lpy
@@ -276,7 +276,9 @@
   (let [process (apply start opts+args)
         retcode (.wait process)]
     (if (zero? retcode)
-      (slurp (.-stdout process))
+      (if-let [out (.-stdout process)]
+        (slurp out)
+        "")
       (throw
        (subprocess/CalledProcessError retcode
                                       (.-args process)

--- a/tests/basilisp/test_process.lpy
+++ b/tests/basilisp/test_process.lpy
@@ -139,6 +139,7 @@
 
 (deftest exec-test
   (is (= "" (process/exec sys/executable "-c" "pass")))
+  (is (= "" (process/exec {:out :inherit} sys/executable "-c" "print(\"hi\")")))
   (is (= "" (process/exec sys/executable "-c" "import sys; print(\"hi\", file=sys.stderr)")))
   (is (= "hi\n" (process/exec sys/executable "-c" "print(\"hi\")")))
   (is (thrown? subprocess/CalledProcessError


### PR DESCRIPTION
Fixes #1190 