### PR TITLE
Revert support for `clojure.test` style test fixtures

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,7 @@ jobs:
           TOX_SHOW_OUTPUT: "True"
           TOXENV: ${{ matrix.tox-env }}
         run: |
-          tox run-parallel -p 4
+          tox run-parallel -p 4 -- -n auto
           mkdir coverage
           mv .coverage.* "coverage/.coverage.py${{ matrix.version }}"
       - name: Archive code coverage results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Added support for Python 3.14 (#1282)
  * Added support for Unicode escape sequences in string literals (#1295)
  * Added environment variable configurations for the PyTest testrunner to allow more specific test discovery (#1301)
- * Added support for `clojure.test` style fixtures (#1305)
  * Added no-op Clojure compatibility functions: `inc'`, `dec'`, `int-array`, `long-array`, `short-array`, `float-array`, `double-array`, `bool-array` (#1305)
 
 ### Changed

--- a/src/basilisp/contrib/pytest/testrunner.py
+++ b/src/basilisp/contrib/pytest/testrunner.py
@@ -3,13 +3,11 @@ import inspect
 import os
 import re
 import sys
-import threading
 import traceback
 from collections.abc import Callable, Iterable, Iterator
 from functools import cache
 from pathlib import Path
 from types import GeneratorType
-from typing import Optional, cast
 
 import pytest
 
@@ -123,9 +121,7 @@ class TestFailuresInfo(Exception):
 
 TestFunction = Callable[[], lmap.PersistentMap]
 FixtureTeardown = Iterator[None]
-FixtureFunction = (
-    Callable[[], Optional[FixtureTeardown]] | Callable[[Callable[[], None]], None]
-)
+FixtureFunction = Callable[[], FixtureTeardown | None]
 
 
 class FixtureManager:
@@ -149,12 +145,7 @@ class FixtureManager:
             next(coro)
             return coro
         else:
-            # Clojure use-fixtures functions expect to receive a function of no
-            # arguments which they call to execute the tests. In our case, use
-            # a threading.Event to wait until the function is called to proceed.
-            evt = threading.Event()
-            cast(Callable[[Callable[[], None]], None], fixture)(evt.set)
-            evt.wait()
+            fixture()
             return None
 
     @classmethod

--- a/tests/basilisp/cli_test.py
+++ b/tests/basilisp/cli_test.py
@@ -195,7 +195,7 @@ class TestCompilerFlags:
         )
         assert f"3{os.linesep}" == result.lisp_out
 
-    @pytest.mark.parametrize("val", BOOL_TRUE | BOOL_FALSE)
+    @pytest.mark.parametrize("val", sorted(BOOL_TRUE | BOOL_FALSE))
     def test_valid_flag(self, run_cli, val):
         result = run_cli(
             ["run", "--warn-on-var-indirection", val, "-c", "(println  (+ 1 2))"]

--- a/tests/basilisp/testrunner_test.py
+++ b/tests/basilisp/testrunner_test.py
@@ -180,9 +180,9 @@ def test_fixtures(pytester: pytest.Pytester):
     (def each-cleanup (volatile! 0))
 
     ;; return here rather than yielding
-    (defn once-fixture-no-cleanup [tests]
+    (defn once-fixture-no-cleanup []
       (vswap! once-no-cleanup inc)
-      (tests))
+      (yield))
 
     (defn once-fixture-w-cleanup []
       (vswap! once-cleanup inc)


### PR DESCRIPTION
This never worked and the test didn't adequately assess that. Reverting for now. I have filed #1306 to address this in the future.