### PR TITLE
Remove `basilisp.test/gen-assert` completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where `basilisp.test/are` based tests could fail to report line numbers for test failures (#635)
  * Fix a bug where the Basilisp reader and `basilisp.edn/read-string` failed to accept qualified symbols and keywords with the name `/` (#1346)
 
-### Deprecated
- * `basilisp.test/gen-assert`
+### Removed
+ * `basilisp.test/gen-assert` has been removed and replaced with `basilisp.test/assert-expr` (#????)
 
 ## [v0.5.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  * Fix a bug where the Basilisp reader and `basilisp.edn/read-string` failed to accept qualified symbols and keywords with the name `/` (#1346)
 
 ### Removed
- * `basilisp.test/gen-assert` has been removed and replaced with `basilisp.test/assert-expr` (#????)
+ * `basilisp.test/gen-assert` has been removed and replaced with `basilisp.test/assert-expr` (#1347)
 
 ## [v0.5.1]
 ### Added

--- a/src/basilisp/test.lpy
+++ b/src/basilisp/test.lpy
@@ -234,32 +234,6 @@
                    :expected (list (symbol "not") computed#)
                    :type     :fail}))))
 
-(defmulti
-  ^{:arglists '([expr msg line-num])}
-  gen-assert
-  "Deprecated implementation detail of :lpy:fn:`is` for generating macros.
-
-  Not generally called directly, but you may wish to add additional methods
-  to this multimethod to support different kinds of assertions.
-
-  .. deprecated:: 0.6.0
-
-     Use :lpy:fn:`assert-expr` instead."
-  (fn [expr _ _]
-    (cond
-      (vector? expr)     :default
-      (sequential? expr) (let [maybe-f (first expr)]
-                           (if (and (symbol? maybe-f)
-                                    (or (= 'basilisp.core/= maybe-f)
-                                        (#{'thrown-with-msg? 'thrown?} (symbol maybe-f))))
-                             (symbol (name maybe-f))
-                             maybe-f))
-      :else              :default)))
-
-(defmethod gen-assert :default
-  [expr msg ^:no-warn-when-unused line-num]
-  `(assert-expr ~expr ~msg))
-
 (defmacro is
   "Assert that a test condition, ``expr``, is true. :lpy:fn:`is` assertion failures are
   recorded and reported as test failures, causing the entire containing ``deftest`` to
@@ -278,6 +252,7 @@
     ``pattern`` using :lpy:fn:`re-find`
   - ``(is expr)`` is the most basic assertion type that just asserts that ``expr`` is
     truthy
+  - Additional test forms can be added by extending the multimethod :lpy:fn:`assert-expr`
 
   ``is`` assertions must appear inside of a :lpy:fn:`deftest` form."
   ([expr]


### PR DESCRIPTION
Follow up to #1345 

Fully removing `basilisp.test/gen-assert`. Since it was no longer actually used by `basilisp.test/is`, it was not actually useful to retain.