### PR TITLE
Revert pytest-xdist in Github Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,7 @@ jobs:
           TOX_SHOW_OUTPUT: "True"
           TOXENV: ${{ matrix.tox-env }}
         run: |
-          tox run-parallel -p 4 -- -n auto
+          tox run-parallel -p 4
           mkdir coverage
       - name: Collect code coverage files
         if: "startsWith (matrix.os, 'ubuntu')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,6 @@ omit = [
     "*/__version__.py",
     "*/basilisp/contrib/sphinx/*",
 ]
-patch = ["subprocess"]
 
 [tool.coverage.paths]
 source = [


### PR DESCRIPTION
Since adding support for `pytest-xdist` and fixing Coverage to correctly account for its spawned subprocesses, CI jobs have been taking much longer to complete. 