### PR TITLE
Suppress successive forms with stacked `#_` reader macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Single arity functions can be tagged with `^:allow-unsafe-names` to preserve their parameter names (#1212)
 
 ### Fixed
- * Fix an issue where the compiler would generate an illegal `return` statement for asynchronous generators (#1180) 
+ * Fix an issue where the compiler would generate an illegal `return` statement for asynchronous generators (#1180)
+ * Fix an issue where consecutive reader comment forms would not be ignored (#1207)
 
 ## [v0.3.7]
 ### Fixed 

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -1667,7 +1667,7 @@ def _read_reader_macro(ctx: ReaderContext) -> LispReaderForm:  # noqa: MC0001
         return _read_regex(ctx)
     elif char == "_":
         ctx.reader.advance()
-        _read_next(ctx)  # Ignore the entire next form
+        _read_next_consuming_comment(ctx)  # Ignore the entire next form
         return COMMENT
     elif char == "!":
         return _read_comment(ctx)


### PR DESCRIPTION
Fixes #1207 