### PR TITLE
rename awhile, afor to while-async, for-async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Removed implicit support for single-use iterables in sequences, and introduced `iterator-seq` to expliciltly handle them (#1192)
  * `basilisp.core/str` now delegates to the builtin Python `str` in all cases except for customizing the string output for builtin Python types (#1237)
  * Optimised mainstream seq-consuming functions by coercing their inputs into `seq` upfront (#1234)
+ * Renamed `awhile` and `afor` to `while-async` and `for-async` for improved clarity (#1248)
 
 ### Fixed
  * Fix a bug where protocols with methods with leading hyphens in the could not be defined (#1230)

--- a/src/basilisp/core.lpy
+++ b/src/basilisp/core.lpy
@@ -4120,13 +4120,13 @@
 ;; Async Macros ;;
 ;;;;;;;;;;;;;;;;;;
 
-(defmacro afor
+(defmacro for-async
   "Repeatedly execute ``body`` while the binding name is repeatedly rebound to
   successive values from the asynchronous iterable.
 
   .. warning::
 
-     The ``afor`` macro may only be used in an asynchronous function context."
+     The ``for-async`` macro may only be used in an asynchronous function context."
   [binding & body]
   (if (operator/ne 2 (count binding))
     (throw
@@ -4144,14 +4144,14 @@
            (catch python/StopAsyncIteration _
              val#))))))
 
-(defmacro awith
+(defmacro with-async
   "Evaluate ``body`` within a ``try`` / ``except`` expression, binding the named
   expressions as per Python's async context manager protocol spec (Python's
   ``async with`` blocks).
 
   .. warning::
 
-     The ``awith`` macro may only be used in an asynchronous function context."
+     The ``with-async`` macro may only be used in an asynchronous function context."
   [bindings & body]
   (let [binding (first bindings)
         expr    (second bindings)]

--- a/tests/basilisp/test_core_async_macros.lpy
+++ b/tests/basilisp/test_core_async_macros.lpy
@@ -9,7 +9,7 @@
     (asyncio/set-event-loop loop)
     (.run-until-complete loop (apply f args))))
 
-(deftest awith-test
+(deftest with-async-test
   (testing "base case"
     (let [get-val    (contextlib/asynccontextmanager
                       (fn ^:async get-val
@@ -17,11 +17,11 @@
                         (yield :async-val)))
           val-ctxmgr (fn ^:async yield-val
                        []
-                       (awith [v (get-val)]
-                              v))]
+                       (with-async [v (get-val)]
+                         v))]
       (is (= :async-val (async-to-sync val-ctxmgr))))))
 
-(deftest afor-test
+(deftest for-async-test
   (testing "base case"
     (let [get-vals (fn ^:async get-vals
                      []
@@ -30,8 +30,8 @@
           val-loop (fn ^:async val-loop
                      []
                      (let [a   (atom [])
-                           res (afor [v (get-vals)]
-                                     (swap! a conj v)
-                                     v)]
+                           res (for-async [v (get-vals)]
+                                          (swap! a conj v)
+                                          v)]
                        [@a res]))]
       (is (= [[0 1 2 3 4] 4] (async-to-sync val-loop))))))


### PR DESCRIPTION
Hi,

can you please review patch to rename the `awhile` and `afor` macros to `while-async` and `for-async` for better clarity. It addresses the point about naming in #1248.

I felt placing `async` after `for`/`while` reads more naturally, but I'm open to other suggestions if you think a better naming.

Thanks

