### PR TITLE
fix testrunner to handle relative entries in sys.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed 
+ * Fixed a regression introduced in #1176 where the testrunner couldn't handle relative paths in `sys.path`, causing `basilisp test` to fail when no arugments were provided (#1204)
+
 ## [v0.3.6]
 ### Added
  * Added support for the `:decorators` meta key in anonymous `fn`s (#1178)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -745,7 +745,7 @@ def test(
             "Cannot run tests without dependency PyTest. Please install PyTest and try again.",
         )
     else:
-        pytest.main(args=list(extra))
+        sys.exit(pytest.main(args=list(extra)))
 
 
 @_subcommand(
@@ -768,7 +768,9 @@ def test(
         If all options are unambiguous (e.g. they are only either used by Basilisp
         or by PyTest), then you can omit the `--`:
 
-            `basilisp test -k vector -p other_dir`"""
+            `basilisp test -k vector -p other_dir`
+
+        Returns the PyTest exit code as the exit code."""
     ),
     handler=test,
     allows_extra=True,

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -284,11 +284,6 @@ def test_basilisp_test_noargs(pytester: pytest.Pytester):
     cmd = [basilisp, "test"]
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=pytester.path)
 
-    print(f"\n\n--cmd--start: {' '.join(cmd)}")
-    print(f"\n\n--stdout--\n\n {result.stdout.strip()}")
-    print(f"\n\n--stderr--:\n\n {result.stderr.strip()}")
-    print(f"\n\n--cmd--end--: {' '.join(cmd)}\n\n")
-
     assert "==== 1 passed" in result.stdout.strip()
 
     assert result.returncode == 0

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -1,4 +1,6 @@
 import platform
+import shutil
+import subprocess
 import sys
 
 import pytest
@@ -263,6 +265,35 @@ def test_fixtures_with_errors(
     result.assert_outcomes(passed=passes, failed=failures, errors=errors)
 
 
+def test_basilisp_test_noargs(pytester: pytest.Pytester):
+    runtime.Namespace.remove(sym.symbol("a.test-path"))
+
+    code = """
+    (ns tests.test-path
+      (:require
+       [basilisp.test :refer [deftest is]]))
+    (deftest passing-test
+      (is true))
+    """
+    pytester.makefile(".lpy", **{"./tests/test_path": code})
+
+    # I couldn't find a way to directly manipulate the pytester's
+    # `sys.path` with the precise control needed by this test, so we're
+    # invoking `basilisp test` directly as a subprocess instead ...
+    basilisp = shutil.which("basilisp")
+    cmd = [basilisp, "test"]
+    result = subprocess.run(cmd, capture_output=True, text=True, cwd=pytester.path)
+
+    print(f"\n\n--cmd--start: {' '.join(cmd)}")
+    print(f"\n\n--stdout--\n\n {result.stdout.strip()}")
+    print(f"\n\n--stderr--:\n\n {result.stderr.strip()}")
+    print(f"\n\n--cmd--end--: {' '.join(cmd)}\n\n")
+
+    assert "==== 1 passed" in result.stdout.strip()
+
+    assert result.returncode == 0
+
+
 def test_ns_in_syspath(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch):
     runtime.Namespace.remove(sym.symbol("a.test-path"))
 
@@ -324,11 +355,18 @@ def test_ns_not_in_syspath(pytester: pytest.Pytester):
       (:require
        [basilisp.test :refer [deftest is]]))
     """
-    pytester.makefile(".lpy", **{"./test/a/test_path": code})
+    # In this test, we use a `testabc` directory instead of `test`, as
+    # the latter can cause issues on macOS.  Specifically, macOS has a
+    # `/Library/Frameworks/Python.framework/Versions/3.xx/lib/python3.13/test`
+    # directory is picked up, resulting in a slightly different error
+    # message.
+    pytester.makefile(".lpy", **{"./testabc/a/test_path": code})
     pytester.syspathinsert()
-    result: pytest.RunResult = pytester.runpytest("test")
+    result: pytest.RunResult = pytester.runpytest("testabc")
     assert result.ret != 0
-    result.stdout.fnmatch_lines(["*ModuleNotFoundError: No module named 'test.a'"])
+    result.stdout.fnmatch_lines(
+        ["*ModuleNotFoundError: Module named 'a.test-path' is not in sys.path"]
+    )
 
 
 def test_ns_with_underscore(pytester: pytest.Pytester):


### PR DESCRIPTION
Hi,

could you please review patch to fix a likely regression issue where the testrunner couldn't handle relative paths in `sys.path`. It fixes #1204.

This is likely a regression from #1176, where the update to the new module loading system caused relative paths to never match a fully qualified module name. The patch now expands relative paths to their absolute form before comparing them to the module path.

This issue was breaking the vanilla `basilisp test` command, as it adds an empty string (`""`) entry to `sys.path`, which is interpreted as `"."`. Since this is a relative path, it wasn’t handled by the logic, causing the project directory not to be recognized as the root of the Basilisp test modules.

I’ve added a test that invokes `basilisp test` directly as a subprocess. Unfortunately, I couldn’t find a way to control the pytester `sys.path` entries with the precise control required for this test.  Any counter suggestions are most welcome.

Thanks