### PR TITLE
Separate hash map elements with comma in printer output

### DIFF
--- a/src/basilisp/lang/map.py
+++ b/src/basilisp/lang/map.py
@@ -188,7 +188,7 @@ def map_lrepr(  # pylint: disable=too-many-locals
     else:
         items = list(entry_reprs())
 
-    seq_lrepr = PRINT_SEPARATOR.join(items + trailer)
+    seq_lrepr = ", ".join(items + trailer)
 
     ns_prefix = ("#:" + ns_name_shared) if ns_name_shared else ""
     if kwargs["print_meta"] and meta:


### PR DESCRIPTION
Issue: https://github.com/basilisp-lang/basilisp/issues/1275

Dismiss global `PRINT_SEPARATOR` (empty/whitespace by default?) as hash map is a special case and benefits generally of the separator between pairs for readability.

Demo:
```
make repl
basilisp.user=> {:1 :2 :3 :4 :5 :6 :7 :8}
{:5 :6, :7 :8, :3 :4, :1 :2}
```

I'm not familiar of philosophy behind `PRINT_SEPARATOR` so improvement ideas are welcome. Maybe this variable could be overridden only when it has the empty default value? That way hash map would use comma separator as exception by default and the separator could be changed if wanted (is that something people would need to do?).