### PR TITLE
Performance improvements

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,10 +88,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        version: ['3.10', '3.11']
+        version: ['3.11']
         include:
-          - version: '3.10'
-            tox-env: pypy310
           - version: '3.11'
             tox-env: pypy311
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ * Performance improvements for compile time and runtime
+
 ## [v0.5.1]
 ### Added
  * Added `basilisp.csv` namespace (#753)

--- a/src/basilisp/importer.py
+++ b/src/basilisp/importer.py
@@ -48,7 +48,7 @@ def _basilisp_bytecode(
     data.extend(_w_long(mtime))
     data.extend(_w_long(source_size))
     data.extend(marshal.dumps(code))
-    return data
+    return bytes(data)
 
 
 def _get_basilisp_bytecode(

--- a/src/basilisp/lang/compiler/analyzer.py
+++ b/src/basilisp/lang/compiler/analyzer.py
@@ -351,7 +351,7 @@ class AnalyzerContext:
         allow_unresolved_symbols: bool = False,
     ) -> None:
         self._allow_unresolved_symbols = allow_unresolved_symbols
-        self._filename = Maybe(filename).or_else_get(DEFAULT_COMPILER_FILE_PATH)
+        self._filename = DEFAULT_COMPILER_FILE_PATH if filename is None else filename
         self._func_ctx: collections.deque[FunctionContext] = collections.deque([])
         self._is_quoted: collections.deque[bool] = collections.deque([])
         self._opts = (

--- a/src/basilisp/lang/compiler/nodes.py
+++ b/src/basilisp/lang/compiler/nodes.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from enum import Enum
 from typing import Any, Generic, Optional, TypeVar, Union
 
@@ -199,19 +199,11 @@ class Node(ABC, Generic[T]):
             or self.env.end_line is None
             or self.env.end_col is None
         ):
-            loc = form_loc
-        else:
-            loc = (self.env.line, self.env.col, self.env.end_line, self.env.end_col)
+            assert form_loc is not None and all(
+                e is not None for e in form_loc
+            ), "Must specify location information"
+            self.env.set_loc(form_loc)
 
-        assert loc is not None and all(
-            e is not None for e in loc
-        ), "Must specify location information"
-
-        new_attrs: MutableMapping[str, NodeEnv | Node | Iterable[Node]] = {
-            "env": attr.evolve(
-                self.env, line=loc[0], col=loc[1], end_line=loc[2], end_col=loc[3]
-            )
-        }
         for child_kw in self.children:
             child_attr = munge(child_kw.name)
             assert child_attr != "env", "Node environment already set"
@@ -219,15 +211,14 @@ class Node(ABC, Generic[T]):
             if child_attr.endswith("s"):
                 iter_child: Iterable[Node] = getattr(self, child_attr)
                 assert iter_child is not None, "Listed child must not be none"
-                new_attrs[child_attr] = vec.vector(
-                    item.fix_missing_locations(form_loc) for item in iter_child
-                )
+                for item in iter_child:
+                    item.fix_missing_locations(form_loc)
             else:
                 child: Node = getattr(self, child_attr)
                 assert child is not None, "Listed child must not be none"
-                new_attrs[child_attr] = child.fix_missing_locations(form_loc)
+                child.fix_missing_locations(form_loc)
 
-        return self.assoc(**new_attrs)
+        return self
 
 
 def deftype_or_reify_python_member_names(
@@ -326,7 +317,7 @@ class LocalType(Enum):
     THIS = kw.keyword("this")
 
 
-@attr.frozen
+@attr.define
 class NodeEnv:
     ns: Namespace
     file: str
@@ -336,6 +327,9 @@ class NodeEnv:
     end_col: int | None = None
     pos: NodeSyntacticPosition | None = None
     func_ctx: FunctionContext | None = None
+
+    def set_loc(self, form_loc: tuple[int, int, int, int]) -> None:
+        self.line, self.col, self.end_line, self.end_col = form_loc
 
 
 @attr.frozen

--- a/src/basilisp/lang/reader.py
+++ b/src/basilisp/lang/reader.py
@@ -55,7 +55,7 @@ from basilisp.lang.source import format_source_context
 from basilisp.lang.tagged import TaggedLiteral, tagged_literal
 from basilisp.lang.typing import IterableLispForm, LispForm, ReaderForm
 from basilisp.lang.util import munge
-from basilisp.util import Maybe, partition
+from basilisp.util import partition
 
 ns_name_chars = re.compile(r"\w|-|\+|\*|\?|/|\=|\\|!|&|%|>|<|\$|:|\.")
 alphanumeric_chars = re.compile(r"\w")
@@ -386,14 +386,18 @@ class ReaderContext:
         process_reader_cond: bool = True,
         default_data_reader_fn: DefaultDataReaderFn | None = None,
     ) -> None:
-        self._data_readers = Maybe(data_readers).or_else_get(lmap.EMPTY)
-        self._default_data_reader_fn = Maybe(default_data_reader_fn).or_else_get(
+        self._data_readers = lmap.EMPTY if data_readers is None else data_readers
+        self._default_data_reader_fn = (
             _raise_unknown_tag
+            if default_data_reader_fn is None
+            else default_data_reader_fn
         )
-        self._features = Maybe(features).or_else_get(READER_COND_DEFAULT_FEATURE_SET)
+        self._features = (
+            READER_COND_DEFAULT_FEATURE_SET if features is None else features
+        )
         self._process_reader_cond = process_reader_cond
         self._reader = reader
-        self._resolve = Maybe(resolver).or_else_get(lambda x: x)
+        self._resolve = (lambda x: x) if resolver is None else resolver
         self._process_tagged_literals: collections.deque[bool] = collections.deque([])
         self._in_anon_fn: collections.deque[bool] = collections.deque([])
         self._syntax_quoted: collections.deque[bool] = collections.deque([])

--- a/src/basilisp/lang/seq.py
+++ b/src/basilisp/lang/seq.py
@@ -10,7 +10,6 @@ from basilisp.lang.interfaces import (
     ISequential,
     IWithMeta,
 )
-from basilisp.util import Maybe
 
 T = TypeVar("T")
 
@@ -72,7 +71,7 @@ class Cons(ISeq[T], ISequential, IWithMeta):
         meta: IPersistentMap | None = None,
     ) -> None:
         self._first = first
-        self._rest = Maybe(seq).or_else_get(EMPTY)
+        self._rest = EMPTY if seq is None else seq
         self._meta = meta
 
     @property

--- a/src/basilisp/util.py
+++ b/src/basilisp/util.py
@@ -1,4 +1,5 @@
 import contextlib
+import sys
 import time
 from collections.abc import Callable, Iterable, Sequence
 from typing import Generic, TypeVar
@@ -66,15 +67,23 @@ class Maybe(Generic[T]):
         return self._inner is not None
 
 
-def partition(coll: Sequence[T], n: int) -> Iterable[tuple[T, ...]]:
-    """Partition `coll` into groups of size `n`."""
-    assert n > 0
-    start = 0
-    stop = n
-    while stop <= len(coll):
-        yield tuple(e for e in coll[start:stop])
-        start += n
-        stop += n
-    if start < len(coll) < stop:
-        stop = len(coll)
-        yield tuple(e for e in coll[start:stop])
+if sys.version_info >= (3, 12):
+    from itertools import batched
+
+    def partition(coll: Sequence[T], n: int) -> Iterable[tuple[T, ...]]:
+        return batched(coll, n)
+
+else:
+
+    def partition(coll: Sequence[T], n: int) -> Iterable[tuple[T, ...]]:
+        """Partition `coll` into groups of size `n`."""
+        assert n > 0
+        start = 0
+        stop = n
+        while stop <= len(coll):
+            yield tuple(e for e in coll[start:stop])
+            start += n
+            stop += n
+        if start < len(coll) < stop:
+            stop = len(coll)
+            yield tuple(e for e in coll[start:stop])


### PR DESCRIPTION
* Take advantage of [`itertools.batched`](https://docs.python.org/3/library/itertools.html#itertools.batched) (which is written in C) for Python 3.12+ replacing `basilisp.lang.util.partition`.
* Stop creating `Maybe` objects in the constructor of `Cons` cells, since a simple `if` expression check would suffice.
* Make `NodeEnv` types mutable, reducing the amount of new object creation via `attrs.evolve` that needs to happen at compile time for new AST nodes.