### PR TITLE
Synchronize `basilisp.main.init` to allow repeat invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * `basilisp.core/str` now delegates to the builtin Python `str` in all cases except for customizing the string output for builtin Python types (#1237)
  * Optimised mainstream seq-consuming functions by coercing their inputs into `seq` upfront (#1234)
  * Renamed `awith` and `afor` to `with-async` and `for-async` for improved clarity (#1248)
+ * `basilisp.main.init` will only initialize the runtime environment on the first invocation (#1242)
 
 ### Fixed
  * Fix a bug where protocols with methods with leading hyphens in the could not be defined (#1230)

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -120,8 +120,16 @@ Given a Basilisp entrypoint function ``main`` (taking no arguments) in the ``pro
 If you were to place this in a module such as ``myproject.main``, you could easily configure a `setuptools entry point <https://setuptools.pypa.io/en/latest/userguide/entry_point.html>`_ (or any analog with another build tool) to point to that script directly, effectively launching you directly to Basilisp code.
 
 For more sophisticated projects which may not have a direct or wrappable entrypoint, you can initialize the Basilisp runtime directly by calling :py:func:`basilisp.main.init` with no arguments.
-This may be a better fit for a project using something like Django, where the entrypoint is dictated by Django.
-In that case, you could use a hook such as Django's ``AppConfig.ready()``.
+A natural placement for this function call would be in the root ``__init__.py`` for a package, where you can freely import and initialize Basilisp.
+
+.. code-block:: python
+
+   import basilisp.main
+
+   basilisp.main.init()
+
+You could also initialize Basilisp in a framework such as Django, where the entrypoint is dictated by the framework.
+For example, you could use a hook such as Django's ``AppConfig.ready()``.
 
 .. code-block:: python
 


### PR DESCRIPTION
Fixes #1242 