### PR TITLE
Allow empty `try` and `catch` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  * Added support for Python 3.14 (#1282)
 
+### Changed
+ * `try` and `catch` special form bodies may now be empty and will return `nil` when no expressions are given (#1294)
+
 ### Fixed
  * Fix a bug where `import` refers would incorrectly be applied to all import modules in the same form (#1274)
  * Suppress pytest assertion rewrite warning for basilisp when running `basilisp test` (#1252)

--- a/docs/specialforms.rst
+++ b/docs/specialforms.rst
@@ -393,8 +393,8 @@ Primary Special Forms
 
 .. lpy:specialform:: (try *exprs *catch-exprs finally?)
 
-   Execute 1 or more expressions (``exprs``) in an implicit :lpy:form:`do`, returning the final value if no exceptions occur.
-   If an exception occurs and a matching ``catch`` expression is provided, handle the exception and return the value of the ``catch`` expression.
+   Execute 0 or more expressions (``exprs``) in an implicit :lpy:form:`do`, returning the final value if no exceptions occur or ``nil`` if no expressions were given.
+   If an exception occurs and a matching ``catch`` expression is provided, handle the exception and return the value of the ``catch`` expression or ``nil`` if no expression is given.
    Evaluation of which ``catch`` expression to use follows the semantics of the underlying Python VM -- that is, for an exception ``e``, bind to the first ``catch`` expression for which ``(instance? ExceptionType e)`` returns ``true``.
    Users may optionally provide a ``finally`` clause trailing the final ``catch`` expression which will be executed in all cases.
 

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -3319,7 +3319,7 @@ def _catch_ast(form: ISeq, ctx: AnalyzerContext) -> Catch:
     assert form.first == SpecialForm.CATCH
     nelems = count(form)
 
-    if nelems < 4:
+    if nelems < 3:
         raise ctx.AnalyzerException(
             "catch forms must contain at least 4 elements: (catch class local body*)",
             form=form,
@@ -3415,7 +3415,11 @@ def _try_ast(form: ISeq, ctx: AnalyzerContext) -> Try:
         isinstance(node, Catch) for node in catches
     ), "All catch statements must be catch ops"
 
-    *try_statements, try_ret = try_exprs
+    if try_exprs:
+        *try_statements, try_ret = try_exprs
+    else:
+        try_statements, try_ret = [], _const_node(None, ctx)
+
     return Try(
         form=form,
         body=Do(

--- a/tests/basilisp/compiler_test.py
+++ b/tests/basilisp/compiler_test.py
@@ -6192,6 +6192,14 @@ class TestThrow:
 
 
 class TestTryCatch:
+    def test_try_empty_body(self, lcompile: CompileFn):
+        assert None is lcompile(
+            """
+          (try
+            (catch AttributeError _ :not-nil))
+        """
+        )
+
     def test_single_catch_ignoring_binding(
         self,
         lcompile: CompileFn,
@@ -6252,16 +6260,16 @@ class TestTryCatch:
         captured = capsys.readouterr()
         assert "neither\n" == captured.out
 
-    def test_catch_num_elems(self, lcompile: CompileFn):
-        with pytest.raises(compiler.CompilerException):
-            lcompile(
-                """
-              (try
-                (.lower "UPPER")
-                (catch AttributeError _))
+    def test_catch_default_nil(self, lcompile: CompileFn):
+        assert None is lcompile(
             """
-            )
+          (try
+            (.fakemethod "UPPER")
+            (catch AttributeError _))
+        """
+        )
 
+    def test_catch_num_elems(self, lcompile: CompileFn):
         with pytest.raises(compiler.CompilerException):
             lcompile(
                 """


### PR DESCRIPTION
Fixes #1294 