### PR TITLE
Publish artifacts to Github Release

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build the distribution
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,10 +28,40 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  release:
+  github-release:
     runs-on: ubuntu-latest
     environment:
       name: release
+    name: >-
+      Sign the Python distribution with Sigstore and upload them to GitHub Release
+    needs:
+      - build
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: gh release upload "$GITHUB_REF_NAME" dist/** --repo "$GITHUB_REPOSITORY"
+
+  pypi-release:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    name: Release to PyPI
     needs:
       - build
     permissions:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -73,4 +73,4 @@ jobs:
           path: dist/
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -73,4 +73,4 @@ jobs:
           path: dist/
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -46,3 +46,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
+          skip-existing: true

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -1,0 +1,48 @@
+name: Release to Test PyPI
+
+on:
+  push:
+    branches: [ main, "feature/publish-artifacts-to-release" ]
+
+concurrency:
+  group: test-pypi-release
+
+jobs:
+  build:
+    name: Build the distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ vars.PYTHON_VERSION }}
+      - name: Install Poetry
+        run: curl -sSL https://install.python-poetry.org | python3 -
+      - name: Build Basilisp distributions
+        run: poetry build
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/
+          if-no-files-found: error
+
+  test-pypi-release:
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/basilisp
+    name: Release to PyPI
+    needs:
+      - build
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.2
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -43,6 +43,6 @@ jobs:
           path: dist/
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -2,7 +2,7 @@ name: Release to Test PyPI
 
 on:
   push:
-    branches: [ main, "feature/publish-artifacts-to-release" ]
+    branches: [ main ]
 
 concurrency:
   group: test-pypi-release

--- a/.github/workflows/test-pypi-release.yml
+++ b/.github/workflows/test-pypi-release.yml
@@ -31,7 +31,7 @@ jobs:
     environment:
       name: test-pypi
       url: https://test.pypi.org/p/basilisp
-    name: Release to PyPI
+    name: Release to Test PyPI
     needs:
       - build
     permissions:
@@ -43,6 +43,6 @@ jobs:
           path: dist/
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
 * Add a step to the release pipeline to publish sigstore signed artifacts to the associated Github Release.
 * Add a Test PyPI release job which runs on merge to `main`.