### PR TITLE
fix async test warning

### DIFF
--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -3079,8 +3079,10 @@ class TestFunctionDef:
         )
 
         async def get():
+            ret = None
             async for val in awaiter_fn():
-                return val
+                ret = val
+            return ret
 
         assert kw.keyword("async-generator") == async_to_sync(get)
 


### PR DESCRIPTION
Hi,

can you please consider patch to fix the following test warning. It ensures the async generator is properly closed by completing the `async for` loop.

thanks 

```
========================================== warnings summary ===========================================
tests/basilisp/compiler_test.py::TestFunctionDef::test_multi_arity_meta
  /opt/homebrew/Cellar/python@3.13/3.13.3/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py:744: RuntimeWarning: coroutine method 'aclose' of '__unique_kdghii_1104' was never awaited
    self._ready.clear()
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== 49 passed, 3718 deselected, 1 warning in 1.20s ============================

```