### PR TITLE
Add a CLI subcommand to install Clojure Jar files in the virtualenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added the `basilisp.url` namespace for structured URL manipulation (#1239)
  * Added support for proxies (#425)
  * Added a `:slots` meta flag for `deftype` to disable creation of `__slots__` on created types (#1241)
+ * Added a CLI subcommand `install-jar` to install a Clojure `*.jar` file into the virtualenv (#668)
 
 ### Changed
  * Removed implicit support for single-use iterables in sequences, and introduced `iterator-seq` to expliciltly handle them (#1192)

--- a/src/basilisp/contrib/jarutil.py
+++ b/src/basilisp/contrib/jarutil.py
@@ -1,0 +1,23 @@
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+
+def install_jar(site_packages: Path, source_jar: Path) -> None:
+    if source_jar.suffix != ".jar":
+        raise ValueError(f"Expected a *.jar file; got *{source_jar.suffix}")
+
+    with TemporaryDirectory() as tmpdir, ZipFile(source_jar, mode="r") as zf:
+        zf.extractall(
+            path=tmpdir,
+            members=[mem for mem in zf.namelist() if not mem.startswith("META-INF")],
+        )
+        for p in Path(tmpdir).iterdir():
+            if p.is_dir():
+                destination = site_packages / p.name
+                d = shutil.copytree(p, destination)
+                print(f"Created {d}")
+            else:
+                f = shutil.copy(p, site_packages)
+                print(f"Created {f}")


### PR DESCRIPTION
Fixes #668 

I wanted to add this subcommand as a sort of provisional attempt to address #668. For now, the idea is to point `basilisp install-jar [jar]` to a `*.jar` file in your local Maven repository:

```bash
$ clojure -Sdeps '{:deps {org.clojure/tools.cli {:mvn/version "1.1.230"}}}'
$ basilisp install-jar  ~/.m2/repository/org/clojure/tools.cli/1.1.230/tools.cli-1.1.230.jar
```

Because Clojure's directory structure is generally compatible with Basilisps and because Basilisp can read `*.cljc` files now, this should make the library immediately importable. _However..._

In testing this (very rudimentary) solution, I wasn't able to find almost any Clojure libraries that would load without some additional modifications. I tried to find "pure" Clojure libraries (such as [medley](https://github.com/weavejester/medley) and even [tools.cli](https://github.com/clojure/tools.cli)) but they typically lacked `:lpy` reader conditionals in one or more points in the code so it wouldn't load. Given the limited scope of Clojure libraries that might work with Basilisp out of the box, I question the value of this functionality.

I don't foresee this being the final format of this functionality, but until I'm able to really dig in on some of the tickets around project management I imagined something like this might be a decent stop gap.