### PR TITLE
suppress pytest rewrite assertion warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Optimised mainstream seq-consuming functions by coercing their inputs into `seq` upfront (#1234)
  * Renamed `awith` and `afor` to `with-async` and `for-async` for improved clarity (#1248)
  * `basilisp.main.init` will only initialize the runtime environment on the first invocation (#1242)
+ * Suppress pytest assertion rewrite warning for basilisp when running `basilisp test` (#1252)
 
 ### Fixed
  * Fix a bug where protocols with methods with leading hyphens in the could not be defined (#1230)

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -745,6 +745,15 @@ def test(
             "Cannot run tests without dependency PyTest. Please install PyTest and try again.",
         )
     else:
+        # `basilisp` declares the testrunner as a pytest plugin, so
+        # pytest tries to import it for assertion rewriting.  Since
+        # it's already imported, pytest emits a warning. As rewriting
+        # isn't needed, we ignore it.
+        extra = [
+            "-W",
+            "ignore:Module already imported so cannot be rewritten:pytest.PytestAssertRewriteWarning",
+        ] + extra
+
         sys.exit(pytest.main(args=list(extra)))
 
 


### PR DESCRIPTION
Hi,

can you please consider patch to suppress the pytest rewrite assertion warning when running `basilisp test`. It fixes #1252 

I haven’t added a test, as it would require creating a virtual environment during testing, which seemed excessive for this issue. However, I’m happy to add one if you feel it’s necessary.

Thanks