### PR TITLE
suppress pytest rewrite assertion warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ prompt-toolkit = ">=3.0.0,<4.0.0"
 pyrsistent = ">=0.18.0,<1.0.0"
 typing-extensions = ">=4.7.0,<5.0.0"
 
-pytest = { version = ">=8.4.0,<9.0.0", optional = true }
+pytest = { version = ">=7.0.0,<9.0.0", optional = true }
 pygments = { version = ">=2.9.0,<3.0.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
@@ -45,7 +45,7 @@ black = ">=24.0.0"
 docutils = "*"
 isort = "*"
 pygments = "*"
-pytest = ">=8.4.0,<9.0.0"
+pytest = ">=7.0.0,<9.0.0"
 pytest-pycharm = "*"
 # Ensure the Sphinx version remains synchronized with docs/requirements.txt
 # to maintain consistent output during both development and publishing on

--- a/src/basilisp/cli.py
+++ b/src/basilisp/cli.py
@@ -748,7 +748,8 @@ def test(
         # `basilisp` declares the testrunner as a pytest plugin, so
         # pytest tries to import it for assertion rewriting.  Since
         # it's already imported, pytest emits a warning. As rewriting
-        # isn't needed, we ignore it.
+        # isn't needed, we ignore it. (Requires pytest >=8.4.0 to take
+        # effect)
         extra = [
             "-W",
             "ignore:Module already imported so cannot be rewritten; basilisp:pytest.PytestAssertRewriteWarning",


### PR DESCRIPTION
Hi,

can you please consider patch to suppress the pytest rewrite assertion warning when running `basilisp test`. It fixes #1252.

I haven’t added a test, as it would require creating a virtual environment during testing, which seemed excessive for this issue. However, I’m happy to add one if you feel it’s necessary.

Thanks

Note: this is a follow up to #1255 but it uses the `;` separator to specify the module name, introduced by  https://github.com/pytest-dev/pytest/pull/13429 in [Pytest 8.4.0](https://docs.pytest.org/en/stable/changelog.html#pytest-8-4-0-2025-06-02).